### PR TITLE
Add shared stats frame persistence control

### DIFF
--- a/src/collector/frame_resolution.rs
+++ b/src/collector/frame_resolution.rs
@@ -1,0 +1,143 @@
+const FRAME_RESOLUTION_EPSILON_SECONDS: f32 = 1e-4;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub enum StatsFrameResolution {
+    #[default]
+    EveryFrame,
+    TimeStep {
+        seconds: f32,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum FinalStatsFrameAction {
+    Append { dt: f32 },
+    ReplaceLast { dt: f32 },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StatsFramePersistenceController {
+    resolution: StatsFrameResolution,
+    next_emit_time: Option<f32>,
+    last_emitted_frame_number: Option<usize>,
+    last_emitted_time: Option<f32>,
+    last_emitted_dt: f32,
+}
+
+impl StatsFramePersistenceController {
+    pub(crate) fn new(resolution: StatsFrameResolution) -> Self {
+        Self {
+            resolution,
+            next_emit_time: None,
+            last_emitted_frame_number: None,
+            last_emitted_time: None,
+            last_emitted_dt: 0.0,
+        }
+    }
+
+    pub(crate) fn on_frame(&mut self, frame_number: usize, current_time: f32) -> Option<f32> {
+        if self.last_emitted_time.is_none() {
+            return Some(self.record_emit(frame_number, current_time));
+        }
+
+        match self.resolution {
+            StatsFrameResolution::EveryFrame => Some(self.record_emit(frame_number, current_time)),
+            StatsFrameResolution::TimeStep { seconds } => {
+                if !seconds.is_finite() || seconds <= 0.0 {
+                    return Some(self.record_emit(frame_number, current_time));
+                }
+
+                let next_emit_time = self.next_emit_time.unwrap_or(current_time + seconds);
+                if current_time + FRAME_RESOLUTION_EPSILON_SECONDS < next_emit_time {
+                    self.next_emit_time = Some(next_emit_time);
+                    return None;
+                }
+
+                let dt = self.record_emit(frame_number, current_time);
+                let mut advanced_next_emit_time = next_emit_time;
+                while advanced_next_emit_time <= current_time + FRAME_RESOLUTION_EPSILON_SECONDS {
+                    advanced_next_emit_time += seconds;
+                }
+                self.next_emit_time = Some(advanced_next_emit_time);
+                Some(dt)
+            }
+        }
+    }
+
+    pub(crate) fn final_frame_action(
+        &self,
+        frame_number: usize,
+        current_time: f32,
+    ) -> Option<FinalStatsFrameAction> {
+        let Some(last_emitted_time) = self.last_emitted_time else {
+            return Some(FinalStatsFrameAction::Append { dt: 0.0 });
+        };
+
+        if self.last_emitted_frame_number == Some(frame_number) {
+            return Some(FinalStatsFrameAction::ReplaceLast {
+                dt: self.last_emitted_dt,
+            });
+        }
+
+        Some(FinalStatsFrameAction::Append {
+            dt: (current_time - last_emitted_time).max(0.0),
+        })
+    }
+
+    fn record_emit(&mut self, frame_number: usize, current_time: f32) -> f32 {
+        let dt = self
+            .last_emitted_time
+            .map(|last_time| (current_time - last_time).max(0.0))
+            .unwrap_or(0.0);
+        self.last_emitted_frame_number = Some(frame_number);
+        self.last_emitted_time = Some(current_time);
+        self.last_emitted_dt = dt;
+        self.next_emit_time = match self.resolution {
+            StatsFrameResolution::EveryFrame => None,
+            StatsFrameResolution::TimeStep { seconds } if seconds.is_finite() && seconds > 0.0 => {
+                Some(current_time + seconds)
+            }
+            StatsFrameResolution::TimeStep { .. } => None,
+        };
+        dt
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FinalStatsFrameAction, StatsFramePersistenceController, StatsFrameResolution};
+
+    #[test]
+    fn every_frame_resolution_emits_every_frame() {
+        let mut controller = StatsFramePersistenceController::new(StatsFrameResolution::EveryFrame);
+
+        assert_eq!(controller.on_frame(10, 0.0), Some(0.0));
+        assert_eq!(controller.on_frame(11, 0.1), Some(0.1));
+        assert_eq!(controller.on_frame(12, 0.25), Some(0.15));
+        assert_eq!(
+            controller.final_frame_action(12, 0.25),
+            Some(FinalStatsFrameAction::ReplaceLast { dt: 0.15 })
+        );
+    }
+
+    #[test]
+    fn timestep_resolution_emits_crossings_and_appends_final_frame() {
+        let mut controller =
+            StatsFramePersistenceController::new(StatsFrameResolution::TimeStep { seconds: 0.5 });
+
+        assert_eq!(controller.on_frame(0, 0.0), Some(0.0));
+        assert_eq!(controller.on_frame(1, 0.2), None);
+        assert_eq!(controller.on_frame(2, 0.49), None);
+        assert_eq!(controller.on_frame(3, 0.5), Some(0.5));
+        assert_eq!(controller.on_frame(4, 0.74), None);
+        match controller.final_frame_action(4, 0.74) {
+            Some(FinalStatsFrameAction::Append { dt }) => {
+                assert!(
+                    (dt - 0.24).abs() < 1e-6,
+                    "expected dt close to 0.24, got {dt}"
+                );
+            }
+            action => panic!("expected append action, got {action:?}"),
+        }
+    }
+}

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,5 +1,6 @@
 pub mod callback;
 pub mod decorator;
+mod frame_resolution;
 pub mod ndarray;
 pub mod replay_data;
 pub mod replay_data_heuristics;
@@ -9,6 +10,7 @@ pub mod stats_timeline;
 pub use self::ndarray::*;
 pub use callback::*;
 pub use decorator::*;
+pub use frame_resolution::StatsFrameResolution;
 pub use replay_data::*;
 pub use replay_data_heuristics::*;
 pub use stats::*;

--- a/src/collector/stats/collector.rs
+++ b/src/collector/stats/collector.rs
@@ -3,6 +3,9 @@ use std::marker::PhantomData;
 
 use serde_json::{Map, Value};
 
+use crate::collector::frame_resolution::{
+    FinalStatsFrameAction, StatsFramePersistenceController, StatsFrameResolution,
+};
 use crate::stats::analysis_nodes::graph_with_builtin_analysis_nodes;
 use crate::*;
 
@@ -15,15 +18,11 @@ use super::playback::{
 };
 use super::types::{serialize_to_json_value, CollectedStats, CollectedStatsModule};
 
+#[derive(Default)]
 enum SampleMode {
+    #[default]
     Aggregate,
     Timeline,
-}
-
-impl Default for SampleMode {
-    fn default() -> Self {
-        Self::Aggregate
-    }
 }
 
 struct BuiltinModuleSelection {
@@ -251,6 +250,7 @@ pub struct StatsCollector<T = StatsSnapshotFrame, F = IdentityFrameTransform> {
     captured_frames: Option<Vec<T>>,
     sample_mode: SampleMode,
     last_sample_time: Option<f32>,
+    frame_persistence: StatsFramePersistenceController,
     last_demolish_count: usize,
     last_boost_pad_event_count: usize,
     last_touch_event_count: usize,
@@ -348,6 +348,7 @@ impl<T, F> StatsCollector<T, F> {
             captured_frames: None,
             sample_mode: SampleMode::Aggregate,
             last_sample_time: None,
+            frame_persistence: StatsFramePersistenceController::new(StatsFrameResolution::default()),
             last_demolish_count: 0,
             last_boost_pad_event_count: 0,
             last_touch_event_count: 0,
@@ -371,6 +372,7 @@ impl<T, F> StatsCollector<T, F> {
             captured_frames,
             sample_mode,
             last_sample_time,
+            frame_persistence,
             last_demolish_count,
             last_boost_pad_event_count,
             last_touch_event_count,
@@ -386,6 +388,7 @@ impl<T, F> StatsCollector<T, F> {
             captured_frames: captured_frames.map(|_| Vec::new()),
             sample_mode,
             last_sample_time,
+            frame_persistence,
             last_demolish_count,
             last_boost_pad_event_count,
             last_touch_event_count,
@@ -403,6 +406,11 @@ impl<T, F> StatsCollector<T, F> {
         G: FnMut(Map<String, Value>) -> SubtrActorResult<Modules>,
     {
         self.with_frame_transform(ModuleFrameTransform::new(transform))
+    }
+
+    pub fn with_frame_resolution(mut self, resolution: StatsFrameResolution) -> Self {
+        self.frame_persistence = StatsFramePersistenceController::new(resolution);
+        self
     }
 
     pub fn get_stats(mut self, replay: &boxcars::Replay) -> SubtrActorResult<CollectedStats>
@@ -529,10 +537,11 @@ where
                 .as_ref()
                 .expect("replay metadata should be initialized before snapshotting")
                 .clone();
-            self.capture_frame_snapshot(
-                &replay_meta,
-                self.modules.snapshot_frame(&self.graph, &replay_meta)?,
-            )?;
+            if let Some(emitted_dt) = self.frame_persistence.on_frame(frame_number, current_time) {
+                let mut frame = self.modules.snapshot_frame(&self.graph, &replay_meta)?;
+                frame.dt = emitted_dt;
+                self.capture_frame_snapshot(&replay_meta, frame)?;
+            }
         }
 
         self.last_sample_time = Some(current_time);
@@ -555,9 +564,22 @@ where
         let Some(_) = self.graph.state::<FrameInfo>() else {
             return Ok(());
         };
-        let final_snapshot = self.modules.snapshot_frame(&self.graph, &replay_meta)?;
+        let mut final_snapshot = self.modules.snapshot_frame(&self.graph, &replay_meta)?;
         if self.captured_frames.is_some() {
-            self.replace_last_frame_snapshot(&replay_meta, final_snapshot)?;
+            match self
+                .frame_persistence
+                .final_frame_action(final_snapshot.frame_number, final_snapshot.time)
+            {
+                Some(FinalStatsFrameAction::Append { dt }) => {
+                    final_snapshot.dt = dt;
+                    self.capture_frame_snapshot(&replay_meta, final_snapshot)?;
+                }
+                Some(FinalStatsFrameAction::ReplaceLast { dt }) => {
+                    final_snapshot.dt = dt;
+                    self.replace_last_frame_snapshot(&replay_meta, final_snapshot)?;
+                }
+                None => {}
+            }
         }
         Ok(())
     }

--- a/src/collector/stats/playback.rs
+++ b/src/collector/stats/playback.rs
@@ -79,7 +79,11 @@ impl CapturedStatsData<StatsSnapshotFrame> {
             config: self.timeline_config(),
             replay_meta: self.replay_meta.clone(),
             timeline_events: self.timeline_events_typed()?,
-            backboard_events: self.module_player_events("backboard", "events", parse_backboard_event)?,
+            backboard_events: self.module_player_events(
+                "backboard",
+                "events",
+                parse_backboard_event,
+            )?,
             ceiling_shot_events: self.module_player_events(
                 "ceiling_shot",
                 "events",
@@ -116,7 +120,10 @@ impl CapturedStatsData<StatsSnapshotFrame> {
             "replay_meta".to_owned(),
             serialize_to_json_value(&self.replay_meta)?,
         );
-        timeline.insert("timeline_events".to_owned(), Value::Array(self.timeline_events()));
+        timeline.insert(
+            "timeline_events".to_owned(),
+            Value::Array(self.timeline_events()),
+        );
         timeline.insert(
             "backboard_events".to_owned(),
             Value::Array(self.module_array("backboard", "events")),

--- a/src/collector/stats_timeline.rs
+++ b/src/collector/stats_timeline.rs
@@ -1,3 +1,6 @@
+use crate::collector::frame_resolution::{
+    FinalStatsFrameAction, StatsFramePersistenceController, StatsFrameResolution,
+};
 use crate::stats::analysis_nodes::analysis_graph::{AnalysisGraph, AnalysisNodeDyn};
 use crate::stats::analysis_nodes::{
     boxed_analysis_node_by_name, LivePlayNode, PositioningNode, PressureNode, RushNode,
@@ -140,6 +143,7 @@ pub struct StatsTimelineCollector {
     replay_meta: Option<ReplayMeta>,
     frames: Vec<ReplayStatsFrame>,
     last_sample_time: Option<f32>,
+    frame_persistence: StatsFramePersistenceController,
 }
 
 impl Default for StatsTimelineCollector {
@@ -168,6 +172,7 @@ impl StatsTimelineCollector {
             replay_meta: None,
             frames: Vec::new(),
             last_sample_time: None,
+            frame_persistence: StatsFramePersistenceController::new(StatsFrameResolution::default()),
         }
     }
 
@@ -279,6 +284,11 @@ impl StatsTimelineCollector {
         )
     }
 
+    pub fn with_frame_resolution(mut self, resolution: StatsFrameResolution) -> Self {
+        self.frame_persistence = StatsFramePersistenceController::new(resolution);
+        self
+    }
+
     pub fn get_replay_data(
         mut self,
         replay: &boxcars::Replay,
@@ -316,7 +326,11 @@ impl Collector for StatsTimelineCollector {
         self.graph.evaluate_with_state(&frame_input)?;
         self.last_sample_time = Some(current_time);
 
-        self.frames.push(self.snapshot_frame()?);
+        if let Some(emitted_dt) = self.frame_persistence.on_frame(frame_number, current_time) {
+            let mut frame = self.snapshot_frame()?;
+            frame.dt = emitted_dt;
+            self.frames.push(frame);
+        }
 
         Ok(TimeAdvance::NextFrame)
     }
@@ -329,9 +343,22 @@ impl Collector for StatsTimelineCollector {
         let Some(_) = self.graph.state::<StatsTimelineFrameState>() else {
             return Ok(());
         };
-        let final_snapshot = self.snapshot_frame()?;
-        if let Some(last_frame) = self.frames.last_mut() {
-            *last_frame = final_snapshot;
+        let mut final_snapshot = self.snapshot_frame()?;
+        match self
+            .frame_persistence
+            .final_frame_action(final_snapshot.frame_number, final_snapshot.time)
+        {
+            Some(FinalStatsFrameAction::Append { dt }) => {
+                final_snapshot.dt = dt;
+                self.frames.push(final_snapshot);
+            }
+            Some(FinalStatsFrameAction::ReplaceLast { dt }) => {
+                final_snapshot.dt = dt;
+                if let Some(last_frame) = self.frames.last_mut() {
+                    *last_frame = final_snapshot;
+                }
+            }
+            None => {}
         }
         Ok(())
     }

--- a/src/collector/stats_timeline.rs
+++ b/src/collector/stats_timeline.rs
@@ -238,9 +238,10 @@ impl StatsTimelineCollector {
                 .graph_value_or_default::<Vec<CeilingShotEvent>, CeilingShotCalculator, _>(
                     |calculator| calculator.events().to_vec(),
                 ),
-            double_tap_events: self.graph_value_or_default::<Vec<DoubleTapEvent>, DoubleTapCalculator, _>(
-                |calculator| calculator.events().to_vec(),
-            ),
+            double_tap_events: self
+                .graph_value_or_default::<Vec<DoubleTapEvent>, DoubleTapCalculator, _>(
+                    |calculator| calculator.events().to_vec(),
+                ),
             fifty_fifty_events: self
                 .graph_value_or_default::<Vec<FiftyFiftyEvent>, FiftyFiftyCalculator, _>(
                     |calculator| calculator.events().to_vec(),

--- a/src/mechanics/mod.rs
+++ b/src/mechanics/mod.rs
@@ -1,9 +1,9 @@
 pub mod flip_reset {
+    #[cfg(test)]
+    pub(crate) use crate::stats::calculators::flip_reset_candidate;
     pub use crate::stats::{
         DodgeRefreshedEvent, FlipResetEvent, FlipResetFollowupDodgeEvent, PostWallDodgeEvent,
     };
-    #[cfg(test)]
-    pub(crate) use crate::stats::calculators::flip_reset_candidate;
 }
 
 pub mod flip_reset_tuning_set {

--- a/src/stats/analysis_nodes/analysis_graph.rs
+++ b/src/stats/analysis_nodes/analysis_graph.rs
@@ -187,6 +187,7 @@ where
     }
 }
 
+#[derive(Default)]
 pub struct AnalysisGraph {
     nodes: Vec<Box<dyn AnalysisNodeDyn>>,
     evaluation_order: Vec<usize>,
@@ -194,19 +195,6 @@ pub struct AnalysisGraph {
     declared_input_states: HashMap<TypeId, &'static str>,
     root_states: HashMap<TypeId, Box<dyn Any>>,
     resolved: bool,
-}
-
-impl Default for AnalysisGraph {
-    fn default() -> Self {
-        Self {
-            nodes: Vec::new(),
-            evaluation_order: Vec::new(),
-            declared_root_states: HashMap::new(),
-            declared_input_states: HashMap::new(),
-            root_states: HashMap::new(),
-            resolved: false,
-        }
-    }
 }
 
 impl AnalysisGraph {

--- a/src/stats/calculators/fifty_fifty_state.rs
+++ b/src/stats/calculators/fifty_fifty_state.rs
@@ -57,6 +57,7 @@ impl FiftyFiftyStateCalculator {
         Some(event)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update(
         &mut self,
         frame: &FrameInfo,

--- a/src/stats/calculators/positioning.rs
+++ b/src/stats/calculators/positioning.rs
@@ -219,6 +219,7 @@ impl PositioningCalculator {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn process_sample(
         &mut self,
         frame: &FrameInfo,
@@ -479,6 +480,7 @@ impl PositioningCalculator {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update(
         &mut self,
         frame: &FrameInfo,

--- a/src/stats/calculators/rush.rs
+++ b/src/stats/calculators/rush.rs
@@ -310,6 +310,7 @@ impl RushCalculator {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update_parts(
         &mut self,
         frame: &FrameInfo,

--- a/tests/stats_frame_resolution_test.rs
+++ b/tests/stats_frame_resolution_test.rs
@@ -1,0 +1,101 @@
+mod common;
+
+use subtr_actor::{StatsCollector, StatsFrameResolution, StatsTimelineCollector};
+
+#[test]
+fn default_resolution_matches_every_frame_resolution() {
+    let replay = common::parse_replay("assets/replays/rlcs.replay");
+
+    let default_stats_collector = StatsCollector::new()
+        .get_replay_stats_timeline(&replay)
+        .expect("default stats collector timeline should build");
+    let explicit_every_frame_stats_collector = StatsCollector::new()
+        .with_frame_resolution(StatsFrameResolution::EveryFrame)
+        .get_replay_stats_timeline(&replay)
+        .expect("explicit every-frame stats collector timeline should build");
+    common::assert_replay_stats_timeline_eq(
+        &default_stats_collector,
+        &explicit_every_frame_stats_collector,
+    );
+
+    let default_timeline_collector = StatsTimelineCollector::new()
+        .get_replay_data(&replay)
+        .expect("default stats timeline collector should build");
+    let explicit_every_frame_timeline_collector = StatsTimelineCollector::new()
+        .with_frame_resolution(StatsFrameResolution::EveryFrame)
+        .get_replay_data(&replay)
+        .expect("explicit every-frame stats timeline collector should build");
+    common::assert_replay_stats_timeline_eq(
+        &default_timeline_collector,
+        &explicit_every_frame_timeline_collector,
+    );
+}
+
+#[test]
+fn sampled_stats_collectors_share_frame_persistence_behavior() {
+    let replay = common::parse_replay("assets/replays/rlcs.replay");
+    let resolution = StatsFrameResolution::TimeStep { seconds: 0.5 };
+
+    let full_timeline = StatsTimelineCollector::new()
+        .get_replay_data(&replay)
+        .expect("full stats timeline should build");
+    let sampled_collector_timeline = StatsCollector::new()
+        .with_frame_resolution(resolution)
+        .get_replay_stats_timeline(&replay)
+        .expect("sampled stats collector timeline should build");
+    let sampled_timeline_collector = StatsTimelineCollector::new()
+        .with_frame_resolution(resolution)
+        .get_replay_data(&replay)
+        .expect("sampled stats timeline collector should build");
+
+    common::assert_replay_stats_timeline_eq(
+        &sampled_collector_timeline,
+        &sampled_timeline_collector,
+    );
+
+    assert!(
+        sampled_collector_timeline.frames.len() < full_timeline.frames.len(),
+        "expected sampled output to persist fewer frames than full output"
+    );
+    assert_eq!(
+        sampled_collector_timeline
+            .frames
+            .first()
+            .map(|frame| frame.frame_number),
+        full_timeline.frames.first().map(|frame| frame.frame_number),
+        "expected sampled output to retain the first frame"
+    );
+    assert_eq!(
+        sampled_collector_timeline
+            .frames
+            .last()
+            .map(|frame| frame.frame_number),
+        full_timeline.frames.last().map(|frame| frame.frame_number),
+        "expected sampled output to retain the final frame"
+    );
+
+    let first_frame = sampled_collector_timeline
+        .frames
+        .first()
+        .expect("sampled output should include at least one frame");
+    assert!(
+        first_frame.dt.abs() < 1e-6,
+        "expected first sampled frame dt to be zero, got {}",
+        first_frame.dt
+    );
+
+    for window in sampled_collector_timeline.frames.windows(2) {
+        let previous = &window[0];
+        let current = &window[1];
+        let expected_dt = (current.time - previous.time).max(0.0);
+        let diff = (current.dt - expected_dt).abs();
+        assert!(
+            diff < 1e-4,
+            "expected sampled frame dt to match emitted spacing between frames {} and {}: got dt={}, expected {}",
+            previous.frame_number,
+            current.frame_number,
+            current.dt,
+            expected_dt,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared stats frame persistence controller with `EveryFrame` and time-step resolution modes
- wire both stats collectors through the shared persistence path while keeping per-frame graph evaluation
- add regression coverage that explicit `EveryFrame` matches the default collector behavior

## Validation
- `python3 scripts/check_release_versions.py`
- `cargo fmt --all -- --check`
- `cargo metadata --locked --format-version 1 > /dev/null`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release --verbose`
- `npm ci` and `npm run build` in `js/player`
- `npm ci`, `npm test`, and `npm run build` in `js/stat-evaluation-player`

## Notes
- `cargo test --verbose` still hits the existing failure in `tests/stats_timeline_collector_test.rs::test_stats_timeline_collector_final_frame_matches_reducers`.
- I confirmed the same test fails on the current base commit `c3245d9`, so this branch does not introduce that failure.