### PR TITLE
Merge useful changes from blastorg fork

### DIFF
--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -23,7 +23,7 @@ pub enum TimeAdvance {
 /// [`ReplayProcessor`] for access to additional replay data and context. It
 /// determines the pace of replay progression via the [`TimeAdvance`] return
 /// value.
-pub trait Collector: Sized {
+pub trait Collector {
     /// Process a single frame from a replay.
     ///
     /// # Arguments
@@ -55,7 +55,10 @@ pub trait Collector: Sized {
     ///
     /// Returns the [`Collector`] itself, potentially modified by the processing
     /// of the replay.
-    fn process_replay(mut self, replay: &boxcars::Replay) -> SubtrActorResult<Self> {
+    fn process_replay(mut self, replay: &boxcars::Replay) -> SubtrActorResult<Self>
+    where
+        Self: Sized,
+    {
         ReplayProcessor::new(replay)?.process(&mut self)?;
         Ok(self)
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -18,6 +18,7 @@ pub static PLAYER_TYPE: &str = "TAGame.Default__PRI_TA";
 pub static BOOST_AMOUNT_KEY: &str = "TAGame.CarComponent_Boost_TA:ReplicatedBoostAmount";
 pub static BOOST_REPLICATED_KEY: &str = "TAGame.CarComponent_Boost_TA:ReplicatedBoost";
 pub static COMPONENT_ACTIVE_KEY: &str = "TAGame.CarComponent_TA:ReplicatedActive";
+pub static DEMOLISH_EXTENDED_KEY: &str = "TAGame.Car_TA:ReplicatedDemolishExtended";
 pub static DEMOLISH_GOAL_EXPLOSION_KEY: &str = "TAGame.Car_TA:ReplicatedDemolishGoalExplosion";
 pub static IGNORE_SYNCING_KEY: &str = "TAGame.RBActor_TA:bIgnoreSyncing";
 pub static LAST_BOOST_AMOUNT_KEY: &str = "TAGame.CarComponent_Boost_TA:ReplicatedBoostAmount.Last";
@@ -36,4 +37,4 @@ pub static EMPTY_ACTOR_IDS: [boxcars::ActorId; 0] = [];
 
 pub static BOOST_USED_PER_SECOND: f32 = 80.0 / 0.93;
 
-pub static MAX_DEMOLISH_KNOWN_FRAMES_PASSED: usize = 100;
+pub static MAX_DEMOLISH_KNOWN_FRAMES_PASSED: usize = 150;

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -885,7 +885,10 @@ impl<'a> ReplayProcessor<'a> {
 
     // ID Mapping functions
 
-    pub fn get_player_id_from_car_id(&self, actor_id: &boxcars::ActorId) -> SubtrActorResult<PlayerId> {
+    pub fn get_player_id_from_car_id(
+        &self,
+        actor_id: &boxcars::ActorId,
+    ) -> SubtrActorResult<PlayerId> {
         self.get_player_id_from_actor_id(&self.get_player_actor_id_from_car_actor_id(actor_id)?)
     }
 
@@ -907,14 +910,11 @@ impl<'a> ReplayProcessor<'a> {
         &self,
         actor_id: &boxcars::ActorId,
     ) -> SubtrActorResult<boxcars::ActorId> {
-        self.car_to_player
-            .get(actor_id)
-            .copied()
-            .ok_or_else(|| {
-                SubtrActorError::new(SubtrActorErrorVariant::NoMatchingPlayerId {
-                    actor_id: *actor_id,
-                })
+        self.car_to_player.get(actor_id).copied().ok_or_else(|| {
+            SubtrActorError::new(SubtrActorErrorVariant::NoMatchingPlayerId {
+                actor_id: *actor_id,
             })
+        })
     }
 
     fn demolish_is_known(&self, demo: &DemolishAttribute, frame_index: usize) -> bool {
@@ -1096,13 +1096,19 @@ impl<'a> ReplayProcessor<'a> {
 
     // Actor functions
 
-    pub fn get_object_id_for_key(&self, name: &'static str) -> SubtrActorResult<&boxcars::ObjectId> {
+    pub fn get_object_id_for_key(
+        &self,
+        name: &'static str,
+    ) -> SubtrActorResult<&boxcars::ObjectId> {
         self.name_to_object_id
             .get(name)
             .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::ObjectIdNotFound { name }))
     }
 
-    pub fn get_actor_ids_by_type(&self, name: &'static str) -> SubtrActorResult<&[boxcars::ActorId]> {
+    pub fn get_actor_ids_by_type(
+        &self,
+        name: &'static str,
+    ) -> SubtrActorResult<&[boxcars::ActorId]> {
         self.get_object_id_for_key(name)
             .map(|object_id| self.get_actor_ids_by_object_id(object_id))
     }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 /// [`Ok`] variant of a [`Result`]. If the attribute doesn't match, it results in an
 /// [`Err`] variant with a [`SubtrActorError`], specifying the expected type and
 /// the actual type.
+#[macro_export]
 macro_rules! attribute_match {
     ($value:expr, $type:path $(,)?) => {{
         let attribute = $value;
@@ -35,6 +36,7 @@ macro_rules! attribute_match {
 /// * `$map` - The data map.
 /// * `$prop` - The attribute key.
 /// * `$type` - The expected enum path.
+#[macro_export]
 macro_rules! get_attribute_errors_expected {
     ($self:ident, $map:expr, $prop:expr, $type:path) => {
         $self
@@ -1061,13 +1063,13 @@ impl<'a> ReplayProcessor<'a> {
 
     // Actor functions
 
-    fn get_object_id_for_key(&self, name: &'static str) -> SubtrActorResult<&boxcars::ObjectId> {
+    pub fn get_object_id_for_key(&self, name: &'static str) -> SubtrActorResult<&boxcars::ObjectId> {
         self.name_to_object_id
             .get(name)
             .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::ObjectIdNotFound { name }))
     }
 
-    fn get_actor_ids_by_type(&self, name: &'static str) -> SubtrActorResult<&[boxcars::ActorId]> {
+    pub fn get_actor_ids_by_type(&self, name: &'static str) -> SubtrActorResult<&[boxcars::ActorId]> {
         self.get_object_id_for_key(name)
             .map(|object_id| self.get_actor_ids_by_object_id(object_id))
     }
@@ -1096,7 +1098,7 @@ impl<'a> ReplayProcessor<'a> {
         self.get_attribute(&self.get_actor_state(actor_id)?.attributes, property)
     }
 
-    fn get_attribute<'b>(
+    pub fn get_attribute<'b>(
         &'b self,
         map: &'b HashMap<boxcars::ObjectId, (boxcars::Attribute, usize)>,
         property: &'static str,
@@ -1104,7 +1106,7 @@ impl<'a> ReplayProcessor<'a> {
         self.get_attribute_and_updated(map, property).map(|v| &v.0)
     }
 
-    fn get_attribute_and_updated<'b>(
+    pub fn get_attribute_and_updated<'b>(
         &'b self,
         map: &'b HashMap<boxcars::ObjectId, (boxcars::Attribute, usize)>,
         property: &'static str,

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,6 +11,56 @@ macro_rules! fmt_err {
 
 pub type PlayerId = boxcars::RemoteId;
 
+/// Represents which demolition format a replay uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DemolishFormat {
+    /// Old format (pre-September 2024): uses `ReplicatedDemolishGoalExplosion`
+    Fx,
+    /// New format (September 2024+): uses `ReplicatedDemolishExtended`
+    Extended,
+}
+
+/// Wrapper enum for different demolition attribute formats across Rocket League versions.
+///
+/// Rocket League changed the demolition data structure around September 2024 (v2.43+),
+/// moving from `DemolishFx` to `DemolishExtended`. This enum provides a unified interface
+/// for both formats.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DemolishAttribute {
+    Fx(boxcars::DemolishFx),
+    Extended(boxcars::DemolishExtended),
+}
+
+impl DemolishAttribute {
+    pub fn attacker_actor_id(&self) -> boxcars::ActorId {
+        match self {
+            DemolishAttribute::Fx(fx) => fx.attacker,
+            DemolishAttribute::Extended(ext) => ext.attacker.actor,
+        }
+    }
+
+    pub fn victim_actor_id(&self) -> boxcars::ActorId {
+        match self {
+            DemolishAttribute::Fx(fx) => fx.victim,
+            DemolishAttribute::Extended(ext) => ext.victim.actor,
+        }
+    }
+
+    pub fn attacker_velocity(&self) -> boxcars::Vector3f {
+        match self {
+            DemolishAttribute::Fx(fx) => fx.attack_velocity,
+            DemolishAttribute::Extended(ext) => ext.attacker_velocity,
+        }
+    }
+
+    pub fn victim_velocity(&self) -> boxcars::Vector3f {
+        match self {
+            DemolishAttribute::Fx(fx) => fx.victim_velocity,
+            DemolishAttribute::Extended(ext) => ext.victim_velocity,
+        }
+    }
+}
+
 /// [`DemolishInfo`] struct represents data related to a demolition event in the game.
 ///
 /// Demolition events occur when one player 'demolishes' or 'destroys' another by
@@ -32,6 +82,8 @@ pub struct DemolishInfo {
     pub attacker_velocity: boxcars::Vector3f,
     /// The velocity of the victim at the time of demolition.
     pub victim_velocity: boxcars::Vector3f,
+    /// The location of the victim at the time of demolition.
+    pub victim_location: boxcars::Vector3f,
 }
 
 /// [`ReplayMeta`] struct represents metadata about the replay being processed.


### PR DESCRIPTION
## Summary

Incorporates useful changes from the [blastorg/subtr-actor](https://github.com/blastorg/subtr-actor) fork, cleaned up and reorganized into logical commits with original contributor attribution.

- **car_to_player mapping**: Adds a reverse `car_to_player` HashMap for O(1) car-to-player lookups that persists through car destruction (needed for demolition tracking)
- **Dual demolition format support**: Handles both old `DemolishFx` and new `DemolishExtended` formats (Rocket League v2.43+, Sept 2024), with auto-detection and a unified `DemolishAttribute` wrapper enum
- **Public API expansion**: Makes several processor helper methods and macros public (`get_object_id_for_key`, `get_actor_ids_by_type`, `get_attribute`, `get_player_id_from_car_id`, `attribute_match!`, `get_attribute_errors_expected!`)
- **Multi-collector processing**: Adds `process_all()` to run multiple collectors over one replay, relaxes `Collector` trait `Sized` bound to enable `dyn Collector`
- **Debug improvements**: Replaces `println!` with `log::debug!`, improves `actor_state_string` error handling and `all_mappings_string` output

### Contributors
- Daniel Shields (ds@blast.tv)
- GDGunnars (gdg@gdg.is)
- Nils Abdi Andersen-Ale

## Test plan
- [x] All 34 existing tests pass
- [ ] Verify demolition tracking works with both old and new replay formats
- [ ] Verify `car_to_player` mapping persists correctly through demolitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)