### PR TITLE
Bump boxcars to 0.10.10 for ViralItemActor_TA support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ description = "Rocket League replay transformer"
 
 [dependencies]
 anyhow = "1.0.98"
-boxcars = "0.10.4"
+boxcars = "0.10.10"
 derive-new = "0.7.0"
 float-ord = "0.3.2"
 glam = "0.30.4"


### PR DESCRIPTION
## Summary
- Updates boxcars dependency from 0.10.4 to 0.10.10

## Motivation
Rocket League v2.54+ introduced the `ViralItemActor_TA` actor type which causes parsing failures with boxcars 0.10.4:

```
Error decoding frame: no known attributes found for actor id / object id: 5 / 182. (TAGame.Default__ViralItemActor_TA)
```

This was fixed in boxcars v0.10.5 via https://github.com/nickbabcock/boxcars/pull/216

## Testing
Verified that Season 19+ replays (Build Version 251202.62834.504897) now parse successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)