### PR TITLE
Fix BallHasBeenHit always returning 1

### DIFF
--- a/src/collector/ndarray.rs
+++ b/src/collector/ndarray.rs
@@ -1315,8 +1315,8 @@ build_global_feature_adder!(
                 let rotation = rb.rotation;
                 let location = rb.location;
                 convert_all_floats!(
-                    location.x, location.y, location.z,
-                    rotation.x, rotation.y, rotation.z, rotation.w
+                    location.x, location.y, location.z, rotation.x, rotation.y, rotation.z,
+                    rotation.w
                 )
             }
             Err(_) => convert_all_floats!(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0),

--- a/tests/game_state_test.rs
+++ b/tests/game_state_test.rs
@@ -92,6 +92,8 @@ fn test_game_state_with_replay() {
     assert!(!unique_states.is_empty(), "Should have game state values");
 
     // Verify countdown values are in valid range 0-3
+    let mut ball_hit_true_count = 0usize;
+    let mut ball_hit_false_count = 0usize;
     for row in array.rows() {
         let countdown = row[countdown_idx] as i32;
         assert!(
@@ -106,5 +108,23 @@ fn test_game_state_with_replay() {
             "Ball hit should be 0 or 1, got {}",
             ball_hit
         );
+        if ball_hit == 1.0 {
+            ball_hit_true_count += 1;
+        } else {
+            ball_hit_false_count += 1;
+        }
     }
+
+    // Regression test for https://github.com/rlrml/subtr-actor/issues/16
+    // BallHasBeenHit should be 0 during kickoff and 1 after the ball is hit.
+    // Previously it was always 1 because NDArrayCollector skipped frames where
+    // the ball rigid body didn't exist, which coincided with kickoff (when
+    // BallHasBeenHit is false).
+    assert!(
+        ball_hit_true_count > 0 && ball_hit_false_count > 0,
+        "BallHasBeenHit should contain both 0 and 1 values across a full replay, \
+         got {} true and {} false",
+        ball_hit_true_count,
+        ball_hit_false_count
+    );
 }


### PR DESCRIPTION
## Summary

- Fixes #16: `BallHasBeenHit` was always 1 in `NDArrayCollector` output because `process_frame` skipped all data collection when the ball rigid body didn't exist, which coincided exactly with when `BallHasBeenHit` was false (during kickoff)
- Removed the `ball_rigid_body_exists()` early return gate from `NDArrayCollector::process_frame`
- Made ball-dependent feature adders (`BallRigidBody`, `BallRigidBodyNoVelocities`, `BallRigidBodyQuaternions`, `VelocityAddedBallRigidBodyNoVelocities`, `SecondsRemaining`) handle missing ball gracefully by returning default values, following the pattern already used by `InterpolatedBallRigidBodyNoVelocities` and all player feature adders

## Test plan

- [x] Existing test suite passes (32 tests + 11 doc-tests)
- [x] Strengthened `test_game_state_with_replay` to assert `BallHasBeenHit` contains both 0 and 1 values across a full replay (regression test for #16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)