### PR TITLE
fix: update boxcars version to work with the new EAC replay files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "40ce3582fb888755eb1a77668e69f90c3b317fdcc85bbeacd0d9bdfa89427173"
 
 [[package]]
 name = "boxcars"
-version = "0.10.11"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d1dfdbdbd7921631afcb379cca971f5a8597eb5e35ab6dcb59ed4d7d6d56b7"
+checksum = "1431e9bfa0c6d7d6d76e0b99d7035c7e13c7243f8ac11ffdcf5d92fbb57abdfa"
 dependencies = [
  "bitter",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rlrml/subtr-actor"
 edition = "2021"
 
 [workspace.dependencies]
-boxcars = "0.10.11"
+boxcars = "0.11.1"
 
 [package]
 name = "subtr-actor"


### PR DESCRIPTION
New EAC replay format.