### PR TITLE
[codex] Add shareable stats player URL config

### DIFF
--- a/js/stat-evaluation-player/src/boostPickupFilters.test.ts
+++ b/js/stat-evaluation-player/src/boostPickupFilters.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBoostPickupFilterController } from "./boostPickupFilters.ts";
+
+const STATS_TIMELINE = {
+  events: {
+    boost_pickups: [],
+  },
+};
+
+function replay(id: string) {
+  return {
+    frameCount: 0,
+    duration: 0,
+    frames: [],
+    ballFrames: [],
+    boostPads: [],
+    players: [{ id, name: id, isTeamZero: true }],
+    timelineEvents: [],
+    teamZeroNames: [],
+    teamOneNames: [],
+  };
+}
+
+test("boost pickup player filters restored from config survive initial replay setup", () => {
+  const controller = createBoostPickupFilterController();
+  controller.applyConfig({
+    playerIds: ["Steam:player-1"],
+    padTypes: ["big"],
+    comparisons: ["both"],
+    activities: ["active"],
+    fieldHalves: ["own"],
+  });
+
+  controller.setup({
+    replay: replay("Steam:player-1") as never,
+    statsTimeline: STATS_TIMELINE as never,
+  });
+
+  assert.deepEqual(controller.getConfig().playerIds, ["Steam:player-1"]);
+  assert.deepEqual(
+    [...(controller.getTimelineRangeOptions().playerIds ?? [])],
+    ["Steam:player-1"],
+  );
+});
+
+test("boost pickup player filters still reset across later replay changes", () => {
+  const controller = createBoostPickupFilterController();
+  controller.setup({
+    replay: replay("Steam:first") as never,
+    statsTimeline: STATS_TIMELINE as never,
+  });
+  controller.applyConfig({
+    playerIds: ["Steam:first"],
+    padTypes: ["big"],
+    comparisons: ["both"],
+    activities: ["active"],
+    fieldHalves: ["own"],
+  });
+
+  controller.setup({
+    replay: replay("Steam:second") as never,
+    statsTimeline: STATS_TIMELINE as never,
+  });
+
+  assert.equal(controller.getConfig().playerIds, null);
+  assert.equal(controller.getTimelineRangeOptions().playerIds, undefined);
+});

--- a/js/stat-evaluation-player/src/boostPickupFilters.ts
+++ b/js/stat-evaluation-player/src/boostPickupFilters.ts
@@ -23,6 +23,7 @@ interface BoostPickupFilterContext {
 interface BoostPickupFilterRuntime {
   refreshTimelineRanges?(): void;
   rerenderCurrentState?(): void;
+  requestConfigSync?(): void;
 }
 
 interface BoostPickupFilterRenderOptions {
@@ -32,12 +33,22 @@ interface BoostPickupFilterRenderOptions {
 export interface BoostPickupFilterController {
   setup(ctx: BoostPickupFilterContext): void;
   teardown(): void;
+  getConfig(): BoostPickupFilterConfig;
+  applyConfig(config: unknown): void;
   getTimelineRangeOptions(): BoostPickupTimelineRangeOptions;
   includePickup(pickup: BoostPickupAnimationPickup): boolean;
   renderSettings(
     ctx: BoostPickupFilterContext | null,
     options: BoostPickupFilterRenderOptions,
   ): HTMLElement;
+}
+
+export interface BoostPickupFilterConfig {
+  readonly padTypes: BoostPickupPadType[];
+  readonly comparisons: BoostPickupComparison[];
+  readonly activities: BoostPickupActivity[];
+  readonly fieldHalves: BoostPickupFieldHalf[];
+  readonly playerIds: string[] | null;
 }
 
 const BOOST_PICKUP_PAD_TYPE_OPTIONS = [
@@ -126,6 +137,7 @@ export function createBoostPickupFilterController(
     BOOST_PICKUP_FIELD_HALF_OPTIONS.map((option) => option.value),
   );
   let activePlayerIds: Set<string> | null = null;
+  let preserveConfiguredPlayerIdsForNextReplay = false;
 
   function createFilterGroup<T extends string>(
     title: string,
@@ -160,6 +172,7 @@ export function createBoostPickupFilterController(
         syncSettingsUi(lastReplay);
         runtime.refreshTimelineRanges?.();
         runtime.rerenderCurrentState?.();
+        runtime.requestConfigSync?.();
       });
 
       const optionText = document.createElement("span");
@@ -220,6 +233,7 @@ export function createBoostPickupFilterController(
         syncSettingsUi(replay);
         runtime.refreshTimelineRanges?.();
         runtime.rerenderCurrentState?.();
+        runtime.requestConfigSync?.();
       });
 
       const optionText = document.createElement("span");
@@ -327,17 +341,84 @@ export function createBoostPickupFilterController(
       activeFieldHalves.has(matchedEvent.field_half);
   }
 
+  function setActiveValues<T extends string>(
+    activeValues: Set<T>,
+    options: Array<BoostPickupFilterOption<T>>,
+    values: unknown,
+  ): void {
+    activeValues.clear();
+    if (!Array.isArray(values)) {
+      for (const option of options) {
+        activeValues.add(option.value);
+      }
+      return;
+    }
+
+    const allowed = new Set(options.map((option) => option.value));
+    for (const value of values) {
+      if (typeof value === "string" && allowed.has(value as T)) {
+        activeValues.add(value as T);
+      }
+    }
+  }
+
+  function getConfig(): BoostPickupFilterConfig {
+    return {
+      padTypes: [...activePadTypes],
+      comparisons: [...activeComparisons],
+      activities: [...activeActivities],
+      fieldHalves: [...activeFieldHalves],
+      playerIds: activePlayerIds ? [...activePlayerIds] : null,
+    };
+  }
+
+  function applyConfig(config: unknown): void {
+    if (!config || typeof config !== "object" || Array.isArray(config)) {
+      return;
+    }
+    const record = config as Record<string, unknown>;
+    setActiveValues(activePadTypes, BOOST_PICKUP_PAD_TYPE_OPTIONS, record.padTypes);
+    setActiveValues(
+      activeComparisons,
+      BOOST_PICKUP_COMPARISON_OPTIONS,
+      record.comparisons,
+    );
+    setActiveValues(activeActivities, BOOST_PICKUP_ACTIVITY_OPTIONS, record.activities);
+    setActiveValues(
+      activeFieldHalves,
+      BOOST_PICKUP_FIELD_HALF_OPTIONS,
+      record.fieldHalves,
+    );
+    activePlayerIds = Array.isArray(record.playerIds)
+      ? new Set(record.playerIds.filter((id): id is string => typeof id === "string"))
+      : null;
+    preserveConfiguredPlayerIdsForNextReplay = lastReplay === null &&
+      activePlayerIds !== null;
+    syncSettingsUi(lastReplay);
+    runtime.refreshTimelineRanges?.();
+    runtime.rerenderCurrentState?.();
+    runtime.requestConfigSync?.();
+  }
+
   return {
     setup(ctx) {
       if (lastReplay !== ctx.replay) {
         lastReplay = ctx.replay;
-        activePlayerIds = null;
+        if (preserveConfiguredPlayerIdsForNextReplay) {
+          preserveConfiguredPlayerIdsForNextReplay = false;
+        } else {
+          activePlayerIds = null;
+        }
       }
       lastStatsTimeline = ctx.statsTimeline;
       syncSettingsUi(ctx.replay);
     },
 
     teardown() {},
+
+    getConfig,
+
+    applyConfig,
 
     getTimelineRangeOptions() {
       const options: BoostPickupTimelineRangeOptions = {

--- a/js/stat-evaluation-player/src/configAdapters.test.ts
+++ b/js/stat-evaluation-player/src/configAdapters.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyConfigAdapterSnapshot,
+  getConfigAdapterSnapshot,
+  type StatsPlayerConfigAdapter,
+} from "./configAdapters.ts";
+
+test("config adapter snapshots use canonical ids", () => {
+  const adapters: StatsPlayerConfigAdapter[] = [
+    {
+      id: "touch",
+      getConfig() {
+        return { decaySeconds: 7 };
+      },
+    },
+    {
+      id: "boost",
+      aliases: ["boost-pickup-animation"],
+      getConfig() {
+        return { padTypes: ["big"] };
+      },
+    },
+  ];
+
+  assert.deepEqual(getConfigAdapterSnapshot(adapters), {
+    touch: { decaySeconds: 7 },
+    boost: { padTypes: ["big"] },
+  });
+});
+
+test("config adapter apply accepts aliases for migrated config keys", () => {
+  let applied: unknown = null;
+  applyConfigAdapterSnapshot(
+    [
+      {
+        id: "boost",
+        aliases: ["boost-pickup-animation"],
+        applyConfig(config) {
+          applied = config;
+        },
+      },
+    ],
+    {
+      "boost-pickup-animation": { comparisons: ["missed"] },
+    },
+  );
+
+  assert.deepEqual(applied, { comparisons: ["missed"] });
+});
+
+test("config adapter canonical config wins over aliases", () => {
+  let applied: unknown = null;
+  applyConfigAdapterSnapshot(
+    [
+      {
+        id: "boost",
+        aliases: ["boost-pickup-animation"],
+        applyConfig(config) {
+          applied = config;
+        },
+      },
+    ],
+    {
+      boost: { comparisons: ["both"] },
+      "boost-pickup-animation": { comparisons: ["missed"] },
+    },
+  );
+
+  assert.deepEqual(applied, { comparisons: ["both"] });
+});
+
+test("config adapter snapshots reject duplicate canonical ids", () => {
+  assert.throws(
+    () =>
+      getConfigAdapterSnapshot([
+        { id: "touch", getConfig: () => ({}) },
+        { id: "touch", getConfig: () => ({}) },
+      ]),
+    /Duplicate stats player config adapter id: touch/,
+  );
+});

--- a/js/stat-evaluation-player/src/configAdapters.ts
+++ b/js/stat-evaluation-player/src/configAdapters.ts
@@ -1,0 +1,45 @@
+export interface StatsPlayerConfigAdapter {
+  id: string;
+  aliases?: readonly string[];
+  getConfig?(): unknown;
+  applyConfig?(config: unknown): void;
+}
+
+export function getConfigAdapterSnapshot(
+  adapters: readonly StatsPlayerConfigAdapter[],
+): Record<string, unknown> {
+  const snapshot: Record<string, unknown> = {};
+  for (const adapter of adapters) {
+    if (!adapter.getConfig) {
+      continue;
+    }
+    if (Object.hasOwn(snapshot, adapter.id)) {
+      throw new Error(`Duplicate stats player config adapter id: ${adapter.id}`);
+    }
+    snapshot[adapter.id] = adapter.getConfig();
+  }
+  return snapshot;
+}
+
+export function applyConfigAdapterSnapshot(
+  adapters: readonly StatsPlayerConfigAdapter[],
+  snapshot: Record<string, unknown>,
+): void {
+  for (const adapter of adapters) {
+    if (!adapter.applyConfig) {
+      continue;
+    }
+
+    if (Object.hasOwn(snapshot, adapter.id)) {
+      adapter.applyConfig(snapshot[adapter.id]);
+      continue;
+    }
+
+    for (const alias of adapter.aliases ?? []) {
+      if (Object.hasOwn(snapshot, alias)) {
+        adapter.applyConfig(snapshot[alias]);
+        break;
+      }
+    }
+  }
+}

--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -13,6 +13,7 @@ import type {
   CanvasRecorderStatus,
   CameraSettings,
   ReplayCameraViewMode,
+  ReplayFreeCameraPreset,
   ReplayPlayerState,
   ReplayPlayerTrack,
   TimelineOverlayPlugin,
@@ -31,6 +32,11 @@ import {
   createStatsFrameLookup,
   getStatsFrameForReplayFrame,
 } from "./statsTimeline.ts";
+import {
+  applyConfigAdapterSnapshot,
+  getConfigAdapterSnapshot,
+  type StatsPlayerConfigAdapter,
+} from "./configAdapters.ts";
 import type {
   PlayerStatsSnapshot,
   StatsFrame,
@@ -55,6 +61,23 @@ import {
   getReplayFileNameFromUrl,
   getReplayUrlFromSearch,
 } from "./replayUrl.ts";
+import {
+  getStatsPlayerConfigFromLocation,
+  mapWindowPlacementToViewport,
+  setStatsPlayerConfigOnUrl,
+  STATS_PLAYER_CONFIG_VERSION,
+  type ConfigViewportSize,
+  type PlayerCameraConfig,
+  type PlayerPlaybackConfig,
+  type RecordingConfig,
+  type SingletonWindowConfig,
+  type SingletonWindowId,
+  type StatsPlayerConfig,
+  type StatsWindowConfig,
+  type StatsWindowKind,
+  type TeamScope,
+  type WindowPlacementConfig,
+} from "./playerConfig.ts";
 import { playerIdToString } from "./touchOverlay.ts";
 
 const DEFAULT_CAMERA_DISTANCE_SCALE = 2.25;
@@ -87,6 +110,9 @@ const boostPickupFilters = createBoostPickupFilterController({
       replayPlayer.getState().boostPickupAnimationEnabled,
     );
   },
+  requestConfigSync() {
+    scheduleConfigUrlUpdate();
+  },
 });
 
 const MODULES = createStatModules({
@@ -100,6 +126,9 @@ const MODULES = createStatModules({
   },
   refreshTimelineRanges() {
     syncTimelineRanges();
+  },
+  requestConfigSync() {
+    scheduleConfigUrlUpdate();
   },
 }, {
   boostPickupFilters,
@@ -198,6 +227,10 @@ let nextWindowZIndex = 30;
 let nextStatsWindowId = 1;
 let boostPadOverlayEnabled = true;
 let loadedReplayName: string | null = null;
+let lastFreeCameraPreset: ReplayFreeCameraPreset | null = null;
+let initialUrlConfig: StatsPlayerConfig | null = null;
+let isApplyingConfig = false;
+let configUrlUpdateTimer: number | null = null;
 
 interface ReplayInputSource {
   name: string;
@@ -205,10 +238,13 @@ interface ReplayInputSource {
   readBytes(): Promise<Uint8Array>;
 }
 
-type SingletonWindowId = "camera" | "playback" | "recording" | "boost-pickups";
-type StatsWindowKind = "player" | "team" | "all-players" | "all-teams" | "ad-hoc";
-type TeamScope = "blue" | "orange";
 type ModuleCapabilityKind = "events" | "ranges" | "effects";
+const SINGLETON_WINDOW_IDS: SingletonWindowId[] = [
+  "camera",
+  "playback",
+  "recording",
+  "boost-pickups",
+];
 
 interface SelectedStatEntry {
   key: string;
@@ -331,6 +367,7 @@ function toggleCapability(
     renderStatsWindows(state.frameIndex);
   }
   renderTimelineEventCount();
+  scheduleConfigUrlUpdate();
 }
 
 function clearTimelineEventSources(): void {
@@ -372,6 +409,7 @@ function toggleBoostPadOverlay(): void {
   boostPadOverlayEnabled = !boostPadOverlayEnabled;
   syncBoostPadOverlayPlugin();
   renderModuleSummary();
+  scheduleConfigUrlUpdate();
 }
 
 function syncTimelineEvents(): void {
@@ -449,6 +487,253 @@ function getElementWindowId(element: HTMLElement): string | null {
     null;
 }
 
+function getCurrentViewportSize(): ConfigViewportSize {
+  return {
+    width: Math.max(1, window.innerWidth),
+    height: Math.max(1, window.innerHeight),
+  };
+}
+
+function readWindowCoordinate(windowEl: HTMLElement, propertyName: string): number {
+  const inlineValue = windowEl.style.getPropertyValue(propertyName).trim();
+  const computedValue = getComputedStyle(windowEl).getPropertyValue(propertyName).trim();
+  const rawValue = inlineValue || computedValue;
+  const parsed = Number.parseFloat(rawValue);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+
+  const rect = windowEl.getBoundingClientRect();
+  return propertyName === "--window-y" ? rect.top : rect.left;
+}
+
+function readWindowPlacement(windowEl: HTMLElement): WindowPlacementConfig {
+  const zIndex = Number.parseInt(windowEl.style.zIndex, 10);
+  return {
+    x: readWindowCoordinate(windowEl, "--window-x"),
+    y: readWindowCoordinate(windowEl, "--window-y"),
+    viewport: getCurrentViewportSize(),
+    zIndex: Number.isFinite(zIndex) ? zIndex : undefined,
+    visible: !windowEl.hidden,
+  };
+}
+
+function applyWindowPlacement(
+  windowEl: HTMLElement,
+  placement: WindowPlacementConfig,
+): void {
+  const mapped = mapWindowPlacementToViewport(
+    placement,
+    getCurrentViewportSize(),
+  );
+  windowEl.style.setProperty("--window-x", `${mapped.x}px`);
+  windowEl.style.setProperty("--window-y", `${mapped.y}px`);
+  windowEl.hidden = !placement.visible;
+  if (placement.zIndex !== undefined) {
+    windowEl.style.zIndex = `${placement.zIndex}`;
+    nextWindowZIndex = Math.max(nextWindowZIndex, placement.zIndex + 1);
+  }
+}
+
+function getSingletonWindowConfigs(): SingletonWindowConfig[] {
+  const configs: SingletonWindowConfig[] = [];
+  const root = appRoot ?? document;
+  for (const id of SINGLETON_WINDOW_IDS) {
+    const element = root.querySelector<HTMLElement>(`[data-window-id="${id}"]`);
+    if (element) {
+      configs.push({
+        id,
+        placement: readWindowPlacement(element),
+      });
+    }
+  }
+  return configs;
+}
+
+function getConfigAdapters(): StatsPlayerConfigAdapter[] {
+  return MODULES
+    .filter((mod) => mod.getConfig || mod.applyConfig)
+    .map((mod) => {
+      const adapter: StatsPlayerConfigAdapter = {
+        id: mod.id,
+      };
+      if (mod.id === "boost") {
+        adapter.aliases = ["boost-pickup-animation"];
+      }
+      if (mod.getConfig) {
+        adapter.getConfig = () => mod.getConfig?.();
+      }
+      if (mod.applyConfig) {
+        adapter.applyConfig = (config: unknown) => mod.applyConfig?.(config);
+      }
+      return adapter;
+    });
+}
+
+function getModuleConfigSnapshot(): Record<string, unknown> {
+  return getConfigAdapterSnapshot(getConfigAdapters());
+}
+
+function applyModuleConfigSnapshot(configs: Record<string, unknown>): void {
+  applyConfigAdapterSnapshot(getConfigAdapters(), configs);
+}
+
+function getStatsWindowConfig(statsWindow: StatsWindowState): StatsWindowConfig {
+  return {
+    id: statsWindow.id,
+    kind: statsWindow.kind,
+    placement: readWindowPlacement(statsWindow.element),
+    playerId: statsWindow.playerId,
+    team: statsWindow.team,
+    entries: statsWindow.entries.map((entry) => ({
+      statId: entry.statId,
+      targetId: entry.targetId,
+    })),
+  };
+}
+
+function getPlaybackConfigSnapshot(): PlayerPlaybackConfig {
+  const state = replayPlayer?.getState();
+  return {
+    currentTime: state?.currentTime,
+    rate: state?.speed ?? Number(playbackRate?.value ?? 1),
+    skipPostGoalTransitions: replayPlayer
+      ? state?.skipPostGoalTransitionsEnabled
+      : skipPostGoalTransitions.checked,
+    skipKickoffs: replayPlayer ? state?.skipKickoffsEnabled : skipKickoffs.checked,
+  };
+}
+
+function getCameraConfigSnapshot(): PlayerCameraConfig {
+  const state = replayPlayer?.getState();
+  return {
+    mode: state?.cameraViewMode,
+    freePreset: lastFreeCameraPreset,
+    attachedPlayerId: state?.attachedPlayerId,
+    distanceScale: state?.cameraDistanceScale,
+    ballCam: state?.ballCamEnabled,
+    customSettings: state?.customCameraSettings,
+  };
+}
+
+function getRecordingConfigSnapshot(): RecordingConfig {
+  return {
+    fps: Number(recordingFps?.value),
+    playbackRate: Number(recordingPlaybackRate?.value),
+  };
+}
+
+function getStatsPlayerConfigSnapshot(): StatsPlayerConfig {
+  return {
+    version: STATS_PLAYER_CONFIG_VERSION,
+    playback: getPlaybackConfigSnapshot(),
+    camera: getCameraConfigSnapshot(),
+    overlays: {
+      timelineEvents: [...activeTimelineEventModuleIds],
+      timelineRanges: [...activeTimelineRangeModuleIds],
+      renderEffects: [...activeRenderEffectModuleIds],
+      followedPlayerHud: false,
+      boostPads: boostPadOverlayEnabled,
+      boostPickupAnimation: replayPlayer?.getState().boostPickupAnimationEnabled ?? false,
+    },
+    recording: getRecordingConfigSnapshot(),
+    singletonWindows: getSingletonWindowConfigs(),
+    statsWindows: [...statsWindows.values()].map(getStatsWindowConfig),
+    moduleConfigs: getModuleConfigSnapshot(),
+  };
+}
+
+function scheduleConfigUrlUpdate(): void {
+  if (isApplyingConfig) {
+    return;
+  }
+  if (configUrlUpdateTimer !== null) {
+    window.clearTimeout(configUrlUpdateTimer);
+  }
+  configUrlUpdateTimer = window.setTimeout(() => {
+    configUrlUpdateTimer = null;
+    const nextUrl = setStatsPlayerConfigOnUrl(
+      new URL(window.location.href),
+      getStatsPlayerConfigSnapshot(),
+    );
+    window.history.replaceState(window.history.state, "", nextUrl);
+  }, 150);
+}
+
+function applyConfigToExistingWindows(config: StatsPlayerConfig): void {
+  const root = appRoot ?? document;
+  for (const windowConfig of config.singletonWindows) {
+    const element = root.querySelector<HTMLElement>(
+      `[data-window-id="${windowConfig.id}"]`,
+    );
+    if (element) {
+      applyWindowPlacement(element, windowConfig.placement);
+    }
+  }
+}
+
+function applyConfigToStaticControls(config: StatsPlayerConfig): void {
+  activeTimelineEventModuleIds = new Set(config.overlays.timelineEvents);
+  activeTimelineRangeModuleIds = new Set(config.overlays.timelineRanges);
+  activeRenderEffectModuleIds = new Set(config.overlays.renderEffects);
+  boostPadOverlayEnabled = config.overlays.boostPads;
+  skipPostGoalTransitions.checked =
+    config.playback.skipPostGoalTransitions ?? skipPostGoalTransitions.checked;
+  skipKickoffs.checked = config.playback.skipKickoffs ?? skipKickoffs.checked;
+  if (config.playback.rate !== undefined) {
+    playbackRate.value = `${config.playback.rate}`;
+  }
+  if (config.recording.fps !== undefined) {
+    recordingFps.value = `${config.recording.fps}`;
+  }
+  if (config.recording.playbackRate !== undefined) {
+    recordingPlaybackRate.value = `${config.recording.playbackRate}`;
+  }
+  applyModuleConfigSnapshot(config.moduleConfigs);
+  applyConfigToExistingWindows(config);
+  replaceStatsWindowsFromConfig(config.statsWindows);
+  renderModuleSummary();
+  renderModuleSettings();
+  renderTimelineEventCount();
+}
+
+function getReplayPlayerStatePatchFromConfig(
+  playback: PlayerPlaybackConfig,
+  camera: PlayerCameraConfig,
+  config: StatsPlayerConfig,
+): Parameters<ReplayPlayer["setState"]>[0] {
+  return {
+    currentTime: playback.currentTime,
+    speed: playback.rate,
+    cameraDistanceScale: camera.distanceScale,
+    customCameraSettings: camera.customSettings,
+    cameraViewMode: camera.mode,
+    attachedPlayerId: camera.attachedPlayerId,
+    ballCamEnabled: camera.ballCam,
+    boostPickupAnimationEnabled: config.overlays.boostPickupAnimation,
+    skipPostGoalTransitionsEnabled: playback.skipPostGoalTransitions,
+    skipKickoffsEnabled: playback.skipKickoffs,
+  };
+}
+
+function applyConfigToReplayPlayer(config: StatsPlayerConfig): void {
+  if (!replayPlayer) {
+    return;
+  }
+  replayPlayer.setState(
+    getReplayPlayerStatePatchFromConfig(config.playback, config.camera, config),
+  );
+  lastFreeCameraPreset = config.camera.freePreset ?? null;
+  if (config.camera.mode === "free" && config.camera.freePreset) {
+    replayPlayer.setFreeCameraPreset(config.camera.freePreset);
+  }
+  syncBoostPadOverlayPlugin();
+  setupActiveModules();
+  renderModuleSummary();
+  renderModuleSettings();
+  renderStatsWindows(replayPlayer.getState().frameIndex);
+}
+
 function bringWindowToFront(windowEl: HTMLElement): void {
   windowEl.style.zIndex = `${nextWindowZIndex++}`;
 }
@@ -460,6 +745,7 @@ function showWindow(id: SingletonWindowId): void {
   );
   windowEl.hidden = false;
   bringWindowToFront(windowEl);
+  scheduleConfigUrlUpdate();
 }
 
 function toggleWindow(id: SingletonWindowId): void {
@@ -471,6 +757,7 @@ function toggleWindow(id: SingletonWindowId): void {
   if (!windowEl.hidden) {
     bringWindowToFront(windowEl);
   }
+  scheduleConfigUrlUpdate();
 }
 
 function hideWindow(id: string): void {
@@ -479,6 +766,7 @@ function hideWindow(id: string): void {
     `[data-window-id="${id}"]`,
   );
   windowEl.hidden = true;
+  scheduleConfigUrlUpdate();
 }
 
 function setLauncherOpen(open: boolean): void {
@@ -536,6 +824,7 @@ function installWindowDragging(root: HTMLElement, signal: AbortSignal): void {
       windowEl.removeEventListener("pointermove", onPointerMove);
       windowEl.removeEventListener("pointerup", onPointerUp);
       windowEl.removeEventListener("pointercancel", onPointerUp);
+      scheduleConfigUrlUpdate();
     };
 
     windowEl.addEventListener("pointermove", onPointerMove);
@@ -591,6 +880,7 @@ function renderModuleSummary(): void {
     setupActiveModules();
     renderModuleSummary();
     renderModuleSettings();
+    scheduleConfigUrlUpdate();
   });
   const boostName = document.createElement("span");
   boostName.textContent = "Boost pickup animation";
@@ -850,14 +1140,24 @@ function renderStatsWindows(
   }
 }
 
-function createStatsWindow(kind: StatsWindowKind): void {
-  const id = `stats-${nextStatsWindowId++}`;
+function createStatsWindow(
+  kind: StatsWindowKind,
+  config?: StatsWindowConfig,
+): StatsWindowState {
+  const id = config?.id ?? `stats-${nextStatsWindowId++}`;
+  const idNumber = Number.parseInt(id.replace(/^stats-/, ""), 10);
+  if (Number.isFinite(idNumber)) {
+    nextStatsWindowId = Math.max(nextStatsWindowId, idNumber + 1);
+  }
   const { x, y } = getStatsWindowDefaultPosition();
   const element = document.createElement("section");
   element.className = "stats-window";
   element.dataset.windowId = id;
   element.style.setProperty("--window-x", `${x}px`);
   element.style.setProperty("--window-y", `${y}px`);
+  if (config) {
+    applyWindowPlacement(element, config.placement);
+  }
 
   const header = document.createElement("header");
   header.className = "stats-window-header";
@@ -886,9 +1186,13 @@ function createStatsWindow(kind: StatsWindowKind): void {
   const state: StatsWindowState = {
     id,
     kind,
-    entries: [],
-    playerId: replayPlayer?.replay.players[0]?.id ?? null,
-    team: "blue",
+    entries: config?.entries.map((entry) => ({
+      key: `${id}:${entry.statId}:${entry.targetId ?? "scope"}`,
+      statId: entry.statId,
+      targetId: entry.targetId,
+    })) ?? [],
+    playerId: config?.playerId ?? replayPlayer?.replay.players[0]?.id ?? null,
+    team: config?.team ?? "blue",
     pickerOpen: false,
     query: "",
     element,
@@ -897,12 +1201,28 @@ function createStatsWindow(kind: StatsWindowKind): void {
 
   hideButton.addEventListener("click", () => {
     element.hidden = true;
+    scheduleConfigUrlUpdate();
   });
 
   statsWindows.set(id, state);
-  bringWindowToFront(element);
+  if (!config) {
+    bringWindowToFront(element);
+  }
   setLauncherOpen(false);
   renderStatsWindow(state);
+  scheduleConfigUrlUpdate();
+  return state;
+}
+
+function replaceStatsWindowsFromConfig(configs: readonly StatsWindowConfig[]): void {
+  for (const statsWindow of statsWindows.values()) {
+    statsWindow.element.remove();
+  }
+  statsWindows.clear();
+  nextStatsWindowId = 1;
+  for (const config of configs) {
+    createStatsWindow(config.kind, config);
+  }
 }
 
 function renderStatsWindow(
@@ -975,6 +1295,7 @@ function renderStatsWindowScope(statsWindow: StatsWindowState): void {
     select.addEventListener("change", () => {
       statsWindow.playerId = select.value || null;
       renderStatsWindow(statsWindow);
+      scheduleConfigUrlUpdate();
     });
   } else {
     select.append(
@@ -990,6 +1311,7 @@ function renderStatsWindowScope(statsWindow: StatsWindowState): void {
     select.addEventListener("change", () => {
       statsWindow.team = select.value === "orange" ? "orange" : "blue";
       renderStatsWindow(statsWindow);
+      scheduleConfigUrlUpdate();
     });
   }
 
@@ -1105,6 +1427,7 @@ function renderStatsWindowPickerList(
         addStatToWindow(statsWindow, definition);
       }
       renderStatsWindow(statsWindow);
+      scheduleConfigUrlUpdate();
     });
     list.append(addGroup);
   }
@@ -1119,6 +1442,7 @@ function renderStatsWindowPickerList(
     activateButton(item, () => {
       addStatToWindow(statsWindow, definition);
       renderStatsWindow(statsWindow);
+      scheduleConfigUrlUpdate();
     });
     list.append(item);
   }
@@ -1392,6 +1716,7 @@ function renderStatRow(
         };
       }
       renderStatsWindow(statsWindow);
+      scheduleConfigUrlUpdate();
     });
     name.append(" ", targetSelect);
   }
@@ -1405,6 +1730,7 @@ function renderStatRow(
   remove.addEventListener("click", () => {
     removeStatFromWindow(statsWindow, entry.key);
     renderStatsWindow(statsWindow);
+    scheduleConfigUrlUpdate();
   });
   row.append(name, valueEl, remove);
   return row;
@@ -1817,13 +2143,18 @@ async function loadReplay(source: ReplayInputSource): Promise<void> {
       onStatusChange: syncRecordingWindow,
     });
     canvasRecorder = recorder;
+    const config = initialUrlConfig;
 
     replayPlayer = new ReplayPlayer(viewport, replay, {
-      initialCameraDistanceScale: DEFAULT_CAMERA_DISTANCE_SCALE,
-      initialCustomCameraSettings: null,
-      initialAttachedPlayerId: null,
-      initialBallCamEnabled: false,
-      initialBoostPickupAnimationEnabled: false,
+      initialPlaybackRate: config?.playback.rate,
+      initialCameraDistanceScale:
+        config?.camera.distanceScale ?? DEFAULT_CAMERA_DISTANCE_SCALE,
+      initialCustomCameraSettings: config?.camera.customSettings ?? null,
+      initialAttachedPlayerId: config?.camera.attachedPlayerId ?? null,
+      initialCameraViewMode: config?.camera.mode,
+      initialBallCamEnabled: config?.camera.ballCam ?? false,
+      initialBoostPickupAnimationEnabled:
+        config?.overlays.boostPickupAnimation ?? false,
       initialSkipPostGoalTransitionsEnabled: skipPostGoalTransitions.checked,
       initialSkipKickoffsEnabled: skipKickoffs.checked,
       plugins: [
@@ -1839,6 +2170,14 @@ async function loadReplay(source: ReplayInputSource): Promise<void> {
 
     setupActiveModules();
     unsubscribe = replayPlayer.subscribe(renderSnapshot);
+    if (config) {
+      isApplyingConfig = true;
+      try {
+        applyConfigToReplayPlayer(config);
+      } finally {
+        isApplyingConfig = false;
+      }
+    }
 
     populateAttachedPlayerOptions(replay.players);
     emptyState.hidden = true;
@@ -2053,6 +2392,16 @@ export function mountStatEvaluationPlayer(
   recordingSize = mustElement<HTMLElement>(root, "#recording-size");
   recordingType = mustElement<HTMLElement>(root, "#recording-type");
 
+  try {
+    initialUrlConfig = getStatsPlayerConfigFromLocation(window.location);
+  } catch (error) {
+    console.error("Invalid stats player config:", error);
+    statusReadout.textContent = error instanceof Error
+      ? error.message
+      : "Invalid stats player config";
+    initialUrlConfig = null;
+  }
+
   const listeners = new AbortController();
   installWindowDragging(floatingWindowLayer, listeners.signal);
   installWindowDragging(statsWindowLayer, listeners.signal);
@@ -2081,6 +2430,13 @@ export function mountStatEvaluationPlayer(
     activeRenderEffectModuleIds = new Set<string>();
     boostPadOverlayEnabled = true;
     loadedReplayName = null;
+    lastFreeCameraPreset = null;
+    initialUrlConfig = null;
+    if (configUrlUpdateTimer !== null) {
+      window.clearTimeout(configUrlUpdateTimer);
+      configUrlUpdateTimer = null;
+    }
+    isApplyingConfig = false;
     nextStatsWindowId = 1;
     nextWindowZIndex = 30;
     removeRenderHook = null;
@@ -2093,6 +2449,15 @@ export function mountStatEvaluationPlayer(
     }
   };
   currentMountCleanup = cleanup;
+
+  if (initialUrlConfig) {
+    isApplyingConfig = true;
+    try {
+      applyConfigToStaticControls(initialUrlConfig);
+    } finally {
+      isApplyingConfig = false;
+    }
+  }
 
   launcherToggle.addEventListener("click", () => {
     setLauncherOpen(launcherMenu.hidden);
@@ -2154,10 +2519,12 @@ export function mountStatEvaluationPlayer(
 
   togglePlayback.addEventListener("click", () => {
     replayPlayer?.togglePlayback();
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   playbackRate.addEventListener("change", () => {
     replayPlayer?.setPlaybackRate(Number(playbackRate.value));
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   recordingStart.addEventListener("click", () => {
@@ -2222,8 +2589,16 @@ export function mountStatEvaluationPlayer(
     }
   }, { signal: listeners.signal });
 
+  recordingFps.addEventListener("change", scheduleConfigUrlUpdate, {
+    signal: listeners.signal,
+  });
+  recordingPlaybackRate.addEventListener("change", scheduleConfigUrlUpdate, {
+    signal: listeners.signal,
+  });
+
   cameraDistance.addEventListener("input", () => {
     replayPlayer?.setCameraDistanceScale(Number(cameraDistance.value));
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   customCameraSettings.addEventListener("change", () => {
@@ -2231,6 +2606,7 @@ export function mountStatEvaluationPlayer(
     replayPlayer?.setCustomCameraSettings(
       customCameraSettings.checked ? readCustomCameraSettings() : null,
     );
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   for (const input of [
@@ -2246,41 +2622,55 @@ export function mountStatEvaluationPlayer(
       const settings = readCustomCameraSettings();
       syncCustomCameraSettingControls(settings);
       replayPlayer?.setCustomCameraSettings(settings);
+      scheduleConfigUrlUpdate();
     }, { signal: listeners.signal });
   }
 
   attachedPlayer.addEventListener("change", () => {
     replayPlayer?.setAttachedPlayer(attachedPlayer.value || null);
+    lastFreeCameraPreset = null;
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   cameraViewFreeButton.addEventListener("click", () => {
     replayPlayer?.setCameraViewMode("free");
+    lastFreeCameraPreset = null;
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   cameraViewFollowButton.addEventListener("click", () => {
     replayPlayer?.setCameraViewMode("follow");
+    lastFreeCameraPreset = null;
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   cameraViewOverheadButton.addEventListener("click", () => {
     replayPlayer?.setFreeCameraPreset("overhead");
+    lastFreeCameraPreset = "overhead";
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   cameraViewSideButton.addEventListener("click", () => {
     replayPlayer?.setFreeCameraPreset("side");
+    lastFreeCameraPreset = "side";
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   ballCam.addEventListener("change", () => {
     replayPlayer?.setBallCamEnabled(ballCam.checked);
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   skipPostGoalTransitions.addEventListener("change", () => {
     replayPlayer?.setSkipPostGoalTransitionsEnabled(
       skipPostGoalTransitions.checked,
     );
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   skipKickoffs.addEventListener("change", () => {
     replayPlayer?.setSkipKickoffsEnabled(skipKickoffs.checked);
+    scheduleConfigUrlUpdate();
   }, { signal: listeners.signal });
 
   renderModuleSummary();

--- a/js/stat-evaluation-player/src/playerConfig.test.ts
+++ b/js/stat-evaluation-player/src/playerConfig.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  decodeStatsPlayerConfig,
+  encodeStatsPlayerConfig,
+  getStatsPlayerConfigFromLocation,
+  mapWindowPlacementToViewport,
+  setStatsPlayerConfigOnUrl,
+  type StatsPlayerConfig,
+} from "./playerConfig.ts";
+
+const CONFIG: StatsPlayerConfig = {
+  version: 1,
+  playback: {
+    currentTime: 42.5,
+    rate: 1.5,
+    skipPostGoalTransitions: true,
+    skipKickoffs: false,
+  },
+  camera: {
+    mode: "follow",
+    attachedPlayerId: "player-one",
+    distanceScale: 2.4,
+    ballCam: true,
+    customSettings: {
+      fov: 108,
+      height: 120,
+      pitch: -5,
+      distance: 280,
+      stiffness: 0.4,
+      swivelSpeed: 3.2,
+      transitionSpeed: 1.1,
+    },
+  },
+  overlays: {
+    timelineEvents: ["touch", "demo"],
+    timelineRanges: ["boost"],
+    renderEffects: ["touch"],
+    followedPlayerHud: true,
+    boostPads: false,
+    boostPickupAnimation: true,
+  },
+  recording: {
+    fps: 60,
+    playbackRate: 0.5,
+  },
+  singletonWindows: [
+    {
+      id: "camera",
+      placement: {
+        x: 16,
+        y: 64,
+        viewport: { width: 1920, height: 1080 },
+        zIndex: 31,
+        visible: true,
+      },
+    },
+  ],
+  statsWindows: [
+    {
+      id: "stats-1",
+      kind: "ad-hoc",
+      placement: {
+        x: 420,
+        y: 120,
+        viewport: { width: 1920, height: 1080 },
+        zIndex: 40,
+        visible: true,
+      },
+      playerId: null,
+      team: null,
+      entries: [
+        { statId: "player.core.score", targetId: "player-one" },
+        { statId: "team.core.goals", targetId: "blue" },
+      ],
+    },
+  ],
+  moduleConfigs: {
+    boost: {
+      padTypes: ["big"],
+      comparisons: ["both", "missed"],
+      activities: ["active"],
+      fieldHalves: ["opponent"],
+      playerIds: ["player-one"],
+    },
+    touch: {
+      decaySeconds: 7,
+      breakdownClasses: ["kind"],
+    },
+  },
+};
+
+test("stats player config round-trips through compressed url-safe encoding", () => {
+  const encoded = encodeStatsPlayerConfig(CONFIG);
+  assert.match(encoded, /^[A-Za-z0-9_-]+$/);
+  assert.deepEqual(decodeStatsPlayerConfig(encoded), CONFIG);
+});
+
+test("stats player config can live in the URL hash without disturbing query params", () => {
+  const url = setStatsPlayerConfigOnUrl(
+    new URL("https://viewer.example/app/?r=abc#tab=stats"),
+    CONFIG,
+  );
+  assert.equal(url.search, "?r=abc");
+
+  const decoded = getStatsPlayerConfigFromLocation({
+    search: url.search,
+    hash: url.hash,
+  } as Location);
+  assert.deepEqual(decoded, CONFIG);
+});
+
+test("stats player config also accepts cfg in search params", () => {
+  const encoded = encodeStatsPlayerConfig(CONFIG);
+  assert.deepEqual(
+    getStatsPlayerConfigFromLocation({
+      search: `?cfg=${encoded}`,
+      hash: "",
+    } as Location),
+    CONFIG,
+  );
+});
+
+test("window placement scales from the saved viewport to the current viewport", () => {
+  assert.deepEqual(
+    mapWindowPlacementToViewport(
+      {
+        x: 960,
+        y: 540,
+        viewport: { width: 1920, height: 1080 },
+        visible: true,
+      },
+      { width: 1280, height: 720 },
+    ),
+    { x: 640, y: 360 },
+  );
+});
+
+test("window placement is clamped to leave controls reachable", () => {
+  assert.deepEqual(
+    mapWindowPlacementToViewport(
+      {
+        x: 1800,
+        y: 1000,
+        viewport: { width: 1920, height: 1080 },
+        visible: true,
+      },
+      { width: 640, height: 360 },
+      200,
+      160,
+    ),
+    { x: 440, y: 200 },
+  );
+});

--- a/js/stat-evaluation-player/src/playerConfig.ts
+++ b/js/stat-evaluation-player/src/playerConfig.ts
@@ -1,0 +1,408 @@
+import { deflateSync, inflateSync, strFromU8, strToU8 } from "fflate";
+import type {
+  CameraSettings,
+  ReplayCameraViewMode,
+  ReplayFreeCameraPreset,
+} from "subtr-actor-player";
+
+export const STATS_PLAYER_CONFIG_VERSION = 1;
+
+export type StatsWindowKind =
+  | "player"
+  | "team"
+  | "all-players"
+  | "all-teams"
+  | "ad-hoc";
+
+export type TeamScope = "blue" | "orange";
+export type ModuleCapabilityKind = "events" | "ranges" | "effects";
+export type SingletonWindowId = "camera" | "playback" | "recording" | "boost-pickups";
+export type ConfigWindowKind = SingletonWindowId | "stats";
+
+export interface ConfigViewportSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface WindowPlacementConfig {
+  readonly x: number;
+  readonly y: number;
+  readonly viewport: ConfigViewportSize;
+  readonly zIndex?: number;
+  readonly visible: boolean;
+}
+
+export interface SelectedStatConfig {
+  readonly statId: string;
+  readonly targetId?: string;
+}
+
+export interface StatsWindowConfig {
+  readonly id: string;
+  readonly kind: StatsWindowKind;
+  readonly placement: WindowPlacementConfig;
+  readonly playerId: string | null;
+  readonly team: TeamScope | null;
+  readonly entries: SelectedStatConfig[];
+}
+
+export interface SingletonWindowConfig {
+  readonly id: SingletonWindowId;
+  readonly placement: WindowPlacementConfig;
+}
+
+export interface PlayerPlaybackConfig {
+  readonly currentTime?: number;
+  readonly rate?: number;
+  readonly skipPostGoalTransitions?: boolean;
+  readonly skipKickoffs?: boolean;
+}
+
+export interface PlayerCameraConfig {
+  readonly mode?: ReplayCameraViewMode;
+  readonly freePreset?: ReplayFreeCameraPreset | null;
+  readonly attachedPlayerId?: string | null;
+  readonly distanceScale?: number;
+  readonly ballCam?: boolean;
+  readonly customSettings?: CameraSettings | null;
+}
+
+export interface PlayerOverlayConfig {
+  readonly timelineEvents: string[];
+  readonly timelineRanges: string[];
+  readonly renderEffects: string[];
+  readonly followedPlayerHud: boolean;
+  readonly boostPads: boolean;
+  readonly boostPickupAnimation: boolean;
+}
+
+export interface RecordingConfig {
+  readonly fps?: number;
+  readonly playbackRate?: number;
+}
+
+export interface StatsPlayerConfigV1 {
+  readonly version: typeof STATS_PLAYER_CONFIG_VERSION;
+  readonly playback: PlayerPlaybackConfig;
+  readonly camera: PlayerCameraConfig;
+  readonly overlays: PlayerOverlayConfig;
+  readonly recording: RecordingConfig;
+  readonly singletonWindows: SingletonWindowConfig[];
+  readonly statsWindows: StatsWindowConfig[];
+  readonly moduleConfigs: Record<string, unknown>;
+}
+
+export type StatsPlayerConfig = StatsPlayerConfigV1;
+
+export const STATS_PLAYER_CONFIG_PARAM = "cfg";
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const normalized = value.replaceAll("-", "+").replaceAll("_", "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+export function encodeStatsPlayerConfig(config: StatsPlayerConfig): string {
+  return bytesToBase64Url(
+    deflateSync(strToU8(JSON.stringify(config)), { level: 9 }),
+  );
+}
+
+export function decodeStatsPlayerConfig(value: string): StatsPlayerConfig {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(strFromU8(inflateSync(base64UrlToBytes(value))));
+  } catch (error) {
+    throw new Error(
+      `Invalid stats player config: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  return normalizeStatsPlayerConfig(parsed);
+}
+
+export function getStatsPlayerConfigFromLocation(
+  location: Pick<Location, "search" | "hash">,
+): StatsPlayerConfig | null {
+  const hashParams = new URLSearchParams(
+    location.hash.startsWith("#") ? location.hash.slice(1) : location.hash,
+  );
+  const searchParams = new URLSearchParams(location.search);
+  const rawValue = hashParams.get(STATS_PLAYER_CONFIG_PARAM) ??
+    searchParams.get(STATS_PLAYER_CONFIG_PARAM);
+  return rawValue ? decodeStatsPlayerConfig(rawValue) : null;
+}
+
+export function setStatsPlayerConfigOnUrl(
+  url: URL,
+  config: StatsPlayerConfig,
+): URL {
+  const next = new URL(url.href);
+  const hashParams = new URLSearchParams(
+    next.hash.startsWith("#") ? next.hash.slice(1) : next.hash,
+  );
+  hashParams.set(STATS_PLAYER_CONFIG_PARAM, encodeStatsPlayerConfig(config));
+  next.hash = hashParams.toString();
+  return next;
+}
+
+export function mapWindowPlacementToViewport(
+  placement: WindowPlacementConfig,
+  viewport: ConfigViewportSize,
+  minimumVisibleWidth = 120,
+  minimumVisibleHeight = 100,
+): { x: number; y: number } {
+  const sourceWidth = finitePositive(placement.viewport.width) ?? viewport.width;
+  const sourceHeight = finitePositive(placement.viewport.height) ?? viewport.height;
+  const scaleX = viewport.width / Math.max(1, sourceWidth);
+  const scaleY = viewport.height / Math.max(1, sourceHeight);
+  const maxX = Math.max(8, viewport.width - minimumVisibleWidth);
+  const maxY = Math.max(8, viewport.height - minimumVisibleHeight);
+
+  return {
+    x: clamp(placement.x * scaleX, 8, maxX),
+    y: clamp(placement.y * scaleY, 8, maxY),
+  };
+}
+
+export function normalizeStatsPlayerConfig(value: unknown): StatsPlayerConfig {
+  if (!isRecord(value) || value.version !== STATS_PLAYER_CONFIG_VERSION) {
+    throw new Error("Unsupported stats player config version");
+  }
+
+  return {
+    version: STATS_PLAYER_CONFIG_VERSION,
+    playback: normalizePlaybackConfig(value.playback),
+    camera: normalizeCameraConfig(value.camera),
+    overlays: normalizeOverlayConfig(value.overlays),
+    recording: normalizeRecordingConfig(value.recording),
+    singletonWindows: normalizeSingletonWindows(value.singletonWindows),
+    statsWindows: normalizeStatsWindows(value.statsWindows),
+    moduleConfigs: isRecord(value.moduleConfigs) ? value.moduleConfigs : {},
+  };
+}
+
+function normalizeRecordingConfig(value: unknown): RecordingConfig {
+  if (!isRecord(value)) {
+    return {};
+  }
+  return {
+    fps: finiteNumber(value.fps),
+    playbackRate: finiteNumber(value.playbackRate),
+  };
+}
+
+function normalizePlaybackConfig(value: unknown): PlayerPlaybackConfig {
+  if (!isRecord(value)) {
+    return {};
+  }
+  return {
+    currentTime: finiteNumber(value.currentTime),
+    rate: finiteNumber(value.rate),
+    skipPostGoalTransitions: booleanValue(value.skipPostGoalTransitions),
+    skipKickoffs: booleanValue(value.skipKickoffs),
+  };
+}
+
+function normalizeCameraConfig(value: unknown): PlayerCameraConfig {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const config: {
+    -readonly [K in keyof PlayerCameraConfig]?: PlayerCameraConfig[K];
+  } = {};
+  const mode = value.mode === "follow"
+    ? "follow"
+    : value.mode === "free"
+      ? "free"
+      : undefined;
+  const freePreset = value.freePreset === "overhead"
+    ? "overhead"
+    : value.freePreset === "side"
+      ? "side"
+      : value.freePreset === null
+        ? null
+        : undefined;
+  const attachedPlayerId = stringOrNull(value.attachedPlayerId);
+  const distanceScale = finiteNumber(value.distanceScale);
+  const ballCam = booleanValue(value.ballCam);
+  const customSettings = normalizeCameraSettings(value.customSettings);
+  if (mode !== undefined) config.mode = mode;
+  if (freePreset !== undefined) config.freePreset = freePreset;
+  if (attachedPlayerId !== undefined) config.attachedPlayerId = attachedPlayerId;
+  if (distanceScale !== undefined) config.distanceScale = distanceScale;
+  if (ballCam !== undefined) config.ballCam = ballCam;
+  if (customSettings !== undefined) config.customSettings = customSettings;
+  return config;
+}
+
+function normalizeCameraSettings(value: unknown): CameraSettings | null | undefined {
+  if (value === null) {
+    return null;
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const settings: CameraSettings = {};
+  const fov = finiteNumber(value.fov);
+  const height = finiteNumber(value.height);
+  const pitch = finiteNumber(value.pitch);
+  const distance = finiteNumber(value.distance);
+  const stiffness = finiteNumber(value.stiffness);
+  const swivelSpeed = finiteNumber(value.swivelSpeed);
+  const transitionSpeed = finiteNumber(value.transitionSpeed);
+  if (fov !== undefined) settings.fov = fov;
+  if (height !== undefined) settings.height = height;
+  if (pitch !== undefined) settings.pitch = pitch;
+  if (distance !== undefined) settings.distance = distance;
+  if (stiffness !== undefined) settings.stiffness = stiffness;
+  if (swivelSpeed !== undefined) settings.swivelSpeed = swivelSpeed;
+  if (transitionSpeed !== undefined) settings.transitionSpeed = transitionSpeed;
+  return settings;
+}
+
+function normalizeOverlayConfig(value: unknown): PlayerOverlayConfig {
+  const record = isRecord(value) ? value : {};
+  return {
+    timelineEvents: stringArray(record.timelineEvents),
+    timelineRanges: stringArray(record.timelineRanges),
+    renderEffects: stringArray(record.renderEffects),
+    followedPlayerHud: booleanValue(record.followedPlayerHud) ?? false,
+    boostPads: booleanValue(record.boostPads) ?? true,
+    boostPickupAnimation: booleanValue(record.boostPickupAnimation) ?? false,
+  };
+}
+
+function normalizeSingletonWindows(value: unknown): SingletonWindowConfig[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item): SingletonWindowConfig | null => {
+      if (!isRecord(item) || !isSingletonWindowId(item.id)) {
+        return null;
+      }
+      return {
+        id: item.id,
+        placement: normalizePlacement(item.placement),
+      };
+    })
+    .filter((item): item is SingletonWindowConfig => item !== null);
+}
+
+function normalizeStatsWindows(value: unknown): StatsWindowConfig[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item): StatsWindowConfig | null => {
+      if (!isRecord(item) || typeof item.id !== "string" ||
+        !isStatsWindowKind(item.kind)) {
+        return null;
+      }
+      return {
+        id: item.id,
+        kind: item.kind,
+        placement: normalizePlacement(item.placement),
+        playerId: stringOrNull(item.playerId) ?? null,
+        team: item.team === "orange" ? "orange" : item.team === "blue" ? "blue" : null,
+        entries: normalizeSelectedStats(item.entries),
+      };
+    })
+    .filter((item): item is StatsWindowConfig => item !== null);
+}
+
+function normalizeSelectedStats(value: unknown): SelectedStatConfig[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item): SelectedStatConfig | null => {
+      if (!isRecord(item) || typeof item.statId !== "string") {
+        return null;
+      }
+      return {
+        statId: item.statId,
+        targetId: typeof item.targetId === "string" ? item.targetId : undefined,
+      };
+    })
+    .filter((item): item is SelectedStatConfig => item !== null);
+}
+
+function normalizePlacement(value: unknown): WindowPlacementConfig {
+  const record = isRecord(value) ? value : {};
+  const viewport = isRecord(record.viewport) ? record.viewport : {};
+  return {
+    x: finiteNumber(record.x) ?? 8,
+    y: finiteNumber(record.y) ?? 8,
+    viewport: {
+      width: finitePositive(viewport.width) ?? 1,
+      height: finitePositive(viewport.height) ?? 1,
+    },
+    zIndex: finiteNumber(record.zIndex),
+    visible: booleanValue(record.visible) ?? true,
+  };
+}
+
+function isSingletonWindowId(value: unknown): value is SingletonWindowId {
+  return value === "camera" || value === "playback" || value === "recording" ||
+    value === "boost-pickups";
+}
+
+function isStatsWindowKind(value: unknown): value is StatsWindowKind {
+  return value === "player" || value === "team" || value === "all-players" ||
+    value === "all-teams" || value === "ad-hoc";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function finitePositive(value: unknown): number | undefined {
+  const number = finiteNumber(value);
+  return number !== undefined && number > 0 ? number : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function stringOrNull(value: unknown): string | null | undefined {
+  if (value === null) {
+    return null;
+  }
+  return typeof value === "string" ? value : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/js/stat-evaluation-player/src/stat-modules/playerModules.ts
+++ b/js/stat-evaluation-player/src/stat-modules/playerModules.ts
@@ -108,6 +108,14 @@ export function createBoostModule(
       );
     },
 
+    getConfig() {
+      return pickupFilters.getConfig();
+    },
+
+    applyConfig(config) {
+      pickupFilters.applyConfig(config);
+    },
+
     includeBoostPickupAnimationPickup(pickup) {
       return pickupFilters.includePickup(pickup);
     },
@@ -363,6 +371,7 @@ export function createSpeedFlipModule(): StatModule {
 
 export function createTouchModule(runtime: StatModuleRuntime): StatModule {
   let overlay: TouchEventOverlay | null = null;
+  let decaySeconds = 5;
   let settingsEl: HTMLDivElement | null = null;
   let decayReadoutEl: HTMLElement | null = null;
   let breakdownReadoutEl: HTMLElement | null = null;
@@ -383,6 +392,7 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
         ctx.replay,
         ctx.statsTimeline,
       );
+      overlay.setDecaySeconds(decaySeconds);
       syncTouchSettingsUi();
     },
 
@@ -397,6 +407,34 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
 
     getTimelineEvents(ctx) {
       return buildTouchTimelineEvents(ctx.statsTimeline, ctx.replay);
+    },
+
+    getConfig() {
+      return {
+        decaySeconds,
+        breakdownClasses: getActiveBreakdownClasses(),
+      };
+    },
+
+    applyConfig(config) {
+      if (config && typeof config === "object" && !Array.isArray(config)) {
+        const record = config as Record<string, unknown>;
+        if (typeof record.decaySeconds === "number" &&
+          Number.isFinite(record.decaySeconds)) {
+          decaySeconds = Math.max(1, Math.min(10, record.decaySeconds));
+          overlay?.setDecaySeconds(decaySeconds);
+        }
+        activeBreakdownClasses.clear();
+        if (Array.isArray(record.breakdownClasses)) {
+          for (const className of record.breakdownClasses) {
+            if (orderedBreakdownClasses.includes(className as TouchBreakdownClass)) {
+              activeBreakdownClasses.add(className as TouchBreakdownClass);
+            }
+          }
+        }
+      }
+      syncTouchSettingsUi();
+      runtime.rerenderCurrentState();
     },
 
     renderStats(frameIndex, ctx) {
@@ -457,11 +495,15 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
         input.min = "1";
         input.max = "10";
         input.step = "0.5";
-        input.value = `${overlay?.getDecaySeconds() ?? 5}`;
+        input.value = `${decaySeconds}`;
         input.addEventListener("input", () => {
           const nextValue = Number(input.value);
-          overlay?.setDecaySeconds(nextValue);
-          syncTouchSettingsUi(nextValue);
+          decaySeconds = Number.isFinite(nextValue)
+            ? Math.max(1, Math.min(10, nextValue))
+            : decaySeconds;
+          overlay?.setDecaySeconds(decaySeconds);
+          syncTouchSettingsUi(decaySeconds);
+          runtime.requestConfigSync?.();
         });
 
         label.append(labelText, input);
@@ -504,6 +546,7 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
             }
             syncTouchSettingsUi();
             runtime.rerenderCurrentState();
+            runtime.requestConfigSync?.();
           });
 
           const optionText = document.createElement("span");
@@ -526,7 +569,7 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
       return;
     }
 
-    const value = nextValue ?? overlay?.getDecaySeconds() ?? 5;
+    const value = nextValue ?? decaySeconds;
     const input = settingsEl.querySelector("input");
     if (input instanceof HTMLInputElement) {
       input.value = `${value}`;
@@ -581,6 +624,28 @@ export function createMovementModule(runtime: StatModuleRuntime): StatModule {
     teardown() {},
 
     onBeforeRender() {},
+
+    getConfig() {
+      return {
+        breakdownClasses: getActiveBreakdownClasses(),
+      };
+    },
+
+    applyConfig(config) {
+      activeBreakdownClasses.clear();
+      if (config && typeof config === "object" && !Array.isArray(config)) {
+        const classes = (config as Record<string, unknown>).breakdownClasses;
+        if (Array.isArray(classes)) {
+          for (const className of classes) {
+            if (orderedBreakdownClasses.includes(className as MovementBreakdownClass)) {
+              activeBreakdownClasses.add(className as MovementBreakdownClass);
+            }
+          }
+        }
+      }
+      syncMovementSettingsUi();
+      runtime.rerenderCurrentState();
+    },
 
     renderStats(frameIndex, ctx) {
       const statsFrame = getStatsFrameForReplayFrame(
@@ -651,6 +716,7 @@ export function createMovementModule(runtime: StatModuleRuntime): StatModule {
             }
             syncMovementSettingsUi();
             runtime.rerenderCurrentState();
+            runtime.requestConfigSync?.();
           });
 
           const optionText = document.createElement("span");

--- a/js/stat-evaluation-player/src/stat-modules/teamModules.ts
+++ b/js/stat-evaluation-player/src/stat-modules/teamModules.ts
@@ -46,6 +46,28 @@ export function createPossessionModule(runtime: StatModuleRuntime): StatModule {
       return buildPossessionTimelineRanges(ctx.statsTimeline, ctx.replay);
     },
 
+    getConfig() {
+      return {
+        breakdownClasses: getActiveBreakdownClasses(),
+      };
+    },
+
+    applyConfig(config) {
+      activeBreakdownClasses.clear();
+      if (config && typeof config === "object" && !Array.isArray(config)) {
+        const classes = (config as Record<string, unknown>).breakdownClasses;
+        if (Array.isArray(classes)) {
+          for (const className of classes) {
+            if (orderedBreakdownClasses.includes(className as PossessionBreakdownClass)) {
+              activeBreakdownClasses.add(className as PossessionBreakdownClass);
+            }
+          }
+        }
+      }
+      syncPossessionSettingsUi();
+      runtime.rerenderCurrentState();
+    },
+
     renderStats(frameIndex, ctx) {
       const statsFrame = getStatsFrameForReplayFrame(
         ctx.statsFrameLookup,
@@ -121,6 +143,7 @@ export function createPossessionModule(runtime: StatModuleRuntime): StatModule {
           }
           syncPossessionSettingsUi();
           runtime.rerenderCurrentState();
+          runtime.requestConfigSync?.();
         });
 
         const optionText = document.createElement("span");
@@ -142,6 +165,7 @@ export function createPossessionModule(runtime: StatModuleRuntime): StatModule {
           }
           syncPossessionSettingsUi();
           runtime.rerenderCurrentState();
+          runtime.requestConfigSync?.();
         });
 
         const thirdOptionText = document.createElement("span");

--- a/js/stat-evaluation-player/src/stat-modules/types.ts
+++ b/js/stat-evaluation-player/src/stat-modules/types.ts
@@ -30,6 +30,8 @@ export interface StatModule {
   onBeforeRender(info: FrameRenderInfo): void;
   getTimelineEvents?(ctx: StatModuleContext): ReplayTimelineEvent[];
   getTimelineRanges?(ctx: StatModuleContext): ReplayTimelineRange[];
+  getConfig?(): unknown;
+  applyConfig?(config: unknown): void;
   includeBoostPickupAnimationPickup?(
     pickup: BoostPickupAnimationPickup,
   ): boolean;
@@ -45,6 +47,7 @@ export interface StatModule {
 export interface StatModuleRuntime {
   rerenderCurrentState(): void;
   refreshTimelineRanges?(): void;
+  requestConfigSync?(): void;
 }
 
 const MOST_BACK_FORWARD_THRESHOLD_Y = 236.0;


### PR DESCRIPTION
## Summary

- Add a versioned, compressed URL config model for the stats evaluation player.
- Persist playback, camera, recording controls, active timeline/overlay toggles, singleton/stat window placement, and configured stats windows into `#cfg=`.
- Restore saved configurations on mount and after replay load, scaling/clamping window positions for differently sized viewports.
- Route module/plugin-like settings through named config adapters so stateful pieces declare snapshot/apply behavior instead of being manually special-cased.
- Canonicalize boost pickup filter state under the `boost` config adapter while accepting the draft-era `boost-pickup-animation` key as an alias.
- Preserve URL-restored boost pickup player filters across the initial replay load while still resetting stale manual player filters for later replay changes.

## Validation

- `npm run check:tsc`
- `npx tsx --tsconfig tsconfig.test.json --test src/configAdapters.test.ts src/boostPickupFilters.test.ts src/playerConfig.test.ts src/statRegistry.test.ts --test-reporter=spec`
- `npm run build:site`
- `npm test -- --test-reporter=spec` (101/101 passing)
- `git diff --check`