### PR TITLE
Bump version to 0.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This is a rough changelog derived from git tags and commit history. It focuses o
 notable user-visible or maintenance-relevant changes rather than every formatting,
 README, or refactor-only commit.
 
+## v0.7.11 - 2026-05-24
+
+- Add optional playlist manifest pagination metadata and preserve it through
+  the JavaScript replay-player manifest parser and stats review player.
+- Refresh Rust, Python, and JavaScript release metadata to `0.7.11`.
+
 ## v0.7.10 - 2026-05-24
 
 - Emit consecutive same-player touch candidates without the previous short

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "rl-replay-subtr-actor"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "boxcars",
  "console_error_panic_hook",
@@ -1136,7 +1136,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subtr-actor"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "anyhow",
  "boxcars",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "subtr-actor-py"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "boxcars",
  "numpy",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "subtr-actor-tools"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "anyhow",
  "boxcars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/subtr-actor-tools", "js", "python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.10"
+version = "0.7.11"
 authors = ["Ivan Malison <ivanmalison@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/rlrml/subtr-actor"

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -24,7 +24,7 @@ boxcars.workspace = true
 
 [dependencies.subtr-actor]
 path = ".."
-version = "0.7.10"
+version = "0.7.11"
 
 [dependencies.web-sys]
 version = "0.3.85"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colonelpanic8/subtr-actor",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "WebAssembly bindings for subtr-actor - Rocket League replay processing and analysis",
   "main": "pkg/rl_replay_subtr_actor.js",
   "types": "pkg/rl_replay_subtr_actor.d.ts",

--- a/js/player/package.json
+++ b/js/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subtr-actor-player",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Replay player library for subtr-actor Rocket League replay workflows",
   "type": "module",
   "main": "./dist/index.js",

--- a/js/stat-evaluation-player/package.json
+++ b/js/stat-evaluation-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subtr-actor-stats-player",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Stats-focused replay player UI for subtr-actor Rocket League replay workflows",
   "type": "module",
   "main": "./dist/index.js",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1.0"
 
 [dependencies.subtr-actor]
 path = ".."
-version = "0.7.10"
+version = "0.7.11"
 
 [dependencies.pyo3]
 version = "0.27.2"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtr-actor-py"
-version = "0.7.10"
+version = "0.7.11"
 description = "Python bindings for the Rocket League replay processing library subtr-actor."
 authors = [{ name = "Ivan Malison", email = "ivanmalison@gmail.com" }]
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- bump Rust, Python, and JavaScript package metadata to 0.7.11
- add changelog notes for playlist manifest pagination metadata
- refresh Cargo.lock release package versions

## Tests
- python3 scripts/check_release_versions.py
- cargo metadata --locked --format-version 1
- pre-commit cargo clippy --all-targets --all-features -- -D warnings