### PR TITLE
[codex] Abstract collector processor view

### DIFF
--- a/src/collector/callback.rs
+++ b/src/collector/callback.rs
@@ -1,4 +1,4 @@
-use crate::{Collector, ReplayProcessor, SubtrActorResult, TimeAdvance};
+use crate::{Collector, ProcessorView, SubtrActorResult, TimeAdvance};
 use boxcars;
 
 /// A lightweight collector that invokes a callback at a configurable frame cadence.
@@ -45,7 +45,7 @@ where
 {
     fn process_frame(
         &mut self,
-        _processor: &ReplayProcessor,
+        _processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,

--- a/src/collector/decorator.rs
+++ b/src/collector/decorator.rs
@@ -53,7 +53,7 @@ impl<'a, C: Collector> Collector for FrameRateDecorator<'a, C> {
     /// [`TimeAdvance::Time`].
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,
@@ -74,7 +74,7 @@ impl<'a, C: Collector> Collector for FrameRateDecorator<'a, C> {
         Ok(next_target_time)
     }
 
-    fn finish_replay(&mut self, processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn finish_replay(&mut self, processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         self.collector.finish_replay(processor)
     }
 }

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -45,7 +45,7 @@ pub trait Collector {
     /// progression.
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,
@@ -73,18 +73,18 @@ pub trait Collector {
     ///
     /// Collectors that aggregate state across frame boundaries can override
     /// this to flush any in-progress segment once replay traversal is complete.
-    fn finish_replay(&mut self, _processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn finish_replay(&mut self, _processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         Ok(())
     }
 }
 
 impl<G> Collector for G
 where
-    G: FnMut(&ReplayProcessor, &boxcars::Frame, usize, f32) -> SubtrActorResult<TimeAdvance>,
+    G: FnMut(&dyn ProcessorView, &boxcars::Frame, usize, f32) -> SubtrActorResult<TimeAdvance>,
 {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,

--- a/src/collector/ndarray/builtins.rs
+++ b/src/collector/ndarray/builtins.rs
@@ -174,7 +174,7 @@ where
 
 build_global_feature_adder!(
     SecondsRemaining,
-    |_, processor: &ReplayProcessor, _frame, _index, _current_time| {
+    |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
         convert_all_floats!(processor.get_seconds_remaining().unwrap_or(0) as f32)
     },
     "seconds remaining"
@@ -188,7 +188,7 @@ build_global_feature_adder!(
 
 build_global_feature_adder!(
     ReplicatedStateName,
-    |_, processor: &ReplayProcessor, _frame, _index, _current_time| {
+    |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
         convert_all_floats!(processor.get_replicated_state_name().unwrap_or(0) as f32)
     },
     "game state"
@@ -196,7 +196,7 @@ build_global_feature_adder!(
 
 build_global_feature_adder!(
     ReplicatedGameStateTimeRemaining,
-    |_, processor: &ReplayProcessor, _frame, _index, _current_time| {
+    |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
         convert_all_floats!(processor
             .get_replicated_game_state_time_remaining()
             .unwrap_or(0) as f32)
@@ -206,7 +206,7 @@ build_global_feature_adder!(
 
 build_global_feature_adder!(
     BallHasBeenHit,
-    |_, processor: &ReplayProcessor, _frame, _index, _current_time| {
+    |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
         convert_all_floats!(if processor.get_ball_has_been_hit().unwrap_or(false) {
             1.0
         } else {
@@ -226,7 +226,7 @@ build_global_feature_adder!(
 
 build_global_feature_adder!(
     BallRigidBody,
-    |_, processor: &ReplayProcessor, _frame, _index, _current_time| {
+    |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
         processor
             .get_normalized_ball_rigid_body()
             .and_then(|rb| get_rigid_body_properties(&rb))
@@ -248,7 +248,7 @@ build_global_feature_adder!(
 
 build_global_feature_adder!(
     BallRigidBodyNoVelocities,
-    |_, processor: &ReplayProcessor, _frame, _index, _current_time| {
+    |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
         processor
             .get_normalized_ball_rigid_body()
             .and_then(|rb| get_rigid_body_properties_no_velocities(&rb))
@@ -265,7 +265,7 @@ build_global_feature_adder!(
 
 build_global_feature_adder!(
     VelocityAddedBallRigidBodyNoVelocities,
-    |_, processor: &ReplayProcessor, _frame, _index, current_time: f32| {
+    |_, processor: &dyn ProcessorView, _frame, _index, current_time: f32| {
         processor
             .get_velocity_applied_ball_rigid_body(current_time)
             .and_then(|rb| get_rigid_body_properties_no_velocities(&rb))
@@ -297,7 +297,7 @@ impl<F> InterpolatedBallRigidBodyNoVelocities<F> {
 global_feature_adder!(
     InterpolatedBallRigidBodyNoVelocities,
     |s: &InterpolatedBallRigidBodyNoVelocities<F>,
-     processor: &ReplayProcessor,
+     processor: &dyn ProcessorView,
      _frame: &boxcars::Frame,
      _index,
      current_time: f32| {
@@ -317,7 +317,7 @@ global_feature_adder!(
 
 build_player_feature_adder!(
     PlayerRigidBody,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
             get_rigid_body_properties(&rb)
         } else {
@@ -340,7 +340,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerRigidBodyNoVelocities,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
             get_rigid_body_properties_no_velocities(&rb)
         } else {
@@ -358,7 +358,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     VelocityAddedPlayerRigidBodyNoVelocities,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, current_time: f32| {
         if let Ok(rb) = processor.get_velocity_applied_player_rigid_body(player_id, current_time) {
             get_rigid_body_properties_no_velocities(&rb)
         } else {
@@ -392,7 +392,7 @@ player_feature_adder!(
     InterpolatedPlayerRigidBodyNoVelocities,
     |s: &InterpolatedPlayerRigidBodyNoVelocities<F>,
      player_id: &PlayerId,
-     processor: &ReplayProcessor,
+     processor: &dyn ProcessorView,
      _frame: &boxcars::Frame,
      _index,
      current_time: f32| {
@@ -416,7 +416,7 @@ player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerRelativeBallPosition,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         let relative_position = processor
             .get_normalized_player_rigid_body(player_id)
             .ok()
@@ -438,7 +438,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerRelativeBallVelocity,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         let relative_velocity = processor
             .get_normalized_player_rigid_body(player_id)
             .ok()
@@ -468,7 +468,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerLocalRelativeBallPosition,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         let local_relative_position = processor
             .get_normalized_player_rigid_body(player_id)
             .ok()
@@ -499,7 +499,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerLocalRelativeBallVelocity,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         let local_relative_velocity = processor
             .get_normalized_player_rigid_body(player_id)
             .ok()
@@ -537,7 +537,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerBallDistance,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         let distance = processor
             .get_normalized_player_rigid_body(player_id)
             .ok()
@@ -554,7 +554,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerBoost,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         convert_all_floats!(processor.get_player_boost_level(player_id).unwrap_or(0.0))
     },
     "boost level (raw replay units)"
@@ -568,7 +568,7 @@ build_player_feature_adder!(
     PlayerJump,
     |_,
      player_id: &PlayerId,
-     processor: &ReplayProcessor,
+     processor: &dyn ProcessorView,
      _frame,
      _frame_number,
      _current_time: f32| {
@@ -596,7 +596,7 @@ build_player_feature_adder!(
     PlayerAnyJump,
     |_,
      player_id: &PlayerId,
-     processor: &ReplayProcessor,
+     processor: &dyn ProcessorView,
      _frame,
      _frame_number,
      _current_time: f32| {
@@ -617,7 +617,7 @@ build_player_feature_adder!(
     PlayerDodgeRefreshed,
     |_,
      player_id: &PlayerId,
-     processor: &ReplayProcessor,
+     processor: &dyn ProcessorView,
      _frame,
      _frame_number,
      _current_time: f32| {
@@ -637,12 +637,12 @@ build_player_feature_adder!(
     PlayerDemolishedBy,
     |_,
      player_id: &PlayerId,
-     processor: &ReplayProcessor,
+     processor: &dyn ProcessorView,
      _frame,
      frame_number,
      _current_time: f32| {
         let demolisher_index = processor
-            .demolishes
+            .demolishes()
             .iter()
             .find(|demolish_info| {
                 &demolish_info.victim == player_id
@@ -663,7 +663,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerRigidBodyQuaternions,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
             let rotation = rb.rotation;
             let location = rb.location;
@@ -685,7 +685,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerRigidBodyQuaternionVelocities,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
             get_rigid_body_properties_quaternion(&rb)
         } else {
@@ -709,7 +709,7 @@ build_player_feature_adder!(
 
 build_player_feature_adder!(
     PlayerRigidBodyBasis,
-    |_, player_id: &PlayerId, processor: &ReplayProcessor, _frame, _index, _current_time: f32| {
+    |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
         if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
             get_rigid_body_properties_basis(&rb)
         } else {
@@ -735,7 +735,7 @@ build_player_feature_adder!(
 
 build_global_feature_adder!(
     BallRigidBodyQuaternions,
-    |_, processor: &ReplayProcessor, _frame, _index, _current_time| {
+    |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
         match processor.get_normalized_ball_rigid_body() {
             Ok(rb) => {
                 let rotation = rb.rotation;
@@ -759,7 +759,7 @@ build_global_feature_adder!(
 
 build_global_feature_adder!(
     BallRigidBodyQuaternionVelocities,
-    |_, processor: &ReplayProcessor, _frame, _index, _current_time| {
+    |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
         processor
             .get_normalized_ball_rigid_body()
             .and_then(|rb| get_rigid_body_properties_quaternion(&rb))
@@ -782,7 +782,7 @@ build_global_feature_adder!(
 
 build_global_feature_adder!(
     BallRigidBodyBasis,
-    |_, processor: &ReplayProcessor, _frame, _index, _current_time| {
+    |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
         processor
             .get_normalized_ball_rigid_body()
             .and_then(|rb| get_rigid_body_properties_basis(&rb))

--- a/src/collector/ndarray/collector.rs
+++ b/src/collector/ndarray/collector.rs
@@ -177,7 +177,7 @@ impl<F> NDArrayCollector<F> {
         Ok(global_feature_count + player_feature_count)
     }
 
-    fn maybe_set_replay_meta(&mut self, processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn maybe_set_replay_meta(&mut self, processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         if self.replay_meta.is_none() {
             self.replay_meta = Some(processor.get_replay_meta()?);
         }
@@ -188,7 +188,7 @@ impl<F> NDArrayCollector<F> {
 impl<F> Collector for NDArrayCollector<F> {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,

--- a/src/collector/ndarray/traits.rs
+++ b/src/collector/ndarray/traits.rs
@@ -16,7 +16,7 @@ pub trait FeatureAdder<F> {
 
     fn add_features(
         &self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_count: usize,
         current_time: f32,
@@ -33,7 +33,7 @@ pub trait LengthCheckedFeatureAdder<F, const N: usize> {
 
     fn get_features(
         &self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_count: usize,
         current_time: f32,
@@ -50,7 +50,7 @@ macro_rules! impl_feature_adder {
         {
             fn add_features(
                 &self,
-                processor: &ReplayProcessor,
+                processor: &dyn ProcessorView,
                 frame: &boxcars::Frame,
                 frame_count: usize,
                 current_time: f32,
@@ -84,7 +84,7 @@ pub trait PlayerFeatureAdder<F> {
     fn add_features(
         &self,
         player_id: &PlayerId,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_count: usize,
         current_time: f32,
@@ -102,7 +102,7 @@ pub trait LengthCheckedPlayerFeatureAdder<F, const N: usize> {
     fn get_features(
         &self,
         player_id: &PlayerId,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_count: usize,
         current_time: f32,
@@ -120,7 +120,7 @@ macro_rules! impl_player_feature_adder {
             fn add_features(
                 &self,
                 player_id: &PlayerId,
-                processor: &ReplayProcessor,
+                processor: &dyn ProcessorView,
                 frame: &boxcars::Frame,
                 frame_count: usize,
                 current_time: f32,
@@ -144,11 +144,11 @@ macro_rules! impl_player_feature_adder {
 
 impl<G, F, const N: usize> FeatureAdder<F> for (G, &[&str; N])
 where
-    G: Fn(&ReplayProcessor, &boxcars::Frame, usize, f32) -> SubtrActorResult<[F; N]>,
+    G: Fn(&dyn ProcessorView, &boxcars::Frame, usize, f32) -> SubtrActorResult<[F; N]>,
 {
     fn add_features(
         &self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_count: usize,
         current_time: f32,
@@ -165,12 +165,12 @@ where
 
 impl<G, F, const N: usize> PlayerFeatureAdder<F> for (G, &[&str; N])
 where
-    G: Fn(&PlayerId, &ReplayProcessor, &boxcars::Frame, usize, f32) -> SubtrActorResult<[F; N]>,
+    G: Fn(&PlayerId, &dyn ProcessorView, &boxcars::Frame, usize, f32) -> SubtrActorResult<[F; N]>,
 {
     fn add_features(
         &self,
         player_id: &PlayerId,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_count: usize,
         current_time: f32,
@@ -233,7 +233,7 @@ macro_rules! global_feature_adder {
 
                     fn get_features(
                         &self,
-                        processor: &ReplayProcessor,
+                        processor: &dyn ProcessorView,
                         frame: &boxcars::Frame,
                         frame_count: usize,
                         current_time: f32,
@@ -294,7 +294,7 @@ macro_rules! player_feature_adder {
                     fn get_features(
                         &self,
                         player_id: &PlayerId,
-                        processor: &ReplayProcessor,
+                        processor: &dyn ProcessorView,
                         frame: &boxcars::Frame,
                         frame_count: usize,
                         current_time: f32,

--- a/src/collector/replay_data.rs
+++ b/src/collector/replay_data.rs
@@ -82,7 +82,7 @@ impl BallFrame {
     /// - The ball's rigid body cannot be retrieved
     ///
     /// Otherwise returns [`Data`](BallFrame::Data) containing the ball's rigid body.
-    fn new_from_processor(processor: &ReplayProcessor, current_time: f32) -> Self {
+    fn new_from_processor(processor: &dyn ProcessorView, current_time: f32) -> Self {
         if processor.get_ignore_ball_syncing().unwrap_or(false) {
             Self::Empty
         } else if let Ok(rigid_body) = processor.get_interpolated_ball_rigid_body(current_time, 0.0)
@@ -173,7 +173,7 @@ impl PlayerFrame {
     /// - The player's boost level cannot be accessed
     /// - Other player state information is inaccessible
     fn new_from_processor(
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         player_id: &PlayerId,
         current_time: f32,
     ) -> SubtrActorResult<Self> {
@@ -425,7 +425,7 @@ impl MetadataFrame {
     ///
     /// Returns a [`SubtrActorError`] if the seconds remaining cannot be retrieved
     /// from the processor.
-    fn new_from_processor(processor: &ReplayProcessor, time: f32) -> SubtrActorResult<Self> {
+    fn new_from_processor(processor: &dyn ProcessorView, time: f32) -> SubtrActorResult<Self> {
         Ok(Self::new(
             time,
             processor.get_seconds_remaining()?,
@@ -740,13 +740,13 @@ impl ReplayDataCollector {
         let meta = processor.get_replay_meta()?;
         Ok(ReplayData {
             meta,
-            demolish_infos: processor.demolishes,
-            boost_pad_events: processor.boost_pad_events,
+            demolish_infos: processor.demolishes().to_vec(),
+            boost_pad_events: processor.boost_pad_events().to_vec(),
             boost_pads,
-            touch_events: processor.touch_events,
-            dodge_refreshed_events: processor.dodge_refreshed_events,
-            player_stat_events: processor.player_stat_events,
-            goal_events: processor.goal_events,
+            touch_events: processor.touch_events().to_vec(),
+            dodge_refreshed_events: processor.dodge_refreshed_events().to_vec(),
+            player_stat_events: processor.player_stat_events().to_vec(),
+            goal_events: processor.goal_events().to_vec(),
             frame_data: self.get_frame_data(),
         })
     }
@@ -818,7 +818,7 @@ impl ReplayDataCollector {
     /// Returns a [`SubtrActorError`] if player frame data cannot be extracted.
     fn get_player_frames(
         &self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         current_time: f32,
     ) -> SubtrActorResult<Vec<(PlayerId, PlayerFrame)>> {
         Ok(processor
@@ -861,7 +861,7 @@ impl Collector for ReplayDataCollector {
     /// - Frame data cannot be added to the collection
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         _frame: &boxcars::Frame,
         _frame_number: usize,
         current_time: f32,

--- a/src/collector/stats/collector.rs
+++ b/src/collector/stats/collector.rs
@@ -494,7 +494,7 @@ impl<T, F> StatsCollector<T, F> {
         Ok(())
     }
 
-    fn refresh_replay_meta(&mut self, processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn refresh_replay_meta(&mut self, processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         let player_count = processor.player_count();
         if self.last_replay_meta_player_count == Some(player_count) {
             return Ok(());
@@ -514,7 +514,7 @@ where
 {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         _frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,
@@ -556,17 +556,17 @@ where
 
         self.last_sample_time = Some(current_time);
         if matches!(self.sample_mode, SampleMode::Aggregate) {
-            self.last_demolish_count = processor.demolishes.len();
-            self.last_boost_pad_event_count = processor.boost_pad_events.len();
-            self.last_touch_event_count = processor.touch_events.len();
-            self.last_player_stat_event_count = processor.player_stat_events.len();
-            self.last_goal_event_count = processor.goal_events.len();
+            self.last_demolish_count = processor.demolishes().len();
+            self.last_boost_pad_event_count = processor.boost_pad_events().len();
+            self.last_touch_event_count = processor.touch_events().len();
+            self.last_player_stat_event_count = processor.player_stat_events().len();
+            self.last_goal_event_count = processor.goal_events().len();
         }
 
         Ok(TimeAdvance::NextFrame)
     }
 
-    fn finish_replay(&mut self, _processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn finish_replay(&mut self, _processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         self.graph.finish()?;
         let Some(replay_meta) = self.replay_meta.as_ref().cloned() else {
             return Ok(());

--- a/src/processor/bootstrap.rs
+++ b/src/processor/bootstrap.rs
@@ -32,7 +32,7 @@ impl<'a> ReplayProcessor<'a> {
     /// If any error other than `FinishProcessingEarly` occurs during the
     /// processing operation, it is propagated up by this function.
     pub fn process_long_enough_to_get_actor_ids(&mut self) -> SubtrActorResult<()> {
-        let mut handler = |_p: &ReplayProcessor, _f: &boxcars::Frame, n: usize, _current_time| {
+        let mut handler = |_p: &dyn ProcessorView, _f: &boxcars::Frame, n: usize, _current_time| {
             // XXX: 10 seconds should be enough to find everyone, right?
             if n > 10 * 30 {
                 SubtrActorError::new_result(SubtrActorErrorVariant::FinishProcessingEarly)

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -3,7 +3,9 @@ use boxcars;
 use std::collections::HashMap;
 
 pub mod actor_state;
+pub mod view;
 pub use actor_state::*;
+pub use view::*;
 
 pub(crate) fn attribute_type_name(attribute: &boxcars::Attribute) -> &'static str {
     match attribute {

--- a/src/processor/view.rs
+++ b/src/processor/view.rs
@@ -1,0 +1,298 @@
+use super::*;
+
+/// Read-only processor surface consumed by collectors and stat calculators.
+///
+/// `ReplayProcessor` still owns replay traversal and actor-state mutation, but
+/// collectors should depend on this trait so the same collection pipeline can
+/// later be driven by non-replay state sources.
+pub trait ProcessorView {
+    fn get_replay_meta(&self) -> SubtrActorResult<ReplayMeta>;
+    fn player_count(&self) -> usize;
+    fn iter_player_ids_in_order(&self) -> Box<dyn Iterator<Item = &PlayerId> + '_>;
+    fn current_in_game_team_player_counts(&self) -> [usize; 2];
+
+    fn get_seconds_remaining(&self) -> SubtrActorResult<i32>;
+    fn get_replicated_state_name(&self) -> SubtrActorResult<i32>;
+    fn get_replicated_game_state_time_remaining(&self) -> SubtrActorResult<i32>;
+    fn get_ball_has_been_hit(&self) -> SubtrActorResult<bool>;
+    fn get_ignore_ball_syncing(&self) -> SubtrActorResult<bool>;
+    fn get_team_scores(&self) -> SubtrActorResult<(i32, i32)>;
+    fn get_ball_hit_team_num(&self) -> SubtrActorResult<u8>;
+    fn get_scored_on_team_num(&self) -> SubtrActorResult<u8>;
+
+    fn get_normalized_ball_rigid_body(&self) -> SubtrActorResult<boxcars::RigidBody>;
+    fn get_velocity_applied_ball_rigid_body(
+        &self,
+        target_time: f32,
+    ) -> SubtrActorResult<boxcars::RigidBody>;
+    fn get_interpolated_ball_rigid_body(
+        &self,
+        target_time: f32,
+        close_enough_to_frame_time: f32,
+    ) -> SubtrActorResult<boxcars::RigidBody>;
+
+    fn get_normalized_player_rigid_body(
+        &self,
+        player_id: &PlayerId,
+    ) -> SubtrActorResult<boxcars::RigidBody>;
+    fn get_velocity_applied_player_rigid_body(
+        &self,
+        player_id: &PlayerId,
+        target_time: f32,
+    ) -> SubtrActorResult<boxcars::RigidBody>;
+    fn get_interpolated_player_rigid_body(
+        &self,
+        player_id: &PlayerId,
+        target_time: f32,
+        close_enough_to_frame_time: f32,
+    ) -> SubtrActorResult<boxcars::RigidBody>;
+
+    fn get_player_name(&self, player_id: &PlayerId) -> SubtrActorResult<String>;
+    fn get_player_team_key(&self, player_id: &PlayerId) -> SubtrActorResult<String>;
+    fn get_player_is_team_0(&self, player_id: &PlayerId) -> SubtrActorResult<bool>;
+    fn get_player_id_from_car_id(&self, actor_id: &boxcars::ActorId) -> SubtrActorResult<PlayerId>;
+    fn get_player_boost_level(&self, player_id: &PlayerId) -> SubtrActorResult<f32>;
+    fn get_player_last_boost_level(&self, player_id: &PlayerId) -> SubtrActorResult<f32>;
+    fn get_player_boost_percentage(&self, player_id: &PlayerId) -> SubtrActorResult<f32>;
+    fn get_boost_active(&self, player_id: &PlayerId) -> SubtrActorResult<u8>;
+    fn get_jump_active(&self, player_id: &PlayerId) -> SubtrActorResult<u8>;
+    fn get_double_jump_active(&self, player_id: &PlayerId) -> SubtrActorResult<u8>;
+    fn get_dodge_active(&self, player_id: &PlayerId) -> SubtrActorResult<u8>;
+    fn get_powerslide_active(&self, player_id: &PlayerId) -> SubtrActorResult<bool>;
+    fn get_player_match_assists(&self, player_id: &PlayerId) -> SubtrActorResult<i32>;
+    fn get_player_match_goals(&self, player_id: &PlayerId) -> SubtrActorResult<i32>;
+    fn get_player_match_saves(&self, player_id: &PlayerId) -> SubtrActorResult<i32>;
+    fn get_player_match_score(&self, player_id: &PlayerId) -> SubtrActorResult<i32>;
+    fn get_player_match_shots(&self, player_id: &PlayerId) -> SubtrActorResult<i32>;
+
+    fn get_active_demos(&self) -> SubtrActorResult<Vec<DemolishAttribute>>;
+    fn demolishes(&self) -> &[DemolishInfo];
+    fn boost_pad_events(&self) -> &[BoostPadEvent];
+    fn touch_events(&self) -> &[TouchEvent];
+    fn dodge_refreshed_events(&self) -> &[DodgeRefreshedEvent];
+    fn player_stat_events(&self) -> &[PlayerStatEvent];
+    fn goal_events(&self) -> &[GoalEvent];
+    fn current_frame_boost_pad_events(&self) -> &[BoostPadEvent];
+    fn current_frame_touch_events(&self) -> &[TouchEvent];
+    fn current_frame_dodge_refreshed_events(&self) -> &[DodgeRefreshedEvent];
+    fn current_frame_player_stat_events(&self) -> &[PlayerStatEvent];
+    fn current_frame_goal_events(&self) -> &[GoalEvent];
+}
+
+impl ProcessorView for ReplayProcessor<'_> {
+    fn get_replay_meta(&self) -> SubtrActorResult<ReplayMeta> {
+        ReplayProcessor::get_replay_meta(self)
+    }
+
+    fn player_count(&self) -> usize {
+        ReplayProcessor::player_count(self)
+    }
+
+    fn iter_player_ids_in_order(&self) -> Box<dyn Iterator<Item = &PlayerId> + '_> {
+        Box::new(ReplayProcessor::iter_player_ids_in_order(self))
+    }
+
+    fn current_in_game_team_player_counts(&self) -> [usize; 2] {
+        ReplayProcessor::current_in_game_team_player_counts(self)
+    }
+
+    fn get_seconds_remaining(&self) -> SubtrActorResult<i32> {
+        ReplayProcessor::get_seconds_remaining(self)
+    }
+
+    fn get_replicated_state_name(&self) -> SubtrActorResult<i32> {
+        ReplayProcessor::get_replicated_state_name(self)
+    }
+
+    fn get_replicated_game_state_time_remaining(&self) -> SubtrActorResult<i32> {
+        ReplayProcessor::get_replicated_game_state_time_remaining(self)
+    }
+
+    fn get_ball_has_been_hit(&self) -> SubtrActorResult<bool> {
+        ReplayProcessor::get_ball_has_been_hit(self)
+    }
+
+    fn get_ignore_ball_syncing(&self) -> SubtrActorResult<bool> {
+        ReplayProcessor::get_ignore_ball_syncing(self)
+    }
+
+    fn get_team_scores(&self) -> SubtrActorResult<(i32, i32)> {
+        ReplayProcessor::get_team_scores(self)
+    }
+
+    fn get_ball_hit_team_num(&self) -> SubtrActorResult<u8> {
+        ReplayProcessor::get_ball_hit_team_num(self)
+    }
+
+    fn get_scored_on_team_num(&self) -> SubtrActorResult<u8> {
+        ReplayProcessor::get_scored_on_team_num(self)
+    }
+
+    fn get_normalized_ball_rigid_body(&self) -> SubtrActorResult<boxcars::RigidBody> {
+        ReplayProcessor::get_normalized_ball_rigid_body(self)
+    }
+
+    fn get_velocity_applied_ball_rigid_body(
+        &self,
+        target_time: f32,
+    ) -> SubtrActorResult<boxcars::RigidBody> {
+        ReplayProcessor::get_velocity_applied_ball_rigid_body(self, target_time)
+    }
+
+    fn get_interpolated_ball_rigid_body(
+        &self,
+        target_time: f32,
+        close_enough_to_frame_time: f32,
+    ) -> SubtrActorResult<boxcars::RigidBody> {
+        ReplayProcessor::get_interpolated_ball_rigid_body(
+            self,
+            target_time,
+            close_enough_to_frame_time,
+        )
+    }
+
+    fn get_normalized_player_rigid_body(
+        &self,
+        player_id: &PlayerId,
+    ) -> SubtrActorResult<boxcars::RigidBody> {
+        ReplayProcessor::get_normalized_player_rigid_body(self, player_id)
+    }
+
+    fn get_velocity_applied_player_rigid_body(
+        &self,
+        player_id: &PlayerId,
+        target_time: f32,
+    ) -> SubtrActorResult<boxcars::RigidBody> {
+        ReplayProcessor::get_velocity_applied_player_rigid_body(self, player_id, target_time)
+    }
+
+    fn get_interpolated_player_rigid_body(
+        &self,
+        player_id: &PlayerId,
+        target_time: f32,
+        close_enough_to_frame_time: f32,
+    ) -> SubtrActorResult<boxcars::RigidBody> {
+        ReplayProcessor::get_interpolated_player_rigid_body(
+            self,
+            player_id,
+            target_time,
+            close_enough_to_frame_time,
+        )
+    }
+
+    fn get_player_name(&self, player_id: &PlayerId) -> SubtrActorResult<String> {
+        ReplayProcessor::get_player_name(self, player_id)
+    }
+
+    fn get_player_team_key(&self, player_id: &PlayerId) -> SubtrActorResult<String> {
+        ReplayProcessor::get_player_team_key(self, player_id)
+    }
+
+    fn get_player_is_team_0(&self, player_id: &PlayerId) -> SubtrActorResult<bool> {
+        ReplayProcessor::get_player_is_team_0(self, player_id)
+    }
+
+    fn get_player_id_from_car_id(&self, actor_id: &boxcars::ActorId) -> SubtrActorResult<PlayerId> {
+        ReplayProcessor::get_player_id_from_car_id(self, actor_id)
+    }
+
+    fn get_player_boost_level(&self, player_id: &PlayerId) -> SubtrActorResult<f32> {
+        ReplayProcessor::get_player_boost_level(self, player_id)
+    }
+
+    fn get_player_last_boost_level(&self, player_id: &PlayerId) -> SubtrActorResult<f32> {
+        ReplayProcessor::get_player_last_boost_level(self, player_id)
+    }
+
+    fn get_player_boost_percentage(&self, player_id: &PlayerId) -> SubtrActorResult<f32> {
+        ReplayProcessor::get_player_boost_percentage(self, player_id)
+    }
+
+    fn get_boost_active(&self, player_id: &PlayerId) -> SubtrActorResult<u8> {
+        ReplayProcessor::get_boost_active(self, player_id)
+    }
+
+    fn get_jump_active(&self, player_id: &PlayerId) -> SubtrActorResult<u8> {
+        ReplayProcessor::get_jump_active(self, player_id)
+    }
+
+    fn get_double_jump_active(&self, player_id: &PlayerId) -> SubtrActorResult<u8> {
+        ReplayProcessor::get_double_jump_active(self, player_id)
+    }
+
+    fn get_dodge_active(&self, player_id: &PlayerId) -> SubtrActorResult<u8> {
+        ReplayProcessor::get_dodge_active(self, player_id)
+    }
+
+    fn get_powerslide_active(&self, player_id: &PlayerId) -> SubtrActorResult<bool> {
+        ReplayProcessor::get_powerslide_active(self, player_id)
+    }
+
+    fn get_player_match_assists(&self, player_id: &PlayerId) -> SubtrActorResult<i32> {
+        ReplayProcessor::get_player_match_assists(self, player_id)
+    }
+
+    fn get_player_match_goals(&self, player_id: &PlayerId) -> SubtrActorResult<i32> {
+        ReplayProcessor::get_player_match_goals(self, player_id)
+    }
+
+    fn get_player_match_saves(&self, player_id: &PlayerId) -> SubtrActorResult<i32> {
+        ReplayProcessor::get_player_match_saves(self, player_id)
+    }
+
+    fn get_player_match_score(&self, player_id: &PlayerId) -> SubtrActorResult<i32> {
+        ReplayProcessor::get_player_match_score(self, player_id)
+    }
+
+    fn get_player_match_shots(&self, player_id: &PlayerId) -> SubtrActorResult<i32> {
+        ReplayProcessor::get_player_match_shots(self, player_id)
+    }
+
+    fn get_active_demos(&self) -> SubtrActorResult<Vec<DemolishAttribute>> {
+        ReplayProcessor::get_active_demos(self).map(Iterator::collect)
+    }
+
+    fn demolishes(&self) -> &[DemolishInfo] {
+        &self.demolishes
+    }
+
+    fn boost_pad_events(&self) -> &[BoostPadEvent] {
+        &self.boost_pad_events
+    }
+
+    fn touch_events(&self) -> &[TouchEvent] {
+        &self.touch_events
+    }
+
+    fn dodge_refreshed_events(&self) -> &[DodgeRefreshedEvent] {
+        &self.dodge_refreshed_events
+    }
+
+    fn player_stat_events(&self) -> &[PlayerStatEvent] {
+        &self.player_stat_events
+    }
+
+    fn goal_events(&self) -> &[GoalEvent] {
+        &self.goal_events
+    }
+
+    fn current_frame_boost_pad_events(&self) -> &[BoostPadEvent] {
+        ReplayProcessor::current_frame_boost_pad_events(self)
+    }
+
+    fn current_frame_touch_events(&self) -> &[TouchEvent] {
+        ReplayProcessor::current_frame_touch_events(self)
+    }
+
+    fn current_frame_dodge_refreshed_events(&self) -> &[DodgeRefreshedEvent] {
+        ReplayProcessor::current_frame_dodge_refreshed_events(self)
+    }
+
+    fn current_frame_player_stat_events(&self) -> &[PlayerStatEvent] {
+        ReplayProcessor::current_frame_player_stat_events(self)
+    }
+
+    fn current_frame_goal_events(&self) -> &[GoalEvent] {
+        ReplayProcessor::current_frame_goal_events(self)
+    }
+}

--- a/src/stats/analysis_graph/collector.rs
+++ b/src/stats/analysis_graph/collector.rs
@@ -46,7 +46,7 @@ impl AnalysisNodeCollector {
 impl Collector for AnalysisNodeCollector {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         _frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,
@@ -74,16 +74,16 @@ impl Collector for AnalysisNodeCollector {
         );
         self.graph.evaluate_with_state(&frame_input)?;
         self.last_sample_time = Some(current_time);
-        self.last_demolish_count = processor.demolishes.len();
-        self.last_boost_pad_event_count = processor.boost_pad_events.len();
-        self.last_touch_event_count = processor.touch_events.len();
-        self.last_player_stat_event_count = processor.player_stat_events.len();
-        self.last_goal_event_count = processor.goal_events.len();
+        self.last_demolish_count = processor.demolishes().len();
+        self.last_boost_pad_event_count = processor.boost_pad_events().len();
+        self.last_touch_event_count = processor.touch_events().len();
+        self.last_player_stat_event_count = processor.player_stat_events().len();
+        self.last_goal_event_count = processor.goal_events().len();
 
         Ok(TimeAdvance::NextFrame)
     }
 
-    fn finish_replay(&mut self, _processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn finish_replay(&mut self, _processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         self.graph.finish()
     }
 }

--- a/src/stats/calculators/flip_reset.rs
+++ b/src/stats/calculators/flip_reset.rs
@@ -261,7 +261,7 @@ impl FlipResetTracker {
 
     pub fn on_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_index: usize,
     ) -> SubtrActorResult<()> {
@@ -312,7 +312,7 @@ impl FlipResetTracker {
 
     fn build_flip_reset_event(
         &self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         touch_event: &TouchEvent,
         frame_index: usize,
     ) -> Option<FlipResetEvent> {
@@ -339,7 +339,7 @@ impl FlipResetTracker {
 
     fn build_flip_reset_event_for_player(
         &self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         player: &PlayerId,
         time: f32,
         frame_index: usize,
@@ -367,7 +367,7 @@ impl FlipResetTracker {
 
     fn build_flip_reset_followup_touch_candidate(
         &self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         touch_event: &TouchEvent,
         frame_index: usize,
     ) -> Option<FlipResetEvent> {
@@ -394,7 +394,7 @@ impl FlipResetTracker {
 
     fn build_flip_reset_proximity_event(
         &self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         player: &PlayerId,
         time: f32,
         frame_index: usize,
@@ -421,7 +421,7 @@ impl FlipResetTracker {
 
     fn update_flip_reset_events(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         current_time: f32,
         frame_index: usize,
     ) -> SubtrActorResult<()> {
@@ -499,7 +499,7 @@ impl FlipResetTracker {
         Ok(())
     }
 
-    fn update_dodge_rising_edges(&mut self, processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn update_dodge_rising_edges(&mut self, processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         self.current_frame_dodge_rising_edges.clear();
         let player_ids: Vec<_> = processor.iter_player_ids_in_order().cloned().collect();
 
@@ -546,7 +546,7 @@ impl FlipResetTracker {
 
     fn update_post_wall_dodge_events(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_index: usize,
     ) -> SubtrActorResult<()> {
@@ -615,7 +615,7 @@ impl FlipResetTracker {
 
     fn update_flip_reset_followup_dodge_events(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_index: usize,
     ) -> SubtrActorResult<()> {
@@ -689,7 +689,7 @@ impl FlipResetTracker {
 impl Collector for FlipResetTracker {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_number: usize,
         _current_time: f32,

--- a/src/stats/calculators/frame_input.rs
+++ b/src/stats/calculators/frame_input.rs
@@ -5,46 +5,34 @@ use super::{
     PlayerFrameState, PlayerSample,
 };
 
-#[derive(Debug, Clone, Copy)]
-enum EventWindow {
-    CurrentFrame,
-    SinceLastSample {
-        last_demolish_count: usize,
-        last_boost_pad_event_count: usize,
-        last_touch_event_count: usize,
-        last_player_stat_event_count: usize,
-        last_goal_event_count: usize,
-    },
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct FrameInput {
-    processor: *const (),
-    frame_number: usize,
-    current_time: f32,
-    dt: f32,
-    event_window: EventWindow,
+    frame_info: FrameInfo,
+    gameplay_state: GameplayState,
+    ball_frame_state: BallFrameState,
+    player_frame_state: PlayerFrameState,
+    frame_events_state: FrameEventsState,
 }
 
 impl FrameInput {
     pub fn timeline(
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame_number: usize,
         current_time: f32,
         dt: f32,
     ) -> Self {
         Self {
-            processor: processor as *const ReplayProcessor<'_> as *const (),
-            frame_number,
-            current_time,
-            dt,
-            event_window: EventWindow::CurrentFrame,
+            frame_info: Self::build_frame_info(processor, frame_number, current_time, dt),
+            gameplay_state: Self::build_gameplay_state(processor),
+            ball_frame_state: Self::build_ball_frame_state(processor, current_time),
+            player_frame_state: Self::build_player_frame_state(processor, current_time),
+            frame_events_state: Self::build_current_frame_events_state(processor),
         }
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn aggregate(
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame_number: usize,
         current_time: f32,
         dt: f32,
@@ -55,37 +43,36 @@ impl FrameInput {
         last_goal_event_count: usize,
     ) -> Self {
         Self {
-            processor: processor as *const ReplayProcessor<'_> as *const (),
-            frame_number,
-            current_time,
-            dt,
-            event_window: EventWindow::SinceLastSample {
+            frame_info: Self::build_frame_info(processor, frame_number, current_time, dt),
+            gameplay_state: Self::build_gameplay_state(processor),
+            ball_frame_state: Self::build_ball_frame_state(processor, current_time),
+            player_frame_state: Self::build_player_frame_state(processor, current_time),
+            frame_events_state: Self::build_events_since_last_sample(
+                processor,
                 last_demolish_count,
                 last_boost_pad_event_count,
                 last_touch_event_count,
                 last_player_stat_event_count,
                 last_goal_event_count,
-            },
+            ),
         }
     }
 
-    fn processor(&self) -> &ReplayProcessor<'_> {
-        // `FrameInput` is only used while evaluating the graph, so the replay
-        // processor borrowed by the collector outlives this ephemeral wrapper.
-        unsafe { &*(self.processor as *const ReplayProcessor<'_>) }
-    }
-
-    pub fn frame_info(&self) -> FrameInfo {
+    fn build_frame_info(
+        processor: &dyn ProcessorView,
+        frame_number: usize,
+        current_time: f32,
+        dt: f32,
+    ) -> FrameInfo {
         FrameInfo {
-            frame_number: self.frame_number,
-            time: self.current_time,
-            dt: self.dt,
-            seconds_remaining: self.processor().get_seconds_remaining().ok(),
+            frame_number,
+            time: current_time,
+            dt,
+            seconds_remaining: processor.get_seconds_remaining().ok(),
         }
     }
 
-    pub fn gameplay_state(&self) -> GameplayState {
-        let processor = self.processor();
+    fn build_gameplay_state(processor: &dyn ProcessorView) -> GameplayState {
         let team_scores = processor.get_team_scores().ok();
         let possession_team_is_team_0 =
             processor
@@ -117,16 +104,18 @@ impl FrameInput {
         }
     }
 
-    pub fn ball_frame_state(&self) -> BallFrameState {
-        self.processor()
-            .get_interpolated_ball_rigid_body(self.current_time, 0.0)
+    fn build_ball_frame_state(processor: &dyn ProcessorView, current_time: f32) -> BallFrameState {
+        processor
+            .get_interpolated_ball_rigid_body(current_time, 0.0)
             .ok()
             .map(|rigid_body| BallSample { rigid_body })
             .into()
     }
 
-    pub fn player_frame_state(&self) -> PlayerFrameState {
-        let processor = self.processor();
+    fn build_player_frame_state(
+        processor: &dyn ProcessorView,
+        current_time: f32,
+    ) -> PlayerFrameState {
         let mut players = Vec::new();
         for player_id in processor.iter_player_ids_in_order() {
             let Ok(is_team_0) = processor.get_player_is_team_0(player_id) else {
@@ -136,7 +125,7 @@ impl FrameInput {
                 player_id: player_id.clone(),
                 is_team_0,
                 rigid_body: processor
-                    .get_interpolated_player_rigid_body(player_id, self.current_time, 0.0)
+                    .get_interpolated_player_rigid_body(player_id, current_time, 0.0)
                     .ok()
                     .filter(|rigid_body| !rigid_body.sleeping),
                 boost_amount: processor.get_player_boost_level(player_id).ok(),
@@ -154,10 +143,10 @@ impl FrameInput {
         PlayerFrameState { players }
     }
 
-    pub fn frame_events_state(&self) -> FrameEventsState {
-        let processor = self.processor();
+    fn build_current_frame_events_state(processor: &dyn ProcessorView) -> FrameEventsState {
         let active_demos = if let Ok(demos) = processor.get_active_demos() {
             demos
+                .into_iter()
                 .filter_map(|demo| {
                     let attacker = processor
                         .get_player_id_from_car_id(&demo.attacker_actor_id())
@@ -171,7 +160,7 @@ impl FrameInput {
         } else {
             Vec::new()
         };
-        let mut events = FrameEventsState {
+        FrameEventsState {
             active_demos,
             demo_events: Vec::new(),
             boost_pad_events: processor.current_frame_boost_pad_events().to_vec(),
@@ -179,24 +168,46 @@ impl FrameInput {
             dodge_refreshed_events: processor.current_frame_dodge_refreshed_events().to_vec(),
             player_stat_events: processor.current_frame_player_stat_events().to_vec(),
             goal_events: processor.current_frame_goal_events().to_vec(),
-        };
-        if let EventWindow::SinceLastSample {
-            last_demolish_count,
-            last_boost_pad_event_count,
-            last_touch_event_count,
-            last_player_stat_event_count,
-            last_goal_event_count,
-        } = self.event_window
-        {
-            events.active_demos.clear();
-            events.demo_events = processor.demolishes[last_demolish_count..].to_vec();
-            events.boost_pad_events =
-                processor.boost_pad_events[last_boost_pad_event_count..].to_vec();
-            events.touch_events = processor.touch_events[last_touch_event_count..].to_vec();
-            events.player_stat_events =
-                processor.player_stat_events[last_player_stat_event_count..].to_vec();
-            events.goal_events = processor.goal_events[last_goal_event_count..].to_vec();
         }
-        events
+    }
+
+    fn build_events_since_last_sample(
+        processor: &dyn ProcessorView,
+        last_demolish_count: usize,
+        last_boost_pad_event_count: usize,
+        last_touch_event_count: usize,
+        last_player_stat_event_count: usize,
+        last_goal_event_count: usize,
+    ) -> FrameEventsState {
+        FrameEventsState {
+            active_demos: Vec::new(),
+            demo_events: processor.demolishes()[last_demolish_count..].to_vec(),
+            boost_pad_events: processor.boost_pad_events()[last_boost_pad_event_count..].to_vec(),
+            touch_events: processor.touch_events()[last_touch_event_count..].to_vec(),
+            dodge_refreshed_events: processor.current_frame_dodge_refreshed_events().to_vec(),
+            player_stat_events: processor.player_stat_events()[last_player_stat_event_count..]
+                .to_vec(),
+            goal_events: processor.goal_events()[last_goal_event_count..].to_vec(),
+        }
+    }
+
+    pub fn frame_info(&self) -> FrameInfo {
+        self.frame_info.clone()
+    }
+
+    pub fn gameplay_state(&self) -> GameplayState {
+        self.gameplay_state.clone()
+    }
+
+    pub fn ball_frame_state(&self) -> BallFrameState {
+        self.ball_frame_state.clone()
+    }
+
+    pub fn player_frame_state(&self) -> PlayerFrameState {
+        self.player_frame_state.clone()
+    }
+
+    pub fn frame_events_state(&self) -> FrameEventsState {
+        self.frame_events_state.clone()
     }
 }

--- a/src/stats/resolved_boost_pad_collector.rs
+++ b/src/stats/resolved_boost_pad_collector.rs
@@ -40,7 +40,7 @@ impl ResolvedBoostPadCollector {
 impl Collector for ResolvedBoostPadCollector {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,
@@ -49,7 +49,7 @@ impl Collector for ResolvedBoostPadCollector {
             .process_frame(processor, frame, frame_number, current_time)
     }
 
-    fn finish_replay(&mut self, processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn finish_replay(&mut self, processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         self.collector.finish_replay(processor)
     }
 }

--- a/src/stats/timeline/collector.rs
+++ b/src/stats/timeline/collector.rs
@@ -143,7 +143,7 @@ impl StatsTimelineCollector {
 impl Collector for StatsTimelineCollector {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         _frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,
@@ -173,7 +173,7 @@ impl Collector for StatsTimelineCollector {
         Ok(TimeAdvance::NextFrame)
     }
 
-    fn finish_replay(&mut self, _processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn finish_replay(&mut self, _processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         self.graph.finish()?;
         let Some(_) = self.replay_meta.as_ref() else {
             return Ok(());

--- a/tests/boost_pickup_duplicate_investigation_test.rs
+++ b/tests/boost_pickup_duplicate_investigation_test.rs
@@ -44,7 +44,7 @@ impl BoostPickupInvestigationCollector {
 impl Collector for BoostPickupInvestigationCollector {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         frame: &boxcars::Frame,
         frame_number: usize,
         current_time: f32,
@@ -82,7 +82,7 @@ impl Collector for BoostPickupInvestigationCollector {
         Ok(advance)
     }
 
-    fn finish_replay(&mut self, processor: &ReplayProcessor) -> SubtrActorResult<()> {
+    fn finish_replay(&mut self, processor: &dyn ProcessorView) -> SubtrActorResult<()> {
         self.analysis.finish_replay(processor)
     }
 }

--- a/tests/boost_units_test.rs
+++ b/tests/boost_units_test.rs
@@ -17,7 +17,7 @@ impl BoostUnitVerifier {
 impl Collector for BoostUnitVerifier {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         _frame: &boxcars::Frame,
         frame_number: usize,
         _current_time: f32,

--- a/tests/boost_values_test.rs
+++ b/tests/boost_values_test.rs
@@ -23,7 +23,7 @@ impl BoostTracker {
 impl Collector for BoostTracker {
     fn process_frame(
         &mut self,
-        processor: &ReplayProcessor,
+        processor: &dyn ProcessorView,
         _frame: &boxcars::Frame,
         frame_number: usize,
         _current_time: f32,

--- a/tests/replay_processing_test.rs
+++ b/tests/replay_processing_test.rs
@@ -1272,7 +1272,7 @@ impl FrameCounter {
 impl Collector for FrameCounter {
     fn process_frame(
         &mut self,
-        _processor: &ReplayProcessor,
+        _processor: &dyn ProcessorView,
         _frame: &boxcars::Frame,
         _frame_number: usize,
         current_time: f32,


### PR DESCRIPTION
## Summary

- add a read-only `ProcessorView` trait implemented by `ReplayProcessor`
- switch collectors, ndarray feature adders, stats calculators, and test collectors to consume `&dyn ProcessorView` instead of `&ReplayProcessor`
- replace collector-side direct event-vector field access with view methods and make `FrameInput` own sampled state instead of carrying a concrete processor pointer

## Impact

Collectors now depend on an abstract processor-like interface, which should make it easier to drive the same collector/stat pipeline from another state source such as BakkesMod later. Replay traversal and mutation still stay on `ReplayProcessor`.

## Validation

- `cargo check`
- `cargo test`
- pre-commit hook: `cargo clippy --all-targets --all-features -- -D warnings`