### PR TITLE
[codex] Add analysis graph hooks for ndarray features

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,10 @@ Use this to resample replay processing to a fixed FPS before collecting data.
 These are useful when working through the Python or JavaScript bindings:
 
 - Global: `BallRigidBody`, `CurrentTime`, `SecondsRemaining`
-- Player: `PlayerRigidBody`, `PlayerBoost`, `PlayerAnyJump`, `PlayerJump`, `AnalysisPlayerTouches`
+- Player: `PlayerRigidBody`, `PlayerBoost`, `PlayerAnyJump`, `PlayerJump`, `PlayerEvent:touch`
+
+Analysis-backed player event indicators use `PlayerEvent:<event_name>` and emit
+`1` for a sampled frame when that player has a new event, otherwise `0`.
 
 `PlayerBoost` is exposed in raw replay units (`0-255`), not percentage.
 

--- a/README.md
+++ b/README.md
@@ -107,13 +107,15 @@ fn main() -> anyhow::Result<()> {
 
     let mut collector = NDArrayCollector::new(
         vec![
-            InterpolatedBallRigidBodyNoVelocities::arc_new(0.003),
-            CurrentTime::arc_new(),
+            NDArrayFeatureAdder::plain(InterpolatedBallRigidBodyNoVelocities::arc_new(0.003)),
+            NDArrayFeatureAdder::plain(CurrentTime::arc_new()),
         ],
         vec![
-            InterpolatedPlayerRigidBodyNoVelocities::arc_new(0.003),
-            PlayerBoost::arc_new(),
-            PlayerAnyJump::arc_new(),
+            NDArrayPlayerFeatureAdder::plain(
+                InterpolatedPlayerRigidBodyNoVelocities::arc_new(0.003),
+            ),
+            NDArrayPlayerFeatureAdder::plain(PlayerBoost::arc_new()),
+            NDArrayPlayerFeatureAdder::plain(PlayerAnyJump::arc_new()),
         ],
     );
 
@@ -194,7 +196,7 @@ Use this to resample replay processing to a fixed FPS before collecting data.
 These are useful when working through the Python or JavaScript bindings:
 
 - Global: `BallRigidBody`, `CurrentTime`, `SecondsRemaining`
-- Player: `PlayerRigidBody`, `PlayerBoost`, `PlayerAnyJump`, `PlayerDoubleJump`
+- Player: `PlayerRigidBody`, `PlayerBoost`, `PlayerAnyJump`, `PlayerJump`, `AnalysisPlayerTouches`
 
 `PlayerBoost` is exposed in raw replay units (`0-255`), not percentage.
 

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2297,8 +2297,14 @@ def main() -> int:
         )
     require_contains(
         web_player_main_source,
-        'renderModuleSummaryGroup("Timeline visualizations", timelineToggles)',
-        "stats evaluation player launcher module summary timeline group",
+        'renderModuleSummaryGroup("Timeline markers", markerToggles)',
+        "stats evaluation player launcher module summary timeline marker group",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'renderModuleSummaryGroup("Timeline ranges", rangeToggles)',
+        "stats evaluation player launcher module summary timeline range group",
         errors,
     )
     require_contains(
@@ -2738,7 +2744,11 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
-        'empty.textContent = "No event types selected.";',
+        'if (selectedSourceIds.size === 0) {\n'
+        '        empty.textContent = "No event types selected.";\n'
+        "      } else {\n"
+        '        empty.textContent = "No events in selected event types.";\n'
+        "      }",
         "stats evaluation player event playlist no-selection empty state",
         errors,
     )

--- a/js/README.md
+++ b/js/README.md
@@ -157,9 +157,11 @@ Common player features:
 - `"PlayerAnyJump"`
 - `"PlayerJump"`
 - `"PlayerDodgeRefreshed"`
-- `"AnalysisPlayerTouches"`
+- `"PlayerEvent:touch"`
 
 `"PlayerBoost"` is exposed in raw replay units (`0-255`), not percentage.
+Analysis-backed player event indicators use `"PlayerEvent:<event_name>"` and
+emit `1` for a sampled frame when that player has a new event, otherwise `0`.
 
 ## Building from Source
 

--- a/js/README.md
+++ b/js/README.md
@@ -157,6 +157,7 @@ Common player features:
 - `"PlayerAnyJump"`
 - `"PlayerJump"`
 - `"PlayerDodgeRefreshed"`
+- `"AnalysisPlayerTouches"`
 
 `"PlayerBoost"` is exposed in raw replay units (`0-255`), not percentage.
 

--- a/python/PYTHON-README.md
+++ b/python/PYTHON-README.md
@@ -179,6 +179,7 @@ Common player features:
 - `PlayerAnyJump`
 - `PlayerJump`
 - `PlayerDodgeRefreshed`
+- `AnalysisPlayerTouches`
 
 `PlayerBoost` is exposed in raw replay units (`0-255`), not `0-100` percent.
 

--- a/python/PYTHON-README.md
+++ b/python/PYTHON-README.md
@@ -179,9 +179,11 @@ Common player features:
 - `PlayerAnyJump`
 - `PlayerJump`
 - `PlayerDodgeRefreshed`
-- `AnalysisPlayerTouches`
+- `PlayerEvent:touch`
 
 `PlayerBoost` is exposed in raw replay units (`0-255`), not `0-100` percent.
+Analysis-backed player event indicators use `PlayerEvent:<event_name>` and emit
+`1` for a sampled frame when that player has a new event, otherwise `0`.
 
 ## Development
 

--- a/src/collector/ndarray/analysis_builtins.rs
+++ b/src/collector/ndarray/analysis_builtins.rs
@@ -1,0 +1,34 @@
+use crate::stats::analysis_graph::{AnalysisDependency, AnalysisNodeDyn, TouchNode};
+use crate::stats::calculators::TouchCalculator;
+use crate::*;
+use boxcars;
+
+fn boxed_touch_node() -> Box<dyn AnalysisNodeDyn> {
+    Box::new(TouchNode::new())
+}
+
+fn touch_dependency() -> Vec<AnalysisDependency> {
+    vec![AnalysisDependency::with_default::<TouchCalculator>(
+        boxed_touch_node,
+    )]
+}
+
+build_analysis_player_feature_adder!(
+    AnalysisPlayerTouches,
+    |_self_: &AnalysisPlayerTouches<F>| touch_dependency(),
+    |_self_: &AnalysisPlayerTouches<F>,
+     context: &AnalysisFeatureContext<'_>,
+     player_id: &PlayerId,
+     _processor: &dyn ProcessorView,
+     _frame: &boxcars::Frame,
+     _frame_count: usize,
+     _current_time: f32| {
+        let touch_event = context
+            .state::<TouchCalculator>()?
+            .new_events()
+            .iter()
+            .any(|event| &event.player == player_id);
+        convert_all_floats!(f32::from(touch_event))
+    },
+    "analysis touch event",
+);

--- a/src/collector/ndarray/analysis_builtins.rs
+++ b/src/collector/ndarray/analysis_builtins.rs
@@ -1,34 +1,380 @@
-use crate::stats::analysis_graph::{AnalysisDependency, AnalysisNodeDyn, TouchNode};
-use crate::stats::calculators::TouchCalculator;
+use crate::stats::analysis_graph::*;
+use crate::stats::calculators::*;
 use crate::*;
 use boxcars;
 
-fn boxed_touch_node() -> Box<dyn AnalysisNodeDyn> {
-    Box::new(TouchNode::new())
+macro_rules! build_analysis_player_event_indicator {
+    (
+        $struct_name:ident,
+        $dependency:ident,
+        $calculator:ty,
+        $events:ident,
+        $player_matches:expr,
+        $column_name:expr $(,)?
+    ) => {
+        build_analysis_player_feature_adder!(
+            $struct_name,
+            |_self_: &$struct_name<F>| vec![$dependency()],
+            |_self_: &$struct_name<F>,
+             context: &AnalysisFeatureContext<'_>,
+             player_id: &PlayerId,
+             _processor: &dyn ProcessorView,
+             _frame: &boxcars::Frame,
+             _frame_count: usize,
+             _current_time: f32| {
+                let player_matches = $player_matches;
+                let has_event = context
+                    .state::<$calculator>()?
+                    .$events()
+                    .iter()
+                    .any(|event| player_matches(event, player_id));
+                convert_all_floats!(f32::from(has_event))
+            },
+            $column_name,
+        );
+    };
 }
 
-fn touch_dependency() -> Vec<AnalysisDependency> {
-    vec![AnalysisDependency::with_default::<TouchCalculator>(
-        boxed_touch_node,
-    )]
-}
-
-build_analysis_player_feature_adder!(
+build_analysis_player_event_indicator!(
     AnalysisPlayerTouches,
-    |_self_: &AnalysisPlayerTouches<F>| touch_dependency(),
-    |_self_: &AnalysisPlayerTouches<F>,
-     context: &AnalysisFeatureContext<'_>,
-     player_id: &PlayerId,
-     _processor: &dyn ProcessorView,
-     _frame: &boxcars::Frame,
-     _frame_count: usize,
-     _current_time: f32| {
-        let touch_event = context
-            .state::<TouchCalculator>()?
-            .new_events()
-            .iter()
-            .any(|event| &event.player == player_id);
-        convert_all_floats!(f32::from(touch_event))
-    },
+    touch_dependency,
+    TouchCalculator,
+    new_events,
+    |event: &TouchClassificationEvent, player_id: &PlayerId| &event.player == player_id,
     "analysis touch event",
 );
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerCenters,
+    center_dependency,
+    CenterCalculator,
+    new_events,
+    |event: &CenterEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis center event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerDoubleTaps,
+    double_tap_dependency,
+    DoubleTapCalculator,
+    new_events,
+    |event: &DoubleTapEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis double tap event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerOneTimers,
+    one_timer_dependency,
+    OneTimerCalculator,
+    new_events,
+    |event: &OneTimerEvent, player_id: &PlayerId| {
+        &event.player == player_id || &event.passer == player_id
+    },
+    "analysis one timer event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerWallAerials,
+    wall_aerial_dependency,
+    WallAerialCalculator,
+    new_events,
+    |event: &WallAerialEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis wall aerial event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerWallAerialShots,
+    wall_aerial_shot_dependency,
+    WallAerialShotCalculator,
+    new_events,
+    |event: &WallAerialShotEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis wall aerial shot event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerCeilingShots,
+    ceiling_shot_dependency,
+    CeilingShotCalculator,
+    new_events,
+    |event: &CeilingShotEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis ceiling shot event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerFlicks,
+    flick_dependency,
+    FlickCalculator,
+    new_events,
+    |event: &FlickEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis flick event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerMustyFlicks,
+    musty_flick_dependency,
+    MustyFlickCalculator,
+    new_events,
+    |event: &MustyFlickEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis musty flick event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerDodgeResets,
+    dodge_reset_dependency,
+    DodgeResetCalculator,
+    new_events,
+    |event: &DodgeResetEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis dodge reset event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerFlipResetDodges,
+    dodge_reset_dependency,
+    DodgeResetCalculator,
+    new_confirmed_flip_reset_events,
+    |event: &ConfirmedFlipResetEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis flip reset dodge event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerHalfFlips,
+    half_flip_dependency,
+    HalfFlipCalculator,
+    new_events,
+    |event: &HalfFlipEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis half flip event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerHalfVolleys,
+    half_volley_dependency,
+    HalfVolleyCalculator,
+    new_events,
+    |event: &HalfVolleyEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis half volley event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerWavedashes,
+    wavedash_dependency,
+    WavedashCalculator,
+    new_events,
+    |event: &WavedashEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis wavedash event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerWhiffs,
+    whiff_dependency,
+    WhiffCalculator,
+    new_events,
+    |event: &WhiffEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis whiff event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerSpeedFlips,
+    speed_flip_dependency,
+    SpeedFlipCalculator,
+    new_events,
+    |event: &SpeedFlipEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis speed flip event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerFlipImpulses,
+    flip_impulse_dependency,
+    FlipImpulseCalculator,
+    new_events,
+    |event: &FlipImpulseEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis flip impulse event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerPowerslides,
+    powerslide_dependency,
+    PowerslideCalculator,
+    new_events,
+    |event: &PowerslideEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis powerslide event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerBallCarries,
+    ball_carry_dependency,
+    BallCarryCalculator,
+    new_carry_events,
+    |event: &BallCarryEvent, player_id: &PlayerId| &event.player_id == player_id,
+    "analysis ball carry event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerBoostPickups,
+    boost_dependency,
+    BoostCalculator,
+    new_pickup_comparison_events,
+    |event: &BoostPickupComparisonEvent, player_id: &PlayerId| &event.player_id == player_id,
+    "analysis boost pickup event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerBoostLedgerEvents,
+    boost_dependency,
+    BoostCalculator,
+    new_ledger_events,
+    |event: &BoostLedgerEvent, player_id: &PlayerId| &event.player_id == player_id,
+    "analysis boost ledger event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerBoostStateEvents,
+    boost_dependency,
+    BoostCalculator,
+    new_state_events,
+    |event: &BoostStateEvent, player_id: &PlayerId| &event.player_id == player_id,
+    "analysis boost state event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerBumps,
+    bump_dependency,
+    BumpCalculator,
+    new_events,
+    |event: &BumpEvent, player_id: &PlayerId| {
+        &event.initiator == player_id || &event.victim == player_id
+    },
+    "analysis bump event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerPasses,
+    pass_dependency,
+    PassCalculator,
+    new_events,
+    |event: &PassEvent, player_id: &PlayerId| {
+        &event.passer == player_id || &event.receiver == player_id
+    },
+    "analysis pass event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerRotationEvents,
+    rotation_dependency,
+    RotationCalculator,
+    new_player_events,
+    |event: &RotationPlayerEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis rotation event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerMovementEvents,
+    movement_dependency,
+    MovementCalculator,
+    new_events,
+    |event: &MovementEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis movement event",
+);
+
+build_analysis_player_event_indicator!(
+    AnalysisPlayerPositioningEvents,
+    positioning_dependency,
+    PositioningCalculator,
+    new_events,
+    |event: &PositioningEvent, player_id: &PlayerId| &event.player == player_id,
+    "analysis positioning event",
+);
+
+pub(crate) fn analysis_player_event_feature_adder_from_name<F>(
+    name: &str,
+) -> Option<NDArrayPlayerFeatureAdder<F>>
+where
+    F: TryFrom<f32> + Send + Sync + 'static,
+    <F as TryFrom<f32>>::Error: std::fmt::Debug,
+{
+    let event_name = name.strip_prefix("PlayerEvent:")?;
+
+    match event_name {
+        "touch" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerTouches::<F>::arc_new(),
+        )),
+        "center" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerCenters::<F>::arc_new(),
+        )),
+        "double_tap" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerDoubleTaps::<F>::arc_new(),
+        )),
+        "one_timer" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerOneTimers::<F>::arc_new(),
+        )),
+        "wall_aerial" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerWallAerials::<F>::arc_new(),
+        )),
+        "wall_aerial_shot" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerWallAerialShots::<F>::arc_new(),
+        )),
+        "ceiling_shot" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerCeilingShots::<F>::arc_new(),
+        )),
+        "flick" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerFlicks::<F>::arc_new(),
+        )),
+        "musty_flick" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerMustyFlicks::<F>::arc_new(),
+        )),
+        "dodge_reset" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerDodgeResets::<F>::arc_new(),
+        )),
+        "flip_reset_dodge" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerFlipResetDodges::<F>::arc_new(),
+        )),
+        "half_flip" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerHalfFlips::<F>::arc_new(),
+        )),
+        "half_volley" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerHalfVolleys::<F>::arc_new(),
+        )),
+        "wavedash" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerWavedashes::<F>::arc_new(),
+        )),
+        "whiff" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerWhiffs::<F>::arc_new(),
+        )),
+        "speed_flip" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerSpeedFlips::<F>::arc_new(),
+        )),
+        "flip_impulse" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerFlipImpulses::<F>::arc_new(),
+        )),
+        "powerslide" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerPowerslides::<F>::arc_new(),
+        )),
+        "ball_carry" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerBallCarries::<F>::arc_new(),
+        )),
+        "boost_pickup" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerBoostPickups::<F>::arc_new(),
+        )),
+        "boost_ledger" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerBoostLedgerEvents::<F>::arc_new(),
+        )),
+        "boost_state" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerBoostStateEvents::<F>::arc_new(),
+        )),
+        "bump" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerBumps::<F>::arc_new(),
+        )),
+        "pass" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerPasses::<F>::arc_new(),
+        )),
+        "rotation" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerRotationEvents::<F>::arc_new(),
+        )),
+        "movement" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerMovementEvents::<F>::arc_new(),
+        )),
+        "positioning" => Some(NDArrayPlayerFeatureAdder::analysis(
+            AnalysisPlayerPositioningEvents::<F>::arc_new(),
+        )),
+        _ => None,
+    }
+}

--- a/src/collector/ndarray/collector.rs
+++ b/src/collector/ndarray/collector.rs
@@ -434,10 +434,7 @@ where
         "PlayerDemolishedBy" => Some(NDArrayPlayerFeatureAdder::plain(
             PlayerDemolishedBy::<F>::arc_new(),
         )),
-        "AnalysisPlayerTouches" | "PlayerTouches" | "PlayerTouchCount" => Some(
-            NDArrayPlayerFeatureAdder::analysis(AnalysisPlayerTouches::<F>::arc_new()),
-        ),
-        _ => None,
+        _ => analysis_player_event_feature_adder_from_name(name),
     }
 }
 

--- a/src/collector/ndarray/collector.rs
+++ b/src/collector/ndarray/collector.rs
@@ -1,11 +1,12 @@
 use super::builtins::*;
 use super::traits::*;
 use crate::collector::{Collector, TimeAdvance};
+use crate::stats::analysis_graph::{AnalysisDependency, AnalysisGraph};
+use crate::stats::calculators::{FrameInput, ReplayFrameInputBuilder};
 use crate::*;
 use ::ndarray;
 use boxcars;
 use serde::Serialize;
-use std::sync::Arc;
 
 /// Column headers for the frame matrix emitted by [`NDArrayCollector`].
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -65,22 +66,96 @@ impl ReplayMetaWithHeaders {
 
 /// Collects replay frames into a dense 2D feature matrix.
 pub struct NDArrayCollector<F> {
-    feature_adders: FeatureAdders<F>,
-    player_feature_adders: PlayerFeatureAdders<F>,
+    feature_adders: NDArrayFeatureAdders<F>,
+    player_feature_adders: NDArrayPlayerFeatureAdders<F>,
+    analysis_runtime: Option<NDArrayAnalysisRuntime>,
     data: Vec<F>,
     replay_meta: Option<ReplayMeta>,
     frames_added: usize,
 }
 
+struct NDArrayAnalysisRuntime {
+    graph: AnalysisGraph,
+    dependencies: Vec<AnalysisDependency>,
+    frame_input_builder: ReplayFrameInputBuilder,
+    last_sample_time: Option<f32>,
+    last_replay_meta_player_count: Option<usize>,
+}
+
+impl NDArrayAnalysisRuntime {
+    fn new(dependencies: Vec<AnalysisDependency>) -> Self {
+        let mut graph = AnalysisGraph::new();
+        graph.register_input_state::<FrameInput>();
+        Self {
+            graph,
+            dependencies,
+            frame_input_builder: ReplayFrameInputBuilder::default(),
+            last_sample_time: None,
+            last_replay_meta_player_count: None,
+        }
+    }
+
+    fn process_frame(
+        &mut self,
+        processor: &dyn ProcessorView,
+        frame_number: usize,
+        current_time: f32,
+    ) -> SubtrActorResult<()> {
+        let player_count = processor.player_count();
+        if self.last_replay_meta_player_count != Some(player_count) {
+            self.graph
+                .ensure_dependencies(self.dependencies.iter().copied())?;
+            self.graph.on_replay_meta(&processor.get_replay_meta()?)?;
+            self.last_replay_meta_player_count = Some(player_count);
+        }
+
+        let dt = self
+            .last_sample_time
+            .map(|last_time| (current_time - last_time).max(0.0))
+            .unwrap_or(0.0);
+        let frame_input =
+            self.frame_input_builder
+                .aggregate(processor, frame_number, current_time, dt);
+        self.graph.evaluate_with_state(&frame_input)?;
+        self.last_sample_time = Some(current_time);
+        Ok(())
+    }
+
+    fn context(&self) -> AnalysisFeatureContext<'_> {
+        AnalysisFeatureContext::new(&self.graph)
+    }
+
+    fn finish_replay(&mut self) -> SubtrActorResult<()> {
+        self.graph.finish()
+    }
+}
+
 impl<F> NDArrayCollector<F> {
-    /// Creates a collector from explicit global and per-player feature adders.
+    /// Creates a collector from ordered global and per-player feature-adder specs.
     pub fn new(
-        feature_adders: FeatureAdders<F>,
-        player_feature_adders: PlayerFeatureAdders<F>,
+        feature_adders: NDArrayFeatureAdders<F>,
+        player_feature_adders: NDArrayPlayerFeatureAdders<F>,
     ) -> Self {
+        let analysis_dependencies = feature_adders
+            .iter()
+            .flat_map(NDArrayFeatureAdder::analysis_dependencies)
+            .chain(
+                player_feature_adders
+                    .iter()
+                    .flat_map(NDArrayPlayerFeatureAdder::analysis_dependencies),
+            )
+            .collect();
+        let uses_analysis = feature_adders
+            .iter()
+            .any(NDArrayFeatureAdder::is_analysis_backed)
+            || player_feature_adders
+                .iter()
+                .any(NDArrayPlayerFeatureAdder::is_analysis_backed);
         Self {
             feature_adders,
             player_feature_adders,
+            analysis_runtime: uses_analysis
+                .then(|| NDArrayAnalysisRuntime::new(analysis_dependencies)),
             data: Vec::new(),
             replay_meta: None,
             frames_added: 0,
@@ -193,26 +268,64 @@ impl<F> Collector for NDArrayCollector<F> {
     ) -> SubtrActorResult<TimeAdvance> {
         self.maybe_set_replay_meta(processor)?;
 
-        for feature_adder in &self.feature_adders {
-            feature_adder.add_features(
-                processor,
-                frame,
-                frame_number,
-                current_time,
-                &mut self.data,
-            )?;
+        if let Some(analysis_runtime) = self.analysis_runtime.as_mut() {
+            analysis_runtime.process_frame(processor, frame_number, current_time)?;
         }
+        let analysis_context = self
+            .analysis_runtime
+            .as_ref()
+            .map(NDArrayAnalysisRuntime::context);
 
-        for player_id in processor.iter_player_ids_in_order() {
-            for player_feature_adder in &self.player_feature_adders {
-                player_feature_adder.add_features(
-                    player_id,
+        for feature_adder in &self.feature_adders {
+            match feature_adder {
+                NDArrayFeatureAdder::Plain(adder) => adder.add_features(
                     processor,
                     frame,
                     frame_number,
                     current_time,
                     &mut self.data,
-                )?;
+                )?,
+                NDArrayFeatureAdder::Analysis(adder) => adder.add_features(
+                    analysis_context
+                        .as_ref()
+                        .expect("analysis runtime exists for analysis feature adders"),
+                    processor,
+                    frame,
+                    frame_number,
+                    current_time,
+                    &mut self.data,
+                )?,
+            }
+        }
+
+        for player_id in processor.iter_player_ids_in_order() {
+            for player_feature_adder in &self.player_feature_adders {
+                match player_feature_adder {
+                    NDArrayPlayerFeatureAdder::Plain(adder) => adder.add_features(
+                        player_id,
+                        processor,
+                        frame,
+                        frame_number,
+                        current_time,
+                        &mut self.data,
+                    )?,
+                    NDArrayPlayerFeatureAdder::Analysis(adder) => {
+                        let context = analysis_context
+                            .as_ref()
+                            .expect("analysis runtime exists for analysis feature adders");
+                        adder.add_features(
+                            AnalysisPlayerFeatureInput {
+                                context,
+                                player_id,
+                                processor,
+                                frame,
+                                frame_count: frame_number,
+                                current_time,
+                            },
+                            &mut self.data,
+                        )?
+                    }
+                }
             }
         }
 
@@ -220,72 +333,110 @@ impl<F> Collector for NDArrayCollector<F> {
 
         Ok(TimeAdvance::NextFrame)
     }
+
+    fn finish_replay(&mut self, _processor: &dyn ProcessorView) -> SubtrActorResult<()> {
+        if let Some(analysis_runtime) = self.analysis_runtime.as_mut() {
+            analysis_runtime.finish_replay()?;
+        }
+        Ok(())
+    }
 }
 
-fn global_feature_adder_from_name<F>(
-    name: &str,
-) -> Option<Arc<dyn FeatureAdder<F> + Send + Sync + 'static>>
+fn global_feature_adder_from_name<F>(name: &str) -> Option<NDArrayFeatureAdder<F>>
 where
     F: TryFrom<f32> + Send + Sync + 'static,
     <F as TryFrom<f32>>::Error: std::fmt::Debug,
 {
     match name {
-        "BallRigidBody" => Some(BallRigidBody::<F>::arc_new()),
-        "BallRigidBodyNoVelocities" => Some(BallRigidBodyNoVelocities::<F>::arc_new()),
-        "BallRigidBodyQuaternions" => Some(BallRigidBodyQuaternions::<F>::arc_new()),
-        "BallRigidBodyQuaternionVelocities" => {
-            Some(BallRigidBodyQuaternionVelocities::<F>::arc_new())
-        }
-        "BallRigidBodyBasis" => Some(BallRigidBodyBasis::<F>::arc_new()),
-        "VelocityAddedBallRigidBodyNoVelocities" => {
-            Some(VelocityAddedBallRigidBodyNoVelocities::<F>::arc_new())
-        }
-        "InterpolatedBallRigidBodyNoVelocities" => {
-            Some(InterpolatedBallRigidBodyNoVelocities::<F>::arc_new(0.0))
-        }
-        "SecondsRemaining" => Some(SecondsRemaining::<F>::arc_new()),
-        "CurrentTime" => Some(CurrentTime::<F>::arc_new()),
-        "FrameTime" => Some(FrameTime::<F>::arc_new()),
-        "ReplicatedStateName" => Some(ReplicatedStateName::<F>::arc_new()),
-        "ReplicatedGameStateTimeRemaining" => {
-            Some(ReplicatedGameStateTimeRemaining::<F>::arc_new())
-        }
-        "BallHasBeenHit" => Some(BallHasBeenHit::<F>::arc_new()),
+        "BallRigidBody" => Some(NDArrayFeatureAdder::plain(BallRigidBody::<F>::arc_new())),
+        "BallRigidBodyNoVelocities" => Some(NDArrayFeatureAdder::plain(
+            BallRigidBodyNoVelocities::<F>::arc_new(),
+        )),
+        "BallRigidBodyQuaternions" => Some(NDArrayFeatureAdder::plain(
+            BallRigidBodyQuaternions::<F>::arc_new(),
+        )),
+        "BallRigidBodyQuaternionVelocities" => Some(NDArrayFeatureAdder::plain(
+            BallRigidBodyQuaternionVelocities::<F>::arc_new(),
+        )),
+        "BallRigidBodyBasis" => Some(NDArrayFeatureAdder::plain(
+            BallRigidBodyBasis::<F>::arc_new(),
+        )),
+        "VelocityAddedBallRigidBodyNoVelocities" => Some(NDArrayFeatureAdder::plain(
+            VelocityAddedBallRigidBodyNoVelocities::<F>::arc_new(),
+        )),
+        "InterpolatedBallRigidBodyNoVelocities" => Some(NDArrayFeatureAdder::plain(
+            InterpolatedBallRigidBodyNoVelocities::<F>::arc_new(0.0),
+        )),
+        "SecondsRemaining" => Some(NDArrayFeatureAdder::plain(SecondsRemaining::<F>::arc_new())),
+        "CurrentTime" => Some(NDArrayFeatureAdder::plain(CurrentTime::<F>::arc_new())),
+        "FrameTime" => Some(NDArrayFeatureAdder::plain(FrameTime::<F>::arc_new())),
+        "ReplicatedStateName" => Some(NDArrayFeatureAdder::plain(
+            ReplicatedStateName::<F>::arc_new(),
+        )),
+        "ReplicatedGameStateTimeRemaining" => Some(NDArrayFeatureAdder::plain(
+            ReplicatedGameStateTimeRemaining::<F>::arc_new(),
+        )),
+        "BallHasBeenHit" => Some(NDArrayFeatureAdder::plain(BallHasBeenHit::<F>::arc_new())),
         _ => None,
     }
 }
 
-fn player_feature_adder_from_name<F>(
-    name: &str,
-) -> Option<Arc<dyn PlayerFeatureAdder<F> + Send + Sync + 'static>>
+fn player_feature_adder_from_name<F>(name: &str) -> Option<NDArrayPlayerFeatureAdder<F>>
 where
     F: TryFrom<f32> + Send + Sync + 'static,
     <F as TryFrom<f32>>::Error: std::fmt::Debug,
 {
     match name {
-        "PlayerRigidBody" => Some(PlayerRigidBody::<F>::arc_new()),
-        "PlayerRigidBodyNoVelocities" => Some(PlayerRigidBodyNoVelocities::<F>::arc_new()),
-        "PlayerRigidBodyQuaternions" => Some(PlayerRigidBodyQuaternions::<F>::arc_new()),
-        "PlayerRigidBodyQuaternionVelocities" => {
-            Some(PlayerRigidBodyQuaternionVelocities::<F>::arc_new())
-        }
-        "PlayerRigidBodyBasis" => Some(PlayerRigidBodyBasis::<F>::arc_new()),
-        "PlayerRelativeBallPosition" => Some(PlayerRelativeBallPosition::<F>::arc_new()),
-        "PlayerRelativeBallVelocity" => Some(PlayerRelativeBallVelocity::<F>::arc_new()),
-        "PlayerLocalRelativeBallPosition" => Some(PlayerLocalRelativeBallPosition::<F>::arc_new()),
-        "PlayerLocalRelativeBallVelocity" => Some(PlayerLocalRelativeBallVelocity::<F>::arc_new()),
-        "VelocityAddedPlayerRigidBodyNoVelocities" => {
-            Some(VelocityAddedPlayerRigidBodyNoVelocities::<F>::arc_new())
-        }
-        "InterpolatedPlayerRigidBodyNoVelocities" => {
-            Some(InterpolatedPlayerRigidBodyNoVelocities::<F>::arc_new(0.003))
-        }
-        "PlayerBallDistance" | "PlayerDistanceToBall" => Some(PlayerBallDistance::<F>::arc_new()),
-        "PlayerBoost" => Some(PlayerBoost::<F>::arc_new()),
-        "PlayerJump" => Some(PlayerJump::<F>::arc_new()),
-        "PlayerAnyJump" => Some(PlayerAnyJump::<F>::arc_new()),
-        "PlayerDodgeRefreshed" => Some(PlayerDodgeRefreshed::<F>::arc_new()),
-        "PlayerDemolishedBy" => Some(PlayerDemolishedBy::<F>::arc_new()),
+        "PlayerRigidBody" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerRigidBody::<F>::arc_new(),
+        )),
+        "PlayerRigidBodyNoVelocities" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerRigidBodyNoVelocities::<F>::arc_new(),
+        )),
+        "PlayerRigidBodyQuaternions" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerRigidBodyQuaternions::<F>::arc_new(),
+        )),
+        "PlayerRigidBodyQuaternionVelocities" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerRigidBodyQuaternionVelocities::<F>::arc_new(),
+        )),
+        "PlayerRigidBodyBasis" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerRigidBodyBasis::<F>::arc_new(),
+        )),
+        "PlayerRelativeBallPosition" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerRelativeBallPosition::<F>::arc_new(),
+        )),
+        "PlayerRelativeBallVelocity" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerRelativeBallVelocity::<F>::arc_new(),
+        )),
+        "PlayerLocalRelativeBallPosition" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerLocalRelativeBallPosition::<F>::arc_new(),
+        )),
+        "PlayerLocalRelativeBallVelocity" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerLocalRelativeBallVelocity::<F>::arc_new(),
+        )),
+        "VelocityAddedPlayerRigidBodyNoVelocities" => Some(NDArrayPlayerFeatureAdder::plain(
+            VelocityAddedPlayerRigidBodyNoVelocities::<F>::arc_new(),
+        )),
+        "InterpolatedPlayerRigidBodyNoVelocities" => Some(NDArrayPlayerFeatureAdder::plain(
+            InterpolatedPlayerRigidBodyNoVelocities::<F>::arc_new(0.003),
+        )),
+        "PlayerBallDistance" | "PlayerDistanceToBall" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerBallDistance::<F>::arc_new(),
+        )),
+        "PlayerBoost" => Some(NDArrayPlayerFeatureAdder::plain(PlayerBoost::<F>::arc_new())),
+        "PlayerJump" => Some(NDArrayPlayerFeatureAdder::plain(PlayerJump::<F>::arc_new())),
+        "PlayerAnyJump" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerAnyJump::<F>::arc_new(),
+        )),
+        "PlayerDodgeRefreshed" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerDodgeRefreshed::<F>::arc_new(),
+        )),
+        "PlayerDemolishedBy" => Some(NDArrayPlayerFeatureAdder::plain(
+            PlayerDemolishedBy::<F>::arc_new(),
+        )),
+        "AnalysisPlayerTouches" | "PlayerTouches" | "PlayerTouchCount" => Some(
+            NDArrayPlayerFeatureAdder::analysis(AnalysisPlayerTouches::<F>::arc_new()),
+        ),
         _ => None,
     }
 }
@@ -297,7 +448,7 @@ where
 {
     /// Builds a collector from the registered string names of feature adders.
     pub fn from_strings_typed(fa_names: &[&str], pfa_names: &[&str]) -> SubtrActorResult<Self> {
-        let feature_adders: Vec<Arc<dyn FeatureAdder<F> + Send + Sync>> = fa_names
+        let feature_adders: NDArrayFeatureAdders<F> = fa_names
             .iter()
             .map(|name| {
                 global_feature_adder_from_name(name).ok_or_else(|| {
@@ -307,7 +458,7 @@ where
                 })
             })
             .collect::<SubtrActorResult<Vec<_>>>()?;
-        let player_feature_adders: Vec<Arc<dyn PlayerFeatureAdder<F> + Send + Sync>> = pfa_names
+        let player_feature_adders: NDArrayPlayerFeatureAdders<F> = pfa_names
             .iter()
             .map(|name| {
                 player_feature_adder_from_name(name).ok_or_else(|| {
@@ -334,12 +485,16 @@ where
 {
     fn default() -> Self {
         NDArrayCollector::new(
-            vec![BallRigidBody::arc_new()],
+            vec![NDArrayFeatureAdder::plain(BallRigidBody::arc_new())],
             vec![
-                PlayerRigidBody::arc_new(),
-                PlayerBoost::arc_new(),
-                PlayerAnyJump::arc_new(),
+                NDArrayPlayerFeatureAdder::plain(PlayerRigidBody::arc_new()),
+                NDArrayPlayerFeatureAdder::plain(PlayerBoost::arc_new()),
+                NDArrayPlayerFeatureAdder::plain(PlayerAnyJump::arc_new()),
             ],
         )
     }
 }
+
+#[cfg(test)]
+#[path = "collector_tests.rs"]
+mod tests;

--- a/src/collector/ndarray/collector_tests.rs
+++ b/src/collector/ndarray/collector_tests.rs
@@ -140,7 +140,7 @@ fn analysis_feature_adders_share_one_graph_evaluation_per_ndarray_row() {
 #[test]
 fn string_feature_names_can_create_analysis_backed_touch_adders() {
     let replay = parse_replay(NDARRAY_ANALYSIS_FIXTURE);
-    let mut collector = NDArrayCollector::<f32>::from_strings(&[], &["AnalysisPlayerTouches"])
+    let mut collector = NDArrayCollector::<f32>::from_strings(&[], &["PlayerEvent:touch"])
         .expect("analysis-backed feature names should resolve");
     FrameRateDecorator::new_from_fps(30.0, &mut collector)
         .process_replay(&replay)
@@ -171,5 +171,49 @@ fn string_feature_names_can_create_analysis_backed_touch_adders() {
     assert!(
         touch_event_count > 0,
         "fixture should produce at least one string-created player touch event"
+    );
+}
+
+#[test]
+fn player_event_names_create_registered_analysis_indicators() {
+    let event_names = [
+        "PlayerEvent:touch",
+        "PlayerEvent:center",
+        "PlayerEvent:double_tap",
+        "PlayerEvent:one_timer",
+        "PlayerEvent:wall_aerial",
+        "PlayerEvent:wall_aerial_shot",
+        "PlayerEvent:ceiling_shot",
+        "PlayerEvent:flick",
+        "PlayerEvent:musty_flick",
+        "PlayerEvent:dodge_reset",
+        "PlayerEvent:flip_reset_dodge",
+        "PlayerEvent:half_flip",
+        "PlayerEvent:half_volley",
+        "PlayerEvent:wavedash",
+        "PlayerEvent:whiff",
+        "PlayerEvent:speed_flip",
+        "PlayerEvent:flip_impulse",
+        "PlayerEvent:powerslide",
+        "PlayerEvent:ball_carry",
+        "PlayerEvent:boost_pickup",
+        "PlayerEvent:boost_ledger",
+        "PlayerEvent:boost_state",
+        "PlayerEvent:bump",
+        "PlayerEvent:pass",
+        "PlayerEvent:rotation",
+        "PlayerEvent:movement",
+        "PlayerEvent:positioning",
+    ];
+    let collector = NDArrayCollector::<f32>::from_strings(&[], &event_names)
+        .expect("registered event feature names should resolve");
+    let headers = collector.get_column_headers();
+
+    assert_eq!(headers.global_headers, Vec::<String>::new());
+    assert_eq!(headers.player_headers.len(), event_names.len());
+    assert_eq!(headers.player_headers[0], "analysis touch event");
+    assert_eq!(
+        headers.player_headers.last(),
+        Some(&"analysis positioning event".to_owned())
     );
 }

--- a/src/collector/ndarray/collector_tests.rs
+++ b/src/collector/ndarray/collector_tests.rs
@@ -1,0 +1,175 @@
+use super::*;
+use crate::collector::ndarray::traits::{
+    dynamic_analysis_feature_adder, dynamic_analysis_player_feature_adder,
+};
+use crate::stats::analysis_graph::{AnalysisNode, AnalysisStateContext};
+use crate::{Collector, FrameRateDecorator};
+use std::path::Path;
+
+const NDARRAY_ANALYSIS_FIXTURE: &str = "assets/post-eac-ranked-duel-2026-04-28-a.replay";
+
+#[derive(Default)]
+struct SharedAnalysisState {
+    evaluations: usize,
+}
+
+#[derive(Default)]
+struct SharedAnalysisNode {
+    state: SharedAnalysisState,
+}
+
+impl AnalysisNode for SharedAnalysisNode {
+    type State = SharedAnalysisState;
+
+    fn name(&self) -> &'static str {
+        "ndarray_test_shared_analysis"
+    }
+
+    fn dependencies(&self) -> Vec<AnalysisDependency> {
+        vec![AnalysisDependency::required::<FrameInput>()]
+    }
+
+    fn evaluate(&mut self, ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
+        let _frame_input = ctx.get::<FrameInput>()?;
+        self.state.evaluations += 1;
+        Ok(())
+    }
+
+    fn state(&self) -> &Self::State {
+        &self.state
+    }
+}
+
+fn boxed_shared_analysis_node() -> Box<dyn crate::stats::analysis_graph::AnalysisNodeDyn> {
+    Box::<SharedAnalysisNode>::default()
+}
+
+fn shared_analysis_dependency() -> Vec<AnalysisDependency> {
+    vec![AnalysisDependency::with_default::<SharedAnalysisState>(
+        boxed_shared_analysis_node,
+    )]
+}
+
+build_analysis_global_feature_adder!(
+    MacroSharedAnalysisCount,
+    |_self_: &MacroSharedAnalysisCount<F>| shared_analysis_dependency(),
+    |_self_: &MacroSharedAnalysisCount<F>,
+     context: &AnalysisFeatureContext<'_>,
+     _processor: &dyn ProcessorView,
+     _frame: &boxcars::Frame,
+     _frame_count: usize,
+     _current_time: f32| {
+        let state = context.state::<SharedAnalysisState>()?;
+        convert_all_floats!(state.evaluations as f32)
+    },
+    "macro shared analysis count",
+);
+
+fn parse_replay(path: &str) -> boxcars::Replay {
+    let replay_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
+    let data = std::fs::read(&replay_path)
+        .unwrap_or_else(|_| panic!("Failed to read replay file: {}", replay_path.display()));
+    boxcars::ParserBuilder::new(&data[..])
+        .always_check_crc()
+        .must_parse_network_data()
+        .parse()
+        .unwrap_or_else(|_| panic!("Failed to parse replay: {}", replay_path.display()))
+}
+
+#[test]
+fn analysis_feature_adders_share_one_graph_evaluation_per_ndarray_row() {
+    static DYNAMIC_HEADERS: [&str; 1] = ["dynamic shared analysis count"];
+    static PLAYER_HEADERS: [&str; 1] = ["player shared analysis count"];
+
+    let replay = parse_replay(NDARRAY_ANALYSIS_FIXTURE);
+    let mut collector = NDArrayCollector::<f32>::new(
+        vec![
+            NDArrayFeatureAdder::analysis(MacroSharedAnalysisCount::arc_new()),
+            NDArrayFeatureAdder::analysis(dynamic_analysis_feature_adder(
+                &DYNAMIC_HEADERS,
+                shared_analysis_dependency(),
+                |context, _processor, _frame, _frame_count, _current_time| {
+                    let state = context.state::<SharedAnalysisState>()?;
+                    Ok([state.evaluations as f32])
+                },
+            )),
+        ],
+        vec![NDArrayPlayerFeatureAdder::analysis(
+            dynamic_analysis_player_feature_adder(
+                &PLAYER_HEADERS,
+                shared_analysis_dependency(),
+                |context, _player_id, _processor, _frame, _frame_count, _current_time| {
+                    let state = context.state::<SharedAnalysisState>()?;
+                    Ok([state.evaluations as f32])
+                },
+            ),
+        )],
+    );
+    FrameRateDecorator::new_from_fps(30.0, &mut collector)
+        .process_replay(&replay)
+        .expect("collector should process replay");
+
+    let (meta, ndarray) = collector
+        .get_meta_and_ndarray()
+        .expect("collector should produce ndarray");
+
+    assert_eq!(
+        meta.column_headers.global_headers,
+        vec![
+            "macro shared analysis count".to_owned(),
+            "dynamic shared analysis count".to_owned()
+        ]
+    );
+    assert_eq!(
+        meta.column_headers.player_headers,
+        vec!["player shared analysis count".to_owned()]
+    );
+    assert!(ndarray.nrows() > 5);
+    assert_eq!(ndarray.ncols(), 2 + meta.replay_meta.player_count());
+
+    for (row_index, row) in ndarray.outer_iter().take(5).enumerate() {
+        let expected = (row_index + 1) as f32;
+        assert_eq!(row[0], expected);
+        assert_eq!(row[1], expected);
+        for player_column in 2..row.len() {
+            assert_eq!(row[player_column], expected);
+        }
+    }
+}
+
+#[test]
+fn string_feature_names_can_create_analysis_backed_touch_adders() {
+    let replay = parse_replay(NDARRAY_ANALYSIS_FIXTURE);
+    let mut collector = NDArrayCollector::<f32>::from_strings(&[], &["AnalysisPlayerTouches"])
+        .expect("analysis-backed feature names should resolve");
+    FrameRateDecorator::new_from_fps(30.0, &mut collector)
+        .process_replay(&replay)
+        .expect("collector should process replay");
+
+    let (meta, ndarray) = collector
+        .get_meta_and_ndarray()
+        .expect("collector should produce ndarray");
+
+    assert_eq!(meta.column_headers.global_headers, Vec::<String>::new());
+    assert_eq!(
+        meta.column_headers.player_headers,
+        vec!["analysis touch event".to_owned()]
+    );
+    assert!(ndarray.nrows() > 5);
+    assert_eq!(ndarray.ncols(), meta.replay_meta.player_count());
+
+    let mut touch_event_count = 0usize;
+    for value in ndarray.iter().copied() {
+        assert!(
+            value == 0.0 || value == 1.0,
+            "player touch event feature should be binary"
+        );
+        if value == 1.0 {
+            touch_event_count += 1;
+        }
+    }
+    assert!(
+        touch_event_count > 0,
+        "fixture should produce at least one string-created player touch event"
+    );
+}

--- a/src/collector/ndarray/mod.rs
+++ b/src/collector/ndarray/mod.rs
@@ -1,7 +1,9 @@
+mod analysis_builtins;
 mod builtins;
 mod collector;
 mod traits;
 
+pub use self::analysis_builtins::*;
 pub use self::builtins::*;
 pub use self::collector::*;
 pub use self::traits::*;

--- a/src/collector/ndarray/traits.rs
+++ b/src/collector/ndarray/traits.rs
@@ -1,10 +1,37 @@
+use crate::stats::analysis_graph::{AnalysisDependency, AnalysisGraph};
 use crate::*;
 /// Re-export of `derive_new` used by the public ndarray feature macros.
 pub use ::derive_new;
 /// Re-export of `paste` used by the public ndarray feature macros.
 pub use ::paste;
 use boxcars;
+use std::any::type_name;
+use std::marker::PhantomData;
 use std::sync::Arc;
+
+/// Typed, read-only view of analysis state available to analysis-backed features.
+pub struct AnalysisFeatureContext<'a> {
+    graph: &'a AnalysisGraph,
+}
+
+impl<'a> AnalysisFeatureContext<'a> {
+    pub(crate) fn new(graph: &'a AnalysisGraph) -> Self {
+        Self { graph }
+    }
+
+    pub fn maybe_state<T: 'static>(&self) -> Option<&'a T> {
+        self.graph.state::<T>()
+    }
+
+    pub fn state<T: 'static>(&self) -> SubtrActorResult<&'a T> {
+        self.maybe_state::<T>().ok_or_else(|| {
+            SubtrActorError::new(SubtrActorErrorVariant::CallbackError(format!(
+                "missing analysis state {}",
+                type_name::<T>(),
+            )))
+        })
+    }
+}
 
 /// Object-safe interface for frame-level feature extraction.
 pub trait FeatureAdder<F> {
@@ -24,8 +51,79 @@ pub trait FeatureAdder<F> {
     ) -> SubtrActorResult<()>;
 }
 
-/// Heterogeneous collection of frame-level feature adders.
-pub type FeatureAdders<F> = Vec<Arc<dyn FeatureAdder<F> + Send + Sync>>;
+/// Object-safe interface for frame-level features backed by the analysis graph.
+pub trait AnalysisFeatureAdder<F> {
+    fn features_added(&self) -> usize {
+        self.get_column_headers().len()
+    }
+
+    fn get_column_headers(&self) -> &[&str];
+
+    fn analysis_dependencies(&self) -> Vec<AnalysisDependency>;
+
+    fn add_features(
+        &self,
+        context: &AnalysisFeatureContext<'_>,
+        processor: &dyn ProcessorView,
+        frame: &boxcars::Frame,
+        frame_count: usize,
+        current_time: f32,
+        vector: &mut Vec<F>,
+    ) -> SubtrActorResult<()>;
+}
+
+/// Fixed-width analysis-backed feature extractor with compile-time column count validation.
+pub trait LengthCheckedAnalysisFeatureAdder<F, const N: usize> {
+    fn get_column_headers_array(&self) -> &[&str; N];
+
+    fn analysis_dependencies(&self) -> Vec<AnalysisDependency>;
+
+    fn get_features(
+        &self,
+        context: &AnalysisFeatureContext<'_>,
+        processor: &dyn ProcessorView,
+        frame: &boxcars::Frame,
+        frame_count: usize,
+        current_time: f32,
+    ) -> SubtrActorResult<[F; N]>;
+}
+
+/// Implements [`AnalysisFeatureAdder`] for a fixed-width analysis-backed type.
+#[macro_export]
+macro_rules! impl_analysis_feature_adder {
+    ($struct_name:ident) => {
+        impl<F: TryFrom<f32>> AnalysisFeatureAdder<F> for $struct_name<F>
+        where
+            <F as TryFrom<f32>>::Error: std::fmt::Debug,
+        {
+            fn add_features(
+                &self,
+                context: &AnalysisFeatureContext<'_>,
+                processor: &dyn ProcessorView,
+                frame: &boxcars::Frame,
+                frame_count: usize,
+                current_time: f32,
+                vector: &mut Vec<F>,
+            ) -> SubtrActorResult<()> {
+                Ok(vector.extend(self.get_features(
+                    context,
+                    processor,
+                    frame,
+                    frame_count,
+                    current_time,
+                )?))
+            }
+
+            fn get_column_headers(&self) -> &[&str] {
+                self.get_column_headers_array()
+            }
+
+            fn analysis_dependencies(&self) -> Vec<AnalysisDependency> {
+                LengthCheckedAnalysisFeatureAdder::analysis_dependencies(self)
+            }
+        }
+    };
+}
 
 /// Fixed-width feature extractor with compile-time column count validation.
 pub trait LengthCheckedFeatureAdder<F, const N: usize> {
@@ -92,8 +190,374 @@ pub trait PlayerFeatureAdder<F> {
     ) -> SubtrActorResult<()>;
 }
 
-/// Heterogeneous collection of per-player feature adders.
-pub type PlayerFeatureAdders<F> = Vec<Arc<dyn PlayerFeatureAdder<F> + Send + Sync>>;
+/// Arguments supplied to object-safe per-player analysis feature adders.
+#[derive(Clone, Copy)]
+pub struct AnalysisPlayerFeatureInput<'a, 'ctx> {
+    pub context: &'a AnalysisFeatureContext<'ctx>,
+    pub player_id: &'a PlayerId,
+    pub processor: &'a dyn ProcessorView,
+    pub frame: &'a boxcars::Frame,
+    pub frame_count: usize,
+    pub current_time: f32,
+}
+
+/// Object-safe interface for per-player features backed by the analysis graph.
+pub trait AnalysisPlayerFeatureAdder<F> {
+    fn features_added(&self) -> usize {
+        self.get_column_headers().len()
+    }
+
+    fn get_column_headers(&self) -> &[&str];
+
+    fn analysis_dependencies(&self) -> Vec<AnalysisDependency>;
+
+    fn add_features(
+        &self,
+        input: AnalysisPlayerFeatureInput<'_, '_>,
+        vector: &mut Vec<F>,
+    ) -> SubtrActorResult<()>;
+}
+
+/// Fixed-width per-player analysis-backed feature extractor.
+pub trait LengthCheckedAnalysisPlayerFeatureAdder<F, const N: usize> {
+    fn get_column_headers_array(&self) -> &[&str; N];
+
+    fn analysis_dependencies(&self) -> Vec<AnalysisDependency>;
+
+    fn get_features(
+        &self,
+        context: &AnalysisFeatureContext<'_>,
+        player_id: &PlayerId,
+        processor: &dyn ProcessorView,
+        frame: &boxcars::Frame,
+        frame_count: usize,
+        current_time: f32,
+    ) -> SubtrActorResult<[F; N]>;
+}
+
+/// Implements [`AnalysisPlayerFeatureAdder`] for a fixed-width analysis-backed type.
+#[macro_export]
+macro_rules! impl_analysis_player_feature_adder {
+    ($struct_name:ident) => {
+        impl<F: TryFrom<f32>> AnalysisPlayerFeatureAdder<F> for $struct_name<F>
+        where
+            <F as TryFrom<f32>>::Error: std::fmt::Debug,
+        {
+            fn add_features(
+                &self,
+                input: AnalysisPlayerFeatureInput<'_, '_>,
+                vector: &mut Vec<F>,
+            ) -> SubtrActorResult<()> {
+                Ok(vector.extend(self.get_features(
+                    input.context,
+                    input.player_id,
+                    input.processor,
+                    input.frame,
+                    input.frame_count,
+                    input.current_time,
+                )?))
+            }
+
+            fn get_column_headers(&self) -> &[&str] {
+                self.get_column_headers_array()
+            }
+
+            fn analysis_dependencies(&self) -> Vec<AnalysisDependency> {
+                LengthCheckedAnalysisPlayerFeatureAdder::analysis_dependencies(self)
+            }
+        }
+    };
+}
+
+pub struct DynamicAnalysisFeatureAdder<F, G, const N: usize> {
+    get_features: G,
+    column_headers: &'static [&'static str; N],
+    dependencies: Vec<AnalysisDependency>,
+    _marker: PhantomData<F>,
+}
+
+impl<F, G, const N: usize> DynamicAnalysisFeatureAdder<F, G, N> {
+    pub fn new(
+        column_headers: &'static [&'static str; N],
+        dependencies: Vec<AnalysisDependency>,
+        get_features: G,
+    ) -> Self {
+        Self {
+            get_features,
+            column_headers,
+            dependencies,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<F, G, const N: usize> AnalysisFeatureAdder<F> for DynamicAnalysisFeatureAdder<F, G, N>
+where
+    F: Send + Sync + 'static,
+    G: Fn(
+            &AnalysisFeatureContext<'_>,
+            &dyn ProcessorView,
+            &boxcars::Frame,
+            usize,
+            f32,
+        ) -> SubtrActorResult<[F; N]>
+        + Send
+        + Sync
+        + 'static,
+{
+    fn get_column_headers(&self) -> &[&str] {
+        self.column_headers.as_slice()
+    }
+
+    fn analysis_dependencies(&self) -> Vec<AnalysisDependency> {
+        self.dependencies.clone()
+    }
+
+    fn add_features(
+        &self,
+        context: &AnalysisFeatureContext<'_>,
+        processor: &dyn ProcessorView,
+        frame: &boxcars::Frame,
+        frame_count: usize,
+        current_time: f32,
+        vector: &mut Vec<F>,
+    ) -> SubtrActorResult<()> {
+        vector.extend((self.get_features)(
+            context,
+            processor,
+            frame,
+            frame_count,
+            current_time,
+        )?);
+        Ok(())
+    }
+}
+
+pub struct DynamicAnalysisPlayerFeatureAdder<F, G, const N: usize> {
+    get_features: G,
+    column_headers: &'static [&'static str; N],
+    dependencies: Vec<AnalysisDependency>,
+    _marker: PhantomData<F>,
+}
+
+impl<F, G, const N: usize> DynamicAnalysisPlayerFeatureAdder<F, G, N> {
+    pub fn new(
+        column_headers: &'static [&'static str; N],
+        dependencies: Vec<AnalysisDependency>,
+        get_features: G,
+    ) -> Self {
+        Self {
+            get_features,
+            column_headers,
+            dependencies,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<F, G, const N: usize> AnalysisPlayerFeatureAdder<F>
+    for DynamicAnalysisPlayerFeatureAdder<F, G, N>
+where
+    F: Send + Sync + 'static,
+    G: Fn(
+            &AnalysisFeatureContext<'_>,
+            &PlayerId,
+            &dyn ProcessorView,
+            &boxcars::Frame,
+            usize,
+            f32,
+        ) -> SubtrActorResult<[F; N]>
+        + Send
+        + Sync
+        + 'static,
+{
+    fn get_column_headers(&self) -> &[&str] {
+        self.column_headers.as_slice()
+    }
+
+    fn analysis_dependencies(&self) -> Vec<AnalysisDependency> {
+        self.dependencies.clone()
+    }
+
+    fn add_features(
+        &self,
+        input: AnalysisPlayerFeatureInput<'_, '_>,
+        vector: &mut Vec<F>,
+    ) -> SubtrActorResult<()> {
+        vector.extend((self.get_features)(
+            input.context,
+            input.player_id,
+            input.processor,
+            input.frame,
+            input.frame_count,
+            input.current_time,
+        )?);
+        Ok(())
+    }
+}
+
+pub fn dynamic_analysis_feature_adder<F, G, const N: usize>(
+    column_headers: &'static [&'static str; N],
+    dependencies: Vec<AnalysisDependency>,
+    get_features: G,
+) -> Arc<dyn AnalysisFeatureAdder<F> + Send + Sync + 'static>
+where
+    F: Send + Sync + 'static,
+    G: Fn(
+            &AnalysisFeatureContext<'_>,
+            &dyn ProcessorView,
+            &boxcars::Frame,
+            usize,
+            f32,
+        ) -> SubtrActorResult<[F; N]>
+        + Send
+        + Sync
+        + 'static,
+{
+    Arc::new(DynamicAnalysisFeatureAdder::new(
+        column_headers,
+        dependencies,
+        get_features,
+    ))
+}
+
+pub fn dynamic_analysis_player_feature_adder<F, G, const N: usize>(
+    column_headers: &'static [&'static str; N],
+    dependencies: Vec<AnalysisDependency>,
+    get_features: G,
+) -> Arc<dyn AnalysisPlayerFeatureAdder<F> + Send + Sync + 'static>
+where
+    F: Send + Sync + 'static,
+    G: Fn(
+            &AnalysisFeatureContext<'_>,
+            &PlayerId,
+            &dyn ProcessorView,
+            &boxcars::Frame,
+            usize,
+            f32,
+        ) -> SubtrActorResult<[F; N]>
+        + Send
+        + Sync
+        + 'static,
+{
+    Arc::new(DynamicAnalysisPlayerFeatureAdder::new(
+        column_headers,
+        dependencies,
+        get_features,
+    ))
+}
+
+#[derive(Clone)]
+pub enum NDArrayFeatureAdder<F> {
+    Plain(Arc<dyn FeatureAdder<F> + Send + Sync>),
+    Analysis(Arc<dyn AnalysisFeatureAdder<F> + Send + Sync>),
+}
+
+impl<F> NDArrayFeatureAdder<F> {
+    pub fn plain(adder: Arc<dyn FeatureAdder<F> + Send + Sync>) -> Self {
+        Self::Plain(adder)
+    }
+
+    pub fn analysis(adder: Arc<dyn AnalysisFeatureAdder<F> + Send + Sync>) -> Self {
+        Self::Analysis(adder)
+    }
+
+    pub fn features_added(&self) -> usize {
+        match self {
+            Self::Plain(adder) => adder.features_added(),
+            Self::Analysis(adder) => adder.features_added(),
+        }
+    }
+
+    pub fn get_column_headers(&self) -> &[&str] {
+        match self {
+            Self::Plain(adder) => adder.get_column_headers(),
+            Self::Analysis(adder) => adder.get_column_headers(),
+        }
+    }
+
+    pub fn analysis_dependencies(&self) -> Vec<AnalysisDependency> {
+        match self {
+            Self::Plain(_) => Vec::new(),
+            Self::Analysis(adder) => adder.analysis_dependencies(),
+        }
+    }
+
+    pub fn is_analysis_backed(&self) -> bool {
+        matches!(self, Self::Analysis(_))
+    }
+}
+
+impl<F> From<Arc<dyn FeatureAdder<F> + Send + Sync>> for NDArrayFeatureAdder<F> {
+    fn from(adder: Arc<dyn FeatureAdder<F> + Send + Sync>) -> Self {
+        Self::plain(adder)
+    }
+}
+
+impl<F> From<Arc<dyn AnalysisFeatureAdder<F> + Send + Sync>> for NDArrayFeatureAdder<F> {
+    fn from(adder: Arc<dyn AnalysisFeatureAdder<F> + Send + Sync>) -> Self {
+        Self::analysis(adder)
+    }
+}
+
+pub type NDArrayFeatureAdders<F> = Vec<NDArrayFeatureAdder<F>>;
+
+#[derive(Clone)]
+pub enum NDArrayPlayerFeatureAdder<F> {
+    Plain(Arc<dyn PlayerFeatureAdder<F> + Send + Sync>),
+    Analysis(Arc<dyn AnalysisPlayerFeatureAdder<F> + Send + Sync>),
+}
+
+impl<F> NDArrayPlayerFeatureAdder<F> {
+    pub fn plain(adder: Arc<dyn PlayerFeatureAdder<F> + Send + Sync>) -> Self {
+        Self::Plain(adder)
+    }
+
+    pub fn analysis(adder: Arc<dyn AnalysisPlayerFeatureAdder<F> + Send + Sync>) -> Self {
+        Self::Analysis(adder)
+    }
+
+    pub fn features_added(&self) -> usize {
+        match self {
+            Self::Plain(adder) => adder.features_added(),
+            Self::Analysis(adder) => adder.features_added(),
+        }
+    }
+
+    pub fn get_column_headers(&self) -> &[&str] {
+        match self {
+            Self::Plain(adder) => adder.get_column_headers(),
+            Self::Analysis(adder) => adder.get_column_headers(),
+        }
+    }
+
+    pub fn analysis_dependencies(&self) -> Vec<AnalysisDependency> {
+        match self {
+            Self::Plain(_) => Vec::new(),
+            Self::Analysis(adder) => adder.analysis_dependencies(),
+        }
+    }
+
+    pub fn is_analysis_backed(&self) -> bool {
+        matches!(self, Self::Analysis(_))
+    }
+}
+
+impl<F> From<Arc<dyn PlayerFeatureAdder<F> + Send + Sync>> for NDArrayPlayerFeatureAdder<F> {
+    fn from(adder: Arc<dyn PlayerFeatureAdder<F> + Send + Sync>) -> Self {
+        Self::plain(adder)
+    }
+}
+
+impl<F> From<Arc<dyn AnalysisPlayerFeatureAdder<F> + Send + Sync>>
+    for NDArrayPlayerFeatureAdder<F>
+{
+    fn from(adder: Arc<dyn AnalysisPlayerFeatureAdder<F> + Send + Sync>) -> Self {
+        Self::analysis(adder)
+    }
+}
+
+pub type NDArrayPlayerFeatureAdders<F> = Vec<NDArrayPlayerFeatureAdder<F>>;
 
 /// Fixed-width per-player feature extractor with compile-time column count validation.
 pub trait LengthCheckedPlayerFeatureAdder<F, const N: usize> {
@@ -252,6 +716,73 @@ macro_rules! global_feature_adder {
     }
 }
 
+/// Declares a new analysis-backed global feature-adder type.
+#[macro_export]
+macro_rules! build_analysis_global_feature_adder {
+    ($struct_name:ident, $dependency_getter:expr, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+
+        #[derive(derive_new::new)]
+        pub struct $struct_name<F> {
+            _zero: std::marker::PhantomData<F>,
+        }
+
+        impl<F: Sync + Send + TryFrom<f32> + 'static> $struct_name<F> where
+            <F as TryFrom<f32>>::Error: std::fmt::Debug,
+        {
+            pub fn arc_new() -> std::sync::Arc<dyn AnalysisFeatureAdder<F> + Send + Sync + 'static> {
+                std::sync::Arc::new(Self::new())
+            }
+        }
+
+        analysis_global_feature_adder!(
+            $struct_name,
+            $dependency_getter,
+            $prop_getter,
+            $( $column_names ),*
+        );
+    }
+}
+
+/// Implements the ndarray traits for an existing analysis-backed global feature type.
+#[macro_export]
+macro_rules! analysis_global_feature_adder {
+    ($struct_name:ident, $dependency_getter:expr, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+        macro_rules! _analysis_global_feature_adder {
+            ($count:ident) => {
+                impl<F: TryFrom<f32>> LengthCheckedAnalysisFeatureAdder<F, $count> for $struct_name<F>
+                where
+                    <F as TryFrom<f32>>::Error: std::fmt::Debug,
+                {
+                    fn get_column_headers_array(&self) -> &[&str; $count] {
+                        &[$( $column_names ),*]
+                    }
+
+                    fn analysis_dependencies(&self) -> Vec<AnalysisDependency> {
+                        $dependency_getter(self)
+                    }
+
+                    fn get_features(
+                        &self,
+                        context: &AnalysisFeatureContext<'_>,
+                        processor: &dyn ProcessorView,
+                        frame: &boxcars::Frame,
+                        frame_count: usize,
+                        current_time: f32,
+                    ) -> SubtrActorResult<[F; $count]> {
+                        $prop_getter(self, context, processor, frame, frame_count, current_time)
+                    }
+                }
+
+                impl_analysis_feature_adder!($struct_name);
+            };
+        }
+        paste::paste! {
+            const [<$struct_name:snake:upper _LENGTH>]: usize = [$($column_names),*].len();
+            _analysis_global_feature_adder!([<$struct_name:snake:upper _LENGTH>]);
+        }
+    }
+}
+
 /// Declares a new per-player feature-adder type and wires it into the ndarray traits.
 #[macro_export]
 macro_rules! build_player_feature_adder {
@@ -309,6 +840,73 @@ macro_rules! player_feature_adder {
         paste::paste! {
             const [<$struct_name:snake:upper _LENGTH>]: usize = [$($column_names),*].len();
             _player_feature_adder!([<$struct_name:snake:upper _LENGTH>]);
+        }
+    }
+}
+
+/// Declares a new analysis-backed per-player feature-adder type.
+#[macro_export]
+macro_rules! build_analysis_player_feature_adder {
+    ($struct_name:ident, $dependency_getter:expr, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+        #[derive(derive_new::new)]
+        pub struct $struct_name<F> {
+            _zero: std::marker::PhantomData<F>,
+        }
+
+        impl<F: Sync + Send + TryFrom<f32> + 'static> $struct_name<F> where
+            <F as TryFrom<f32>>::Error: std::fmt::Debug,
+        {
+            pub fn arc_new() -> std::sync::Arc<dyn AnalysisPlayerFeatureAdder<F> + Send + Sync + 'static> {
+                std::sync::Arc::new(Self::new())
+            }
+        }
+
+        analysis_player_feature_adder!(
+            $struct_name,
+            $dependency_getter,
+            $prop_getter,
+            $( $column_names ),*
+        );
+    }
+}
+
+/// Implements the ndarray traits for an existing analysis-backed per-player feature type.
+#[macro_export]
+macro_rules! analysis_player_feature_adder {
+    ($struct_name:ident, $dependency_getter:expr, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+        macro_rules! _analysis_player_feature_adder {
+            ($count:ident) => {
+                impl<F: TryFrom<f32>> LengthCheckedAnalysisPlayerFeatureAdder<F, $count> for $struct_name<F>
+                where
+                    <F as TryFrom<f32>>::Error: std::fmt::Debug,
+                {
+                    fn get_column_headers_array(&self) -> &[&str; $count] {
+                        &[$( $column_names ),*]
+                    }
+
+                    fn analysis_dependencies(&self) -> Vec<AnalysisDependency> {
+                        $dependency_getter(self)
+                    }
+
+                    fn get_features(
+                        &self,
+                        context: &AnalysisFeatureContext<'_>,
+                        player_id: &PlayerId,
+                        processor: &dyn ProcessorView,
+                        frame: &boxcars::Frame,
+                        frame_count: usize,
+                        current_time: f32,
+                    ) -> SubtrActorResult<[F; $count]> {
+                        $prop_getter(self, context, player_id, processor, frame, frame_count, current_time)
+                    }
+                }
+
+                impl_analysis_player_feature_adder!($struct_name);
+            };
+        }
+        paste::paste! {
+            const [<$struct_name:snake:upper _LENGTH>]: usize = [$($column_names),*].len();
+            _analysis_player_feature_adder!([<$struct_name:snake:upper _LENGTH>]);
         }
     }
 }

--- a/src/stats/analysis_graph/graph.rs
+++ b/src/stats/analysis_graph/graph.rs
@@ -269,6 +269,39 @@ impl AnalysisGraph {
         self.resolved = false;
     }
 
+    pub fn ensure_dependency(&mut self, dependency: AnalysisDependency) -> SubtrActorResult<()> {
+        let providers = self.provider_index_by_type()?;
+        if providers.contains_key(&dependency.state_type_id())
+            || self
+                .declared_root_states
+                .contains_key(&dependency.state_type_id())
+            || self
+                .declared_input_states
+                .contains_key(&dependency.state_type_id())
+        {
+            return Ok(());
+        }
+        if dependency.is_external() {
+            return Err(analysis_node_graph_error(format!(
+                "Required state {} has no provider",
+                dependency.state_type_name(),
+            )));
+        }
+
+        self.push_boxed_node((dependency.default_factory())());
+        Ok(())
+    }
+
+    pub fn ensure_dependencies<I>(&mut self, dependencies: I) -> SubtrActorResult<()>
+    where
+        I: IntoIterator<Item = AnalysisDependency>,
+    {
+        for dependency in dependencies {
+            self.ensure_dependency(dependency)?;
+        }
+        Ok(())
+    }
+
     pub fn resolve(&mut self) -> SubtrActorResult<()> {
         if self.resolved {
             return Ok(());

--- a/src/stats/analysis_graph/mod.rs
+++ b/src/stats/analysis_graph/mod.rs
@@ -20,7 +20,6 @@ mod collector;
 mod nodes;
 
 use crate::stats::calculators::FrameInput;
-
 #[allow(unused_imports)]
 pub use collector::AnalysisNodeCollector;
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary
- Adds optional analysis graph hooks to ndarray global and per-player feature adders.
- Lets `NDArrayCollector` build and evaluate one shared analysis graph from the union of feature-adder dependencies.
- Reuses analysis frame input bookkeeping between the analysis collector and ndarray runtime.
- Adds a regression test proving two ndarray adders share one graph evaluation per emitted row.

## Validation
- `cargo test analysis_feature_adders_share_one_graph_evaluation_per_ndarray_row`
- `cargo test --lib`
- `cargo test` currently hits a pre-existing `tests/stats_frame_resolution_test.rs` failure: `events.boost_pickups.len: left=0, right=557`; reproduced on clean `origin/master`.
