### PR TITLE
Add BakkesMod in-game UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +259,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-ord"
@@ -650,6 +675,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1203,6 +1238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,7 +1312,9 @@ dependencies = [
 name = "subtr-actor-bakkesmod"
 version = "0.12.0"
 dependencies = [
+ "base64",
  "boxcars",
+ "flate2",
  "serde_json",
  "subtr-actor",
 ]

--- a/bakkesmod/README.md
+++ b/bakkesmod/README.md
@@ -69,7 +69,8 @@ events, dodge-refresh transitions, and control state:
   `subtr_actor_bakkesmod_write_graph_info_json`
 
 The in-game launcher can copy and paste the floating-window layout as raw JSON.
-It can also copy a `#cfg=...` fragment that the stats evaluation player accepts.
+It can also copy the same compressed `#cfg=...` fragment emitted by the stats
+evaluation player.
 Paste accepts raw layout JSON, that raw JSON `cfg` fragment, or a full URL
 containing either a raw JSON `cfg` value or the compressed base64url `cfg`
 value emitted by the web stats evaluation player.

--- a/bakkesmod/README.md
+++ b/bakkesmod/README.md
@@ -74,6 +74,8 @@ evaluation player.
 Paste accepts raw layout JSON, that raw JSON `cfg` fragment, or a full URL
 containing either a raw JSON `cfg` value or the compressed base64url `cfg`
 value emitted by the web stats evaluation player.
+The same inputs can be applied from the BakkesMod console with
+`subtr_actor_apply_ui_config <json|cfg|url>`.
 
 ## Windows build outline
 

--- a/bakkesmod/README.md
+++ b/bakkesmod/README.md
@@ -71,8 +71,8 @@ events, dodge-refresh transitions, and control state:
 The in-game launcher can copy and paste the floating-window layout as raw JSON.
 It can also copy a `#cfg=...` fragment that the stats evaluation player accepts.
 Paste accepts raw layout JSON, that raw JSON `cfg` fragment, or a full URL
-containing a raw JSON `cfg` value. Compressed web `cfg` values still need to be
-decoded in the web player first.
+containing either a raw JSON `cfg` value or the compressed base64url `cfg`
+value emitted by the web stats evaluation player.
 
 ## Windows build outline
 

--- a/bakkesmod/README.md
+++ b/bakkesmod/README.md
@@ -68,6 +68,12 @@ events, dodge-refresh transitions, and control state:
   `subtr_actor_bakkesmod_graph_info_json_len` and
   `subtr_actor_bakkesmod_write_graph_info_json`
 
+The in-game launcher can copy and paste the floating-window layout as raw JSON.
+It can also copy a `#cfg=...` fragment that the stats evaluation player accepts.
+Paste accepts raw layout JSON, that raw JSON `cfg` fragment, or a full URL
+containing a raw JSON `cfg` value. Compressed web `cfg` values still need to be
+decoded in the web player first.
+
 ## Windows build outline
 
 The actual plugin build path is Windows/MSVC. From a Developer PowerShell with

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8947,7 +8947,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
         return source.option->label;
       }
     }
-    return event.type;
+    return eventTypeDisplayLabel(event.type);
   };
 
   ImGui::BeginChild("event-playlist-list", ImVec2{0.0f, 0.0f}, true);
@@ -8990,9 +8990,6 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     }
     if (!metaParts.empty()) {
       ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());
-    }
-    if (!event.details.empty()) {
-      ImGui::TextDisabled("%s", event.details.c_str());
     }
     if (active && eventPlaylistAutoFollow && activeEventKey != eventPlaylistLastActiveKey) {
       ImGui::SetScrollHereY(0.5f);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9244,6 +9244,9 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     if (!event.type.empty()) {
       metaParts.push_back(eventTypeDisplayLabel(event.type));
     }
+    if (!event.actor.empty()) {
+      metaParts.push_back(event.actor);
+    }
     metaParts.push_back(mechanicsReviewDecisionLabel(event));
     ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());
     ImGui::PopID();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3391,9 +3391,22 @@ void SubtrActorPlugin::applyUiConfigJson(
       renderEffectSpeedFlipEnabled = containsString(renderEffects, "speed-flip");
       renderEffectTouchEnabled = containsString(renderEffects, "touch");
       setCvarBool("subtr_actor_overlay_enabled", anyRenderEffect);
+    }
+    const bool hasPluginRenderEffects = jsonPropertyExists(*overlays, "pluginRenderEffects");
+    std::vector<std::string> pluginRenderEffects =
+        parseJsonStringArrayProperty(*overlays, "pluginRenderEffects");
+    const bool hasRenderEffects = jsonPropertyExists(*overlays, "renderEffects");
+    if (!hasPluginRenderEffects && hasRenderEffects) {
+      for (const char *id : {"mechanics", "team", "goal_context"}) {
+        if (containsString(renderEffects, id)) {
+          pluginRenderEffects.emplace_back(id);
+        }
+      }
+    }
+    if (hasPluginRenderEffects || hasRenderEffects) {
       setCvarBool(
           "subtr_actor_overlay_mechanics_enabled",
-          containsString(renderEffects, "mechanics") ||
+          containsString(pluginRenderEffects, "mechanics") ||
               renderEffectCeilingShotEnabled ||
               renderEffectFiftyFiftyEnabled ||
               renderEffectRelativePositioningEnabled ||
@@ -3402,10 +3415,10 @@ void SubtrActorPlugin::applyUiConfigJson(
               renderEffectTouchEnabled);
       setCvarBool(
           "subtr_actor_overlay_team_events_enabled",
-          containsString(renderEffects, "team") || renderEffectPressureEnabled);
+          containsString(pluginRenderEffects, "team") || renderEffectPressureEnabled);
       setCvarBool(
           "subtr_actor_overlay_goal_context_enabled",
-          containsString(renderEffects, "goal_context"));
+          containsString(pluginRenderEffects, "goal_context"));
     }
 
     const std::optional<bool> boostPads = parseJsonBoolProperty(*overlays, "boostPads");
@@ -4063,15 +4076,6 @@ std::string SubtrActorPlugin::uiConfigJson() {
   file << "    \"renderEffects\": [";
   wroteOverlayValue = false;
   const bool hudOverlayEnabled = cvarBool("subtr_actor_overlay_enabled", true);
-  writeOverlayId(
-      "mechanics",
-      hudOverlayEnabled && cvarBool("subtr_actor_overlay_mechanics_enabled", true));
-  writeOverlayId(
-      "team",
-      hudOverlayEnabled && cvarBool("subtr_actor_overlay_team_events_enabled", true));
-  writeOverlayId(
-      "goal_context",
-      hudOverlayEnabled && cvarBool("subtr_actor_overlay_goal_context_enabled", true));
   writeOverlayId("ceiling-shot", hudOverlayEnabled && renderEffectCeilingShotEnabled);
   writeOverlayId("fifty-fifty", hudOverlayEnabled && renderEffectFiftyFiftyEnabled);
   writeOverlayId("pressure", hudOverlayEnabled && renderEffectPressureEnabled);
@@ -4083,6 +4087,14 @@ std::string SubtrActorPlugin::uiConfigJson() {
       hudOverlayEnabled && renderEffectAbsolutePositioningEnabled);
   writeOverlayId("speed-flip", hudOverlayEnabled && renderEffectSpeedFlipEnabled);
   writeOverlayId("touch", hudOverlayEnabled && renderEffectTouchEnabled);
+  file << "],\n";
+  file << "    \"pluginRenderEffects\": [";
+  wroteOverlayValue = false;
+  writeOverlayId(
+      "mechanics",
+      cvarBool("subtr_actor_overlay_mechanics_enabled", true));
+  writeOverlayId("team", cvarBool("subtr_actor_overlay_team_events_enabled", true));
+  writeOverlayId("goal_context", cvarBool("subtr_actor_overlay_goal_context_enabled", true));
   file << "],\n";
   file << "    \"followedPlayerHud\": false,\n";
   file << "    \"boostPads\": "

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9058,6 +9058,58 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     }
     return eventTypeDisplayLabel(event.type);
   };
+  auto renderEventPlaylistItem = [&](const std::string &timeLabel,
+                                     const std::string &eventLabel,
+                                     const std::string &metaLabel,
+                                     const ImVec4 &eventColor,
+                                     bool active) {
+    constexpr float timeColumnWidth = 54.0f;
+    constexpr float rowPaddingX = 10.0f;
+    constexpr float rowPaddingY = 8.0f;
+    constexpr float colorRailWidth = 4.0f;
+    constexpr float columnGap = 10.0f;
+    const float rowWidth = ImGui::GetContentRegionAvail().x;
+    const float rowHeight = ImGui::GetTextLineHeight() * 2.0f + rowPaddingY * 2.0f + 2.0f;
+    const std::string buttonId = std::format("##event-playlist-item-{}", eventLabel);
+    const bool clicked = ImGui::InvisibleButton(buttonId.c_str(), ImVec2{rowWidth, rowHeight});
+    const bool hovered = ImGui::IsItemHovered();
+    const ImVec2 rowMin = ImGui::GetItemRectMin();
+    const ImVec2 rowMax = ImGui::GetItemRectMax();
+    ImDrawList *drawList = ImGui::GetWindowDrawList();
+    const ImU32 eventColorU32 = ImGui::ColorConvertFloat4ToU32(eventColor);
+    const ImVec4 rowBg = (active || hovered)
+                             ? ImVec4{eventColor.x, eventColor.y, eventColor.z, 0.15f}
+                             : ImVec4{1.0f, 1.0f, 1.0f, 0.035f};
+    const ImVec4 border = (active || hovered)
+                              ? ImVec4{eventColor.x, eventColor.y, eventColor.z, 0.48f}
+                              : ImVec4{1.0f, 1.0f, 1.0f, 0.09f};
+    drawList->AddRectFilled(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(rowBg), 6.0f);
+    drawList->AddRect(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(border), 6.0f);
+    drawList->AddRectFilled(
+        rowMin,
+        ImVec2{rowMin.x + colorRailWidth, rowMax.y},
+        eventColorU32,
+        6.0f);
+
+    const float timeX = rowMin.x + rowPaddingX + colorRailWidth;
+    const float mainX = timeX + timeColumnWidth + columnGap;
+    const float titleY = rowMin.y + rowPaddingY;
+    const float metaY = titleY + ImGui::GetTextLineHeight() + 3.0f;
+    drawList->AddText(
+        ImVec2{timeX, titleY},
+        IM_COL32(137, 164, 186, 255),
+        timeLabel.c_str());
+    drawList->PushClipRect(
+        ImVec2{mainX, rowMin.y},
+        ImVec2{rowMax.x - rowPaddingX, rowMax.y},
+        true);
+    drawList->AddText(ImVec2{mainX, titleY}, IM_COL32(237, 245, 250, 255), eventLabel.c_str());
+    if (!metaLabel.empty()) {
+      drawList->AddText(ImVec2{mainX, metaY}, IM_COL32(137, 164, 186, 255), metaLabel.c_str());
+    }
+    drawList->PopClipRect();
+    return clicked;
+  };
 
   ImGui::BeginChild("event-playlist-list", ImVec2{0.0f, 0.0f}, true);
   for (const size_t index : playlistEventIndexes) {
@@ -9072,22 +9124,6 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     const std::string timeLabel = formatEventPlaylistTime(event.time);
     const std::string sourceLabel = sourceLabelForEvent(event);
     const std::string eventLabel = event.label.empty() ? sourceLabel : event.label;
-    const std::string itemLabel = std::format("{}##event-playlist-item", eventLabel);
-    ImGui::TextDisabled("%s", timeLabel.c_str());
-    ImGui::SameLine(64.0f);
-    ImGui::PushStyleColor(ImGuiCol_Text, color);
-    const bool selected = ImGui::Selectable(itemLabel.c_str(), active);
-    ImGui::PopStyleColor();
-    if (selected) {
-      mechanicsReviewClipActive = false;
-      playbackCurrentTime = seekTime;
-      playbackSkipPostGoalTransitions = false;
-      playbackSkipKickoffs = false;
-      showSingletonWindow(uiPlaybackControlsOpen, playbackControlsPlacement);
-      if (hasReplayServer) {
-        replayServer.SkipToTime(seekTime);
-      }
-    }
     std::vector<std::string> metaParts;
     if (!event.actor.empty()) {
       metaParts.push_back(event.actor);
@@ -9098,14 +9134,22 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     if (!sourceLabel.empty()) {
       metaParts.push_back(sourceLabel);
     }
-    if (!metaParts.empty()) {
-      ImGui::SetCursorPosX(64.0f);
-      ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());
+    const std::string metaLabel = joinStrings(metaParts, " · ");
+    const bool selected =
+        renderEventPlaylistItem(timeLabel, eventLabel, metaLabel, color, active);
+    if (selected) {
+      mechanicsReviewClipActive = false;
+      playbackCurrentTime = seekTime;
+      playbackSkipPostGoalTransitions = false;
+      playbackSkipKickoffs = false;
+      showSingletonWindow(uiPlaybackControlsOpen, playbackControlsPlacement);
+      if (hasReplayServer) {
+        replayServer.SkipToTime(seekTime);
+      }
     }
     if (active && eventPlaylistAutoFollow && activeEventKey != eventPlaylistLastActiveKey) {
       ImGui::SetScrollHereY(0.5f);
     }
-    ImGui::Separator();
     ImGui::PopID();
   }
   eventPlaylistLastActiveKey = activeEventKey;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -30,7 +30,8 @@ constexpr float PI = 3.14159265358979323846f;
 constexpr float UNREAL_ROTATOR_TO_RADIANS = (2.0f * PI) / 65536.0f;
 constexpr float GOAL_WATCH_LEAD_SECONDS = 4.0f;
 constexpr ImGuiWindowFlags UI_FLOATING_WINDOW_FLAGS =
-    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse;
+    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse |
+    ImGuiWindowFlags_NoSavedSettings;
 constexpr ImGuiWindowFlags UI_CHROME_WINDOW_FLAGS =
     ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
     ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse |
@@ -8012,7 +8013,8 @@ void SubtrActorPlugin::renderScoreboardWindow() {
   applyScoreboardWindowPlacement();
   constexpr ImGuiWindowFlags scoreboardFlags =
       ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize |
-      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse;
+      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse |
+      ImGuiWindowFlags_NoSavedSettings;
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{10.0f, 6.0f});
   ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 999.0f);
   if (!ImGui::Begin("Scoreboard##subtr-actor", &uiScoreboardOpen, scoreboardFlags)) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8918,37 +8918,6 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
     return;
   }
 
-  if (ImGui::Button("All filters")) {
-    boostPickupPadBig = true;
-    boostPickupPadSmall = true;
-    boostPickupPadAmbiguous = true;
-    boostPickupActivityActive = true;
-    boostPickupActivityInactive = true;
-    boostPickupActivityUnknown = true;
-    boostPickupFieldOwn = true;
-    boostPickupFieldOpponent = true;
-    boostPickupFieldUnknown = true;
-    boostPickupPlayerFilterEnabled = false;
-    boostPickupPlayerIds.clear();
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Hide pickups")) {
-    boostPickupPadBig = false;
-    boostPickupPadSmall = false;
-    boostPickupPadAmbiguous = false;
-    boostPickupActivityActive = false;
-    boostPickupActivityInactive = false;
-    boostPickupActivityUnknown = false;
-    boostPickupFieldOwn = false;
-    boostPickupFieldOpponent = false;
-    boostPickupFieldUnknown = false;
-    boostPickupPlayerFilterEnabled = true;
-    boostPickupPlayerIds.clear();
-    scheduleUiConfigAutosave();
-  }
-
-  ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Pad type");
   if (ImGui::Checkbox("Big pads", &boostPickupPadBig)) {
     scheduleUiConfigAutosave();
@@ -8990,17 +8959,6 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
   if (!sampledPlayers.empty()) {
     ImGui::Separator();
     ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Player");
-    if (ImGui::Button("All players")) {
-      boostPickupPlayerFilterEnabled = false;
-      boostPickupPlayerIds.clear();
-      scheduleUiConfigAutosave();
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("No players")) {
-      boostPickupPlayerFilterEnabled = true;
-      boostPickupPlayerIds.clear();
-      scheduleUiConfigAutosave();
-    }
     for (const SaPlayerFrame &player : sampledPlayers) {
       const std::string playerId = webPlayerIdForIndex(player.player_index);
       bool selected =

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11829,14 +11829,43 @@ void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t /*stackIn
 }
 
 void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
+  auto pushStatsScopeSelectorStyle = [](std::optional<LinearColor> teamColor) {
+    ImGui::SetNextItemWidth(std::min(208.0f, ImGui::GetContentRegionAvail().x));
+    if (!teamColor) {
+      return 0;
+    }
+
+    const ImVec4 accent = toImVec4(*teamColor);
+    ImGui::PushStyleColor(ImGuiCol_Border, accent);
+    ImGui::PushStyleColor(
+        ImGuiCol_FrameBg,
+        ImVec4{accent.x * 0.18f, accent.y * 0.18f, accent.z * 0.18f, 0.58f});
+    ImGui::PushStyleColor(
+        ImGuiCol_FrameBgHovered,
+        ImVec4{accent.x * 0.24f, accent.y * 0.24f, accent.z * 0.24f, 0.74f});
+    ImGui::PushStyleColor(
+        ImGuiCol_FrameBgActive,
+        ImVec4{accent.x * 0.30f, accent.y * 0.30f, accent.z * 0.30f, 0.88f});
+    return 4;
+  };
+
   if (window.kind == UiStatsWindowKind::Player) {
     resolveStatsWindowPlayerSelection(window);
     const SaPlayerFrame *selected = sampledPlayerByIndex(window.selected_player_index);
     const std::string selectedLabel =
         selected ? playerLabel(selected->player_index, selected->is_team_0) : "Select player";
-    if (ImGui::BeginCombo(
-            std::format("##stats-window-player-scope-{}", window.id).c_str(),
-            selectedLabel.c_str())) {
+    const std::optional<LinearColor> selectedColor =
+        selected ? std::make_optional(selected->is_team_0 != 0 ? LinearColor{80, 190, 255, 255}
+                                                              : LinearColor{255, 175, 80, 255})
+                 : std::nullopt;
+    const int selectorStyleColors = pushStatsScopeSelectorStyle(selectedColor);
+    const bool comboOpen = ImGui::BeginCombo(
+        std::format("##stats-window-player-scope-{}", window.id).c_str(),
+        selectedLabel.c_str());
+    if (selectorStyleColors > 0) {
+      ImGui::PopStyleColor(selectorStyleColors);
+    }
+    if (comboOpen) {
       for (uint8_t isTeam0 : {uint8_t{1}, uint8_t{0}}) {
         const bool hasTeamPlayers = std::any_of(
             sampledPlayers.begin(),
@@ -11873,9 +11902,17 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
 
   if (window.kind == UiStatsWindowKind::Team) {
     const char *selectedTeam = window.selected_team_is_team_0 != 0 ? "Blue" : "Orange";
-    if (ImGui::BeginCombo(
-            std::format("##stats-window-team-scope-{}", window.id).c_str(),
-            selectedTeam)) {
+    const std::optional<LinearColor> selectedColor =
+        window.selected_team_is_team_0 != 0 ? std::make_optional(LinearColor{80, 190, 255, 255})
+                                           : std::make_optional(LinearColor{255, 175, 80, 255});
+    const int selectorStyleColors = pushStatsScopeSelectorStyle(selectedColor);
+    const bool comboOpen = ImGui::BeginCombo(
+        std::format("##stats-window-team-scope-{}", window.id).c_str(),
+        selectedTeam);
+    if (selectorStyleColors > 0) {
+      ImGui::PopStyleColor(selectorStyleColors);
+    }
+    if (comboOpen) {
       for (uint8_t isTeam0 : {uint8_t{1}, uint8_t{0}}) {
         const LinearColor color =
             isTeam0 != 0 ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255};

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1545,6 +1545,103 @@ std::vector<UiStatDefinitionCandidate> graphStatDefinitionsFromStatsJson(
   return definitions;
 }
 
+std::vector<UiStatDefinitionCandidate> graphStatDefinitionsFromReplayFrameJson(
+    const std::string &frameJson) {
+  std::vector<UiStatDefinitionCandidate> definitions;
+  std::unordered_set<std::string> seenIds;
+
+  auto appendStatsObject =
+      [&](const std::string &statsObject, const std::string &moduleName, const char *scope) {
+        std::vector<std::string> paths;
+        collectJsonLeafStatPaths(statsObject, "", paths, 8);
+        for (const std::string &path : paths) {
+          const std::string id = std::format("{}:{}.{}", scope, moduleName, path);
+          if (!seenIds.insert(id).second || normalizeUiStatId(id) != id) {
+            continue;
+          }
+          definitions.push_back(UiStatDefinitionCandidate{
+              id,
+              std::format("{}.{}", moduleName, path),
+              moduleName,
+              std::string_view{scope} == "player",
+              std::string_view{scope} == "team",
+              false,
+          });
+        }
+      };
+
+  if (const auto teamZero = parseJsonObjectProperty(frameJson, "team_zero")) {
+    for (const std::string &moduleName : parseJsonObjectKeys(*teamZero)) {
+      if (const auto module = parseJsonObjectProperty(*teamZero, moduleName)) {
+        appendStatsObject(*module, moduleName, "team");
+      }
+    }
+  } else if (const auto teamOne = parseJsonObjectProperty(frameJson, "team_one")) {
+    for (const std::string &moduleName : parseJsonObjectKeys(*teamOne)) {
+      if (const auto module = parseJsonObjectProperty(*teamOne, moduleName)) {
+        appendStatsObject(*module, moduleName, "team");
+      }
+    }
+  }
+
+  const std::vector<std::string> players =
+      parseJsonObjectArrayProperty(frameJson, "players");
+  if (!players.empty()) {
+    for (const std::string &moduleName : parseJsonObjectKeys(players.front())) {
+      if (moduleName == "player_id" || moduleName == "name" || moduleName == "is_team_0") {
+        continue;
+      }
+      if (const auto module = parseJsonObjectProperty(players.front(), moduleName)) {
+        appendStatsObject(*module, moduleName, "player");
+      }
+    }
+  }
+
+  return definitions;
+}
+
+std::string replayStatsModuleFrameJson(
+    const std::string &frameJson,
+    const std::string &moduleName) {
+  std::optional<std::string> teamZeroModule;
+  if (const auto teamZero = parseJsonObjectProperty(frameJson, "team_zero")) {
+    teamZeroModule = parseJsonObjectProperty(*teamZero, moduleName);
+  }
+  std::optional<std::string> teamOneModule;
+  if (const auto teamOne = parseJsonObjectProperty(frameJson, "team_one")) {
+    teamOneModule = parseJsonObjectProperty(*teamOne, moduleName);
+  }
+
+  std::string json = "{";
+  json += "\"team_zero\":";
+  json += teamZeroModule.value_or("null");
+  json += ",\"team_one\":";
+  json += teamOneModule.value_or("null");
+  json += ",\"player_stats\":[";
+  bool firstPlayer = true;
+  for (const std::string &player : parseJsonObjectArrayProperty(frameJson, "players")) {
+    const auto playerId = parseJsonPropertyValue(player, "player_id");
+    const auto stats = parseJsonObjectProperty(player, moduleName);
+    if (!playerId || !stats) {
+      continue;
+    }
+    if (!firstPlayer) {
+      json += ",";
+    }
+    firstPlayer = false;
+    json += "{\"player_id\":";
+    json += *playerId;
+    json += ",\"stats\":";
+    json += *stats;
+    json += "}";
+  }
+  json += "]}";
+  if (!teamZeroModule && !teamOneModule && firstPlayer) {
+    return {};
+  }
+  return json;
+}
+
 static_assert(sizeof(SaBoostPadEventKind) == 4);
 static_assert(sizeof(SaPlayerStatEventKind) == 4);
 
@@ -3169,6 +3266,10 @@ bool SubtrActorPlugin::loadRustLibrary() {
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_replay_annotation_players"));
   writeReplayAnnotationFramePlayers = reinterpret_cast<WriteReplayAnnotationFramePlayers>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_replay_annotation_frame_players"));
+  replayAnnotationFrameJsonLen = reinterpret_cast<ReplayAnnotationFrameJsonLen>(
+      GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_replay_annotation_frame_json_len"));
+  writeReplayAnnotationFrameJson = reinterpret_cast<WriteReplayAnnotationFrameJson>(
+      GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_replay_annotation_frame_json"));
   replayAnnotationScoreAtTime = reinterpret_cast<ReplayAnnotationScoreAtTime>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_replay_annotation_score_at_time"));
   pollReplayAnnotations = reinterpret_cast<PollReplayAnnotations>(
@@ -3187,8 +3288,8 @@ bool SubtrActorPlugin::loadRustLibrary() {
       !drainEvents || !drainTeamEvents || !drainGoalContextEvents ||
       !replayAnnotationsCreate || !replayAnnotationsDestroy || !replayAnnotationCount ||
       !replayAnnotationPlayerCount || !writeReplayAnnotationPlayers ||
-      !writeReplayAnnotationFramePlayers || !replayAnnotationScoreAtTime ||
-      !pollReplayAnnotations) {
+      !writeReplayAnnotationFramePlayers || !replayAnnotationFrameJsonLen ||
+      !writeReplayAnnotationFrameJson || !replayAnnotationScoreAtTime || !pollReplayAnnotations) {
     unloadRustLibrary();
     return false;
   }
@@ -3251,6 +3352,8 @@ void SubtrActorPlugin::unloadRustLibrary() {
   replayAnnotationPlayerCount = nullptr;
   writeReplayAnnotationPlayers = nullptr;
   writeReplayAnnotationFramePlayers = nullptr;
+  replayAnnotationFrameJsonLen = nullptr;
+  writeReplayAnnotationFrameJson = nullptr;
   replayAnnotationScoreAtTime = nullptr;
   pollReplayAnnotations = nullptr;
 }
@@ -4693,6 +4796,8 @@ void SubtrActorPlugin::resetReplayAnnotations() {
   replayAnnotations = nullptr;
   replayAnnotationPath.clear();
   replayAnnotationLoadFailed = false;
+  cachedReplayFrameJson.clear();
+  cachedReplayFrameJsonTime = -1.0f;
   if (gameWrapper && gameWrapper->IsInReplay()) {
     sampledPlayers.clear();
     sampledPlayerNames.clear();
@@ -5203,6 +5308,8 @@ void SubtrActorPlugin::resetLiveState() {
   mechanicsReviewIndex = 0;
   cachedStatsJson.clear();
   cachedStatsJsonFrameNumber = std::numeric_limits<uint64_t>::max();
+  cachedReplayFrameJson.clear();
+  cachedReplayFrameJsonTime = -1.0f;
 }
 
 void SubtrActorPlugin::clearPendingFrameEvents() {
@@ -10970,6 +11077,45 @@ const std::string &SubtrActorPlugin::currentStatsJson() const {
   return cachedStatsJson;
 }
 
+const std::string &SubtrActorPlugin::currentReplayFrameJson() const {
+  if (!replayAnnotations || !replayAnnotationFrameJsonLen || !writeReplayAnnotationFrameJson ||
+      !gameWrapper || !gameWrapper->IsInReplay()) {
+    cachedReplayFrameJson.clear();
+    cachedReplayFrameJsonTime = -1.0f;
+    return cachedReplayFrameJson;
+  }
+
+  ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
+  if (replayServer.IsNull()) {
+    cachedReplayFrameJson.clear();
+    cachedReplayFrameJsonTime = -1.0f;
+    return cachedReplayFrameJson;
+  }
+
+  const float replayTime = replayServer.GetReplayTimeElapsed();
+  if (cachedReplayFrameJsonTime == replayTime) {
+    return cachedReplayFrameJson;
+  }
+
+  const size_t byteCount = replayAnnotationFrameJsonLen(replayAnnotations, replayTime);
+  if (byteCount == 0) {
+    cachedReplayFrameJson.clear();
+    cachedReplayFrameJsonTime = replayTime;
+    return cachedReplayFrameJson;
+  }
+
+  std::string buffer(byteCount, '\0');
+  const size_t written = writeReplayAnnotationFrameJson(
+      replayAnnotations,
+      replayTime,
+      reinterpret_cast<uint8_t *>(buffer.data()),
+      buffer.size());
+  buffer.resize(written);
+  cachedReplayFrameJson = std::move(buffer);
+  cachedReplayFrameJsonTime = replayTime;
+  return cachedReplayFrameJson;
+}
+
 std::optional<std::string> SubtrActorPlugin::graphPlayerStatValue(
     const SaPlayerFrame &player,
     std::string_view statId) const {
@@ -10978,35 +11124,45 @@ std::optional<std::string> SubtrActorPlugin::graphPlayerStatValue(
     return std::nullopt;
   }
 
-  const std::string &statsJson = currentStatsJson();
-  if (statsJson.empty()) {
-    return std::nullopt;
-  }
-  const auto frame = parseJsonObjectProperty(statsJson, "frame");
-  if (!frame) {
-    return std::nullopt;
-  }
-  const auto modules = parseJsonObjectProperty(*frame, "modules");
-  if (!modules) {
-    return std::nullopt;
-  }
-  const auto module = parseJsonObjectProperty(*modules, std::string{parsed->module});
-  if (!module) {
-    return std::nullopt;
+  if (const std::string &statsJson = currentStatsJson(); !statsJson.empty()) {
+    const auto frame = parseJsonObjectProperty(statsJson, "frame");
+    const auto modules = frame ? parseJsonObjectProperty(*frame, "modules") : std::nullopt;
+    const auto module =
+        modules ? parseJsonObjectProperty(*modules, std::string{parsed->module})
+                : std::nullopt;
+    if (module) {
+      const std::vector<std::string> playerStats =
+          parseJsonObjectArrayProperty(*module, "player_stats");
+      for (const std::string &entry : playerStats) {
+        const auto playerId = parseJsonObjectProperty(entry, "player_id");
+        if (!playerId || !jsonPlayerIdMatchesIndex(*playerId, player.player_index)) {
+          continue;
+        }
+        const auto stats = parseJsonObjectProperty(entry, "stats");
+        if (!stats) {
+          return std::nullopt;
+        }
+        return jsonDisplayValueAtPath(*stats, parsed->path);
+      }
+    }
   }
 
-  const std::vector<std::string> playerStats =
-      parseJsonObjectArrayProperty(*module, "player_stats");
-  for (const std::string &entry : playerStats) {
+  const std::string &replayFrameJson = currentReplayFrameJson();
+  if (replayFrameJson.empty()) {
+    return std::nullopt;
+  }
+  const std::vector<std::string> replayPlayers =
+      parseJsonObjectArrayProperty(replayFrameJson, "players");
+  for (size_t index = 0; index < replayPlayers.size(); index += 1) {
+    const std::string &entry = replayPlayers[index];
     const auto playerId = parseJsonObjectProperty(entry, "player_id");
-    if (!playerId || !jsonPlayerIdMatchesIndex(*playerId, player.player_index)) {
+    const bool matchesById = playerId && jsonPlayerIdMatchesIndex(*playerId, player.player_index);
+    const bool matchesByReplayOrder = index == player.player_index;
+    if (!matchesById && !matchesByReplayOrder) {
       continue;
     }
-    const auto stats = parseJsonObjectProperty(entry, "stats");
-    if (!stats) {
-      return std::nullopt;
-    }
-    return jsonDisplayValueAtPath(*stats, parsed->path);
+    const auto module = parseJsonObjectProperty(entry, std::string{parsed->module});
+    return module ? jsonDisplayValueAtPath(*module, parsed->path) : std::nullopt;
   }
   return std::nullopt;
 }
@@ -11019,28 +11175,30 @@ std::optional<std::string> SubtrActorPlugin::graphTeamStatValue(
     return std::nullopt;
   }
 
-  const std::string &statsJson = currentStatsJson();
-  if (statsJson.empty()) {
+  if (const std::string &statsJson = currentStatsJson(); !statsJson.empty()) {
+    const auto frame = parseJsonObjectProperty(statsJson, "frame");
+    const auto modules = frame ? parseJsonObjectProperty(*frame, "modules") : std::nullopt;
+    const auto module =
+        modules ? parseJsonObjectProperty(*modules, std::string{parsed->module})
+                : std::nullopt;
+    const auto team =
+        module ? parseJsonObjectProperty(*module, isTeam0 != 0 ? "team_zero" : "team_one")
+               : std::nullopt;
+    if (team) {
+      return jsonDisplayValueAtPath(*team, parsed->path);
+    }
+  }
+
+  const std::string &replayFrameJson = currentReplayFrameJson();
+  if (replayFrameJson.empty()) {
     return std::nullopt;
   }
-  const auto frame = parseJsonObjectProperty(statsJson, "frame");
-  if (!frame) {
-    return std::nullopt;
-  }
-  const auto modules = parseJsonObjectProperty(*frame, "modules");
-  if (!modules) {
-    return std::nullopt;
-  }
-  const auto module = parseJsonObjectProperty(*modules, std::string{parsed->module});
-  if (!module) {
-    return std::nullopt;
-  }
-  const auto team =
-      parseJsonObjectProperty(*module, isTeam0 != 0 ? "team_zero" : "team_one");
-  if (!team) {
-    return std::nullopt;
-  }
-  return jsonDisplayValueAtPath(*team, parsed->path);
+  const auto teamSnapshot =
+      parseJsonObjectProperty(replayFrameJson, isTeam0 != 0 ? "team_zero" : "team_one");
+  const auto module =
+      teamSnapshot ? parseJsonObjectProperty(*teamSnapshot, std::string{parsed->module})
+                   : std::nullopt;
+  return module ? jsonDisplayValueAtPath(*module, parsed->path) : std::nullopt;
 }
 
 std::string SubtrActorPlugin::playerStatValue(
@@ -11463,6 +11621,12 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   }
   for (UiStatDefinitionCandidate &definition :
        graphStatDefinitionsFromStatsJson(currentStatsJson())) {
+    if (definitionIds.insert(definition.id).second) {
+      definitions.push_back(std::move(definition));
+    }
+  }
+  for (UiStatDefinitionCandidate &definition :
+       graphStatDefinitionsFromReplayFrameJson(currentReplayFrameJson())) {
     if (definitionIds.insert(definition.id).second) {
       definitions.push_back(std::move(definition));
     }
@@ -12030,7 +12194,7 @@ void SubtrActorPlugin::renderJsonInspectorPayload(
 
 void SubtrActorPlugin::renderStatsModuleWindow(UiStatsWindow &window) {
   if (!loaded || !engine) {
-    ImGui::TextWrapped("Start live analysis to inspect graph-backed stats modules.");
+    ImGui::TextWrapped("Load the graph runtime to inspect graph-backed stats modules.");
     return;
   }
 
@@ -12060,6 +12224,12 @@ void SubtrActorPlugin::renderStatsModuleWindow(UiStatsWindow &window) {
         statsModuleFrameJsonLen,
         writeStatsModuleFrameJson,
         window.module_name);
+    if (json.empty()) {
+      json = replayStatsModuleFrameJson(currentReplayFrameJson(), window.module_name);
+      if (!json.empty()) {
+        viewLabel = "replay frame";
+      }
+    }
   }
 
   if (json.empty()) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10999,6 +10999,7 @@ void SubtrActorPlugin::renderAdHocTargetSelector(
                                 isSelected) &&
               !statsWindowHasStat(window, statId, nextTarget)) {
             entry.target_id = nextTarget;
+            scheduleUiConfigAutosave();
           }
         }
         ImGui::Separator();
@@ -11025,6 +11026,7 @@ void SubtrActorPlugin::renderAdHocTargetSelector(
       if (ImGui::Selectable(label, entry.target_id == targetId) &&
           !statsWindowHasStat(window, statId, targetId)) {
         entry.target_id = targetId;
+        scheduleUiConfigAutosave();
       }
       ImGui::PopStyleColor();
     }
@@ -11111,6 +11113,7 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
           if (ImGui::Selectable(label.c_str(), isSelected)) {
             window.selected_player_index = player.player_index;
             window.selected_player_id = webPlayerIdForIndex(window.selected_player_index);
+            scheduleUiConfigAutosave();
           }
         }
         ImGui::Separator();
@@ -11134,6 +11137,7 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
         ImGui::PushStyleColor(ImGuiCol_Text, toImVec4(color));
         if (ImGui::Selectable(label.c_str(), selected)) {
           window.selected_team_is_team_0 = isTeam0;
+          scheduleUiConfigAutosave();
         }
         ImGui::PopStyleColor();
       }
@@ -11151,6 +11155,7 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
         const bool selected = moduleName == window.module_name;
         if (ImGui::Selectable(moduleName.c_str(), selected)) {
           window.module_name = moduleName;
+          scheduleUiConfigAutosave();
         }
       }
       ImGui::EndCombo();
@@ -11161,20 +11166,26 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
 
 void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   if (window.kind == UiStatsWindowKind::StatsModule) {
-    ImGui::RadioButton(
-        std::format("Frame##module-view-{}", window.id).c_str(),
-        &window.module_view,
-        0);
+    if (ImGui::RadioButton(
+            std::format("Frame##module-view-{}", window.id).c_str(),
+            &window.module_view,
+            0)) {
+      scheduleUiConfigAutosave();
+    }
     ImGui::SameLine();
-    ImGui::RadioButton(
-        std::format("Module##module-view-{}", window.id).c_str(),
-        &window.module_view,
-        1);
+    if (ImGui::RadioButton(
+            std::format("Module##module-view-{}", window.id).c_str(),
+            &window.module_view,
+            1)) {
+      scheduleUiConfigAutosave();
+    }
     ImGui::SameLine();
-    ImGui::RadioButton(
-        std::format("Config##module-view-{}", window.id).c_str(),
-        &window.module_view,
-        2);
+    if (ImGui::RadioButton(
+            std::format("Config##module-view-{}", window.id).c_str(),
+            &window.module_view,
+            2)) {
+      scheduleUiConfigAutosave();
+    }
     ImGui::Separator();
     return;
   }
@@ -11214,11 +11225,13 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
           queryBuffer.data(),
           queryBuffer.size())) {
     window.picker_query = queryBuffer.data();
+    scheduleUiConfigAutosave();
   }
   if (!window.picker_query.empty()) {
     ImGui::SameLine();
     if (ImGui::SmallButton(std::format("Clear##stat-search-{}", window.id).c_str())) {
       window.picker_query.clear();
+      scheduleUiConfigAutosave();
     }
   }
 
@@ -11279,6 +11292,7 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
     const std::string label =
         std::format("Add all {} ({})##{}-{}", category, count, window.id, category);
     if (ImGui::SmallButton(label.c_str())) {
+      bool added = false;
       for (const UiStatDefinitionMatch &match : matches) {
         if (category != match.definition.category) {
           continue;
@@ -11288,7 +11302,11 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
                                                     : "";
         if (!statsWindowHasStat(window, match.definition.id, targetId)) {
           window.entries.push_back(UiStatsWindow::Entry{match.definition.id, targetId});
+          added = true;
         }
+      }
+      if (added) {
+        scheduleUiConfigAutosave();
       }
     }
   }
@@ -11321,9 +11339,11 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
         const std::string targetId = defaultAdHocTargetId(definition.id);
         if (!statsWindowHasStat(window, definition.id, targetId)) {
           window.entries.push_back(UiStatsWindow::Entry{definition.id, targetId});
+          scheduleUiConfigAutosave();
         }
       } else {
         window.entries.push_back(UiStatsWindow::Entry{definition.id, ""});
+        scheduleUiConfigAutosave();
       }
     }
   }
@@ -11409,6 +11429,7 @@ void SubtrActorPlugin::renderPlayerStatsTable(
     ImGui::NextColumn();
     if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
       window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
+      scheduleUiConfigAutosave();
       ImGui::Columns(1);
       return;
     }
@@ -11439,6 +11460,7 @@ void SubtrActorPlugin::renderTeamStatsTable(UiStatsWindow &window, uint8_t isTea
     ImGui::NextColumn();
     if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
       window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
+      scheduleUiConfigAutosave();
       ImGui::Columns(1);
       return;
     }
@@ -11496,6 +11518,7 @@ void SubtrActorPlugin::renderAllPlayersStatsTable(UiStatsWindow &window) {
           ImGui::NextColumn();
           if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
             window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
+            scheduleUiConfigAutosave();
             ImGui::Columns(1);
             ImGui::TreePop();
             ImGui::PopID();
@@ -11543,6 +11566,7 @@ void SubtrActorPlugin::renderAllTeamsStatsTable(UiStatsWindow &window) {
       if (ImGui::SmallButton(
               std::format("x##remove-stat-{}-{}-{}", window.id, isTeam0, i).c_str())) {
         window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
+        scheduleUiConfigAutosave();
         ImGui::Columns(1);
         return;
       }
@@ -11655,6 +11679,7 @@ void SubtrActorPlugin::renderAdHocStatsWindow(UiStatsWindow &window) {
     ImGui::NextColumn();
     if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
       window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
+      scheduleUiConfigAutosave();
       ImGui::Columns(1);
       return;
     }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3809,6 +3809,16 @@ std::string SubtrActorPlugin::uiConfigJson() {
         << ",\"viewport_height\":" << placement.viewport_height
         << ",\"zIndex\":" << placement.z_index << "}";
   };
+  auto writeStatsPlayerPlacement = [](
+                                       std::ostream &out,
+                                       const UiWindowPlacement &placement,
+                                       bool visible) {
+    out << "{\"x\":" << placement.x << ",\"y\":" << placement.y
+        << ",\"viewport\":{\"width\":" << placement.viewport_width
+        << ",\"height\":" << placement.viewport_height << "}"
+        << ",\"zIndex\":" << placement.z_index
+        << ",\"visible\":" << (visible ? "true" : "false") << "}";
+  };
   auto writeEnabledStringArray =
       [](std::ostream &out, std::initializer_list<std::pair<const char *, bool>> values) {
         out << "[";
@@ -4103,10 +4113,14 @@ std::string SubtrActorPlugin::uiConfigJson() {
   }
   file << "  },\n";
   file << "  \"singletonWindows\": [\n";
-  auto writeWindowConfig = [&](const SingletonWindowControl &window, bool last) {
+  auto writeWindowConfig = [&](const SingletonWindowControl &window, bool last, bool webConfig) {
     const bool visible = window.open != nullptr && *window.open;
     file << "    {\"id\":\"" << window.config_id << "\",\"placement\":";
-    writePlacement(file, *window.placement, visible);
+    if (webConfig) {
+      writeStatsPlayerPlacement(file, *window.placement, visible);
+    } else {
+      writePlacement(file, *window.placement, visible);
+    }
     file << "}";
     if (!last) {
       file << ",";
@@ -4122,12 +4136,12 @@ std::string SubtrActorPlugin::uiConfigJson() {
   }
   webWindows = webSingletonWindowControls();
   for (size_t index = 0; index < webWindows.size(); index += 1) {
-    writeWindowConfig(webWindows[index], index + 1 == webWindows.size());
+    writeWindowConfig(webWindows[index], index + 1 == webWindows.size(), true);
   }
   file << "  ],\n";
   file << "  \"pluginWindows\": [\n";
   for (size_t index = 0; index < pluginWindows.size(); index += 1) {
-    writeWindowConfig(pluginWindows[index], index + 1 == pluginWindows.size());
+    writeWindowConfig(pluginWindows[index], index + 1 == pluginWindows.size(), false);
   }
   file << "  ],\n";
   file << "  \"stats_windows\": [\n";

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -2510,6 +2510,24 @@ std::string SubtrActorPlugin::webPlayerIdForIndex(uint32_t playerIndex) const {
   return std::to_string(playerIndex);
 }
 
+std::optional<std::string> SubtrActorPlugin::webPlayerIdForIndexIfKnown(
+    uint32_t playerIndex) const {
+  const auto uniqueId = playerUniqueIdsByIndex.find(playerIndex);
+  if (uniqueId != playerUniqueIdsByIndex.end() && !uniqueId->second.empty()) {
+    return uniqueId->second;
+  }
+  const auto sampledPlayer = std::find_if(
+      sampledPlayers.begin(),
+      sampledPlayers.end(),
+      [playerIndex](const SaPlayerFrame &player) {
+        return player.player_index == playerIndex;
+      });
+  if (sampledPlayer != sampledPlayers.end()) {
+    return std::to_string(playerIndex);
+  }
+  return std::nullopt;
+}
+
 std::string SubtrActorPlugin::webPlayerIdForWindow(const UiStatsWindow &window) const {
   if (!window.selected_player_id.empty() &&
       !parseUnsignedIntegerString(window.selected_player_id)) {
@@ -2518,9 +2536,19 @@ std::string SubtrActorPlugin::webPlayerIdForWindow(const UiStatsWindow &window) 
   return webPlayerIdForIndex(window.selected_player_index);
 }
 
+std::optional<std::string> SubtrActorPlugin::webPlayerIdForWindowConfig(
+    const UiStatsWindow &window) const {
+  if (!window.selected_player_id.empty()) {
+    return window.selected_player_id;
+  }
+  return webPlayerIdForIndexIfKnown(window.selected_player_index);
+}
+
 void SubtrActorPlugin::resolveStatsWindowPlayerSelection(UiStatsWindow &window) {
   if (window.selected_player_id.empty()) {
-    window.selected_player_id = webPlayerIdForIndex(window.selected_player_index);
+    if (const auto playerId = webPlayerIdForIndexIfKnown(window.selected_player_index)) {
+      window.selected_player_id = *playerId;
+    }
     return;
   }
   if (const auto parsedPlayerIndex = parseUnsignedIntegerString(window.selected_player_id)) {
@@ -2539,6 +2567,13 @@ std::string SubtrActorPlugin::webCameraPlayerId() const {
     return cameraSelectedPlayerId;
   }
   return webPlayerIdForIndex(cameraSelectedPlayerIndex);
+}
+
+std::optional<std::string> SubtrActorPlugin::webCameraPlayerIdConfig() const {
+  if (!cameraSelectedPlayerId.empty()) {
+    return cameraSelectedPlayerId;
+  }
+  return webPlayerIdForIndexIfKnown(cameraSelectedPlayerIndex);
 }
 
 void SubtrActorPlugin::resolveCameraPlayerSelection() {
@@ -3984,7 +4019,11 @@ std::string SubtrActorPlugin::uiConfigJson() {
   }
   file << ",\"attachedPlayerId\":";
   if (cameraViewMode == 1) {
-    file << "\"" << escapeJsonString(webCameraPlayerId()) << "\"";
+    if (const auto attachedPlayerId = webCameraPlayerIdConfig()) {
+      file << "\"" << escapeJsonString(*attachedPlayerId) << "\"";
+    } else {
+      file << "null";
+    }
   } else {
     file << "null";
   }
@@ -4225,7 +4264,12 @@ std::string SubtrActorPlugin::uiConfigJson() {
          << statsWindowKindConfigId(window.kind)
          << "\",\"placement\":";
     writeStatsPlayerStatsWindowPlacement(file, window);
-    file << ",\"playerId\":\"" << escapeJsonString(webPlayerIdForWindow(window)) << "\"";
+    file << ",\"playerId\":";
+    if (const auto playerId = webPlayerIdForWindowConfig(window)) {
+      file << "\"" << escapeJsonString(*playerId) << "\"";
+    } else {
+      file << "null";
+    }
     file << ",\"team\":\"" << (window.selected_team_is_team_0 != 0 ? "blue" : "orange") << "\"";
     file << ",\"entries\":[";
     for (size_t j = 0; j < window.entries.size(); j += 1) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3819,6 +3819,15 @@ std::string SubtrActorPlugin::uiConfigJson() {
         << ",\"zIndex\":" << placement.z_index
         << ",\"visible\":" << (visible ? "true" : "false") << "}";
   };
+  auto writeStatsPlayerStatsWindowPlacement = [](
+                                                  std::ostream &out,
+                                                  const UiStatsWindow &window) {
+    out << "{\"x\":" << window.x << ",\"y\":" << window.y
+        << ",\"viewport\":{\"width\":" << window.viewport_width
+        << ",\"height\":" << window.viewport_height << "}"
+        << ",\"zIndex\":" << window.z_index
+        << ",\"visible\":" << (window.open ? "true" : "false") << "}";
+  };
   auto writeEnabledStringArray =
       [](std::ostream &out, std::initializer_list<std::pair<const char *, bool>> values) {
         out << "[";
@@ -4155,12 +4164,9 @@ std::string SubtrActorPlugin::uiConfigJson() {
          << escapeJsonString(window.config_id.empty() ? std::format("stats-{}", window.id)
                                                       : window.config_id)
          << "\""
-         << ",\"placement\":{\"x\":" << window.x << ",\"y\":" << window.y
-         << ",\"viewport\":{\"width\":" << window.viewport_width
-         << ",\"height\":" << window.viewport_height << "}"
-         << ",\"zIndex\":" << window.z_index
-         << ",\"visible\":" << (window.open ? "true" : "false") << "}"
-         << ",\"selected_player_index\":" << window.selected_player_index
+         << ",\"placement\":";
+    writeStatsPlayerStatsWindowPlacement(file, window);
+    file << ",\"selected_player_index\":" << window.selected_player_index
          << ",\"selected_player_id\":\"" << escapeJsonString(webPlayerIdForWindow(window)) << "\""
          << ",\"selected_team_is_team_0\":"
          << (window.selected_team_is_team_0 != 0 ? "true" : "false")
@@ -4207,11 +4213,8 @@ std::string SubtrActorPlugin::uiConfigJson() {
         window.config_id.empty() ? std::format("stats-{}", window.id) : window.config_id;
     file << "    {\"id\":\"" << escapeJsonString(configId) << "\",\"kind\":\""
          << statsWindowKindConfigId(window.kind)
-         << "\",\"placement\":{\"x\":" << window.x << ",\"y\":" << window.y
-         << ",\"viewport\":{\"width\":" << window.viewport_width
-         << ",\"height\":" << window.viewport_height << "}"
-         << ",\"zIndex\":" << window.z_index
-         << ",\"visible\":" << (window.open ? "true" : "false") << "}";
+         << "\",\"placement\":";
+    writeStatsPlayerStatsWindowPlacement(file, window);
     file << ",\"playerId\":\"" << escapeJsonString(webPlayerIdForWindow(window)) << "\"";
     file << ",\"team\":\"" << (window.selected_team_is_team_0 != 0 ? "blue" : "orange") << "\"";
     file << ",\"entries\":[";

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8211,62 +8211,11 @@ void SubtrActorPlugin::renderEventsWindow() {
     return;
   }
 
-  renderEventFilterCombo("Filter");
-  ImGui::SameLine();
-  if (ImGui::Button("Clear")) {
-    recentUiEvents.clear();
-    mechanicsReviewDecisions.clear();
-    mechanicsReviewIndex = 0;
-  }
-
   renderEventSourceControls();
-
-  size_t visibleCount = 0;
-  for (const UiEventRecord &event : recentUiEvents) {
-    if (uiEventVisible(event)) {
-      visibleCount += 1;
-    }
-  }
-  ImGui::Text("%zu visible / %zu recent", visibleCount, recentUiEvents.size());
-  ImGui::Separator();
-
-  ImGui::BeginChild("event-list", ImVec2{0.0f, 0.0f}, true);
-  ImGui::Columns(4, "event-columns", true);
-  ImGui::Text("Time");
-  ImGui::NextColumn();
-  ImGui::Text("Actor");
-  ImGui::NextColumn();
-  ImGui::Text("Event");
-  ImGui::NextColumn();
-  ImGui::Text("Details");
-  ImGui::NextColumn();
-  ImGui::Separator();
-
-  for (const UiEventRecord &event : recentUiEvents) {
-    if (!uiEventVisible(event)) {
-      continue;
-    }
-    ImGui::Text("%.2fs", event.time);
-    ImGui::NextColumn();
-    ImGui::TextColored(toImVec4(event.color), "%s", event.actor.c_str());
-    ImGui::NextColumn();
-    ImGui::TextWrapped("%s", event.label.c_str());
-    ImGui::NextColumn();
-    ImGui::TextWrapped("%s", event.details.c_str());
-    ImGui::NextColumn();
-  }
-
-  ImGui::Columns(1);
-  ImGui::EndChild();
   ImGui::End();
 }
 
 void SubtrActorPlugin::renderEventSourceControls() {
-  ImGui::SetNextItemOpen(true, ImGuiCond_FirstUseEver);
-  if (!ImGui::TreeNode("Event sources##event-source-controls")) {
-    return;
-  }
-
   const std::string currentFilter = cvarString("subtr_actor_overlay_event_types", "all");
   const bool allSelected = allEventSourcesSelected(currentFilter);
   std::vector<std::string> selected =
@@ -8302,41 +8251,31 @@ void SubtrActorPlugin::renderEventSourceControls() {
     displaySources.push_back(DisplaySource{&option, count, enabled});
   }
 
-  if (ImGui::SmallButton("All events##event-sources")) {
-    selected = selectedEventSourceTokens("all");
-    applySelection();
-  }
-  ImGui::SameLine();
-  if (ImGui::SmallButton("No events##event-sources")) {
-    selected.clear();
-    applySelection();
-  }
-  ImGui::SameLine();
-  const std::string preview =
-      eventFilterPreview(cvarString("subtr_actor_overlay_event_types", "all"));
-  ImGui::TextDisabled("%s", preview.c_str());
-  ImGui::TextDisabled("%zu loaded sources", displaySources.size());
-
-  ImGui::BeginChild("event-source-list", ImVec2{0.0f, 185.0f}, true);
   if (displaySources.empty()) {
     ImGui::TextDisabled("No events loaded.");
-    ImGui::EndChild();
-    ImGui::TreePop();
     return;
   }
 
-  std::string_view currentGroup;
+  if (renderModuleSummaryToggle(
+          "All events",
+          allSelected,
+          "event-sources-actions")) {
+    selected = selectedEventSourceTokens("all");
+    applySelection();
+  }
+  if (renderModuleSummaryToggle(
+          "No events",
+          selected.empty(),
+          "event-sources-actions")) {
+    selected.clear();
+    applySelection();
+  }
+
+  ImGui::Separator();
+  ImGui::BeginChild("event-source-list", ImVec2{0.0f, 0.0f}, true);
+
   for (const DisplaySource &source : displaySources) {
     const EventFilterOption &option = *source.option;
-    const std::string_view optionGroup{option.group};
-    if (currentGroup != optionGroup) {
-      if (!currentGroup.empty()) {
-        ImGui::Separator();
-      }
-      ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", option.group);
-      currentGroup = optionGroup;
-    }
-
     ImGui::PushID(option.value);
     bool enabled = source.enabled;
     const std::string label = std::format("{} ({})", option.label, source.count);
@@ -8353,7 +8292,6 @@ void SubtrActorPlugin::renderEventSourceControls() {
     ImGui::PopID();
   }
   ImGui::EndChild();
-  ImGui::TreePop();
 }
 
 bool SubtrActorPlugin::eventPlaylistSourceEnabled(const UiEventRecord &event) const {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8702,7 +8702,11 @@ void SubtrActorPlugin::renderEventSourceControls() {
 
   if (renderEventSourceAction(
           std::format("All events   {}##event-sources-actions-all", displaySources.size()))) {
-    selected = selectedEventSourceTokens("all");
+    selected.clear();
+    selected.reserve(displaySources.size());
+    for (const DisplaySource &source : displaySources) {
+      selected.emplace_back(source.option->value);
+    }
     applySelection();
   }
   if (renderEventSourceAction("No events   Off##event-sources-actions-none")) {
@@ -8890,7 +8894,12 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
 
   if (filtersOpen) {
     if (ImGui::Button("All##event-playlist-sources-all")) {
-      eventPlaylistSourceFilter = "all";
+      selectedSources.clear();
+      selectedSources.reserve(playlistSources.size());
+      for (const PlaylistSource &source : playlistSources) {
+        selectedSources.emplace_back(source.option->value);
+      }
+      eventPlaylistSourceFilter = eventFilterFromSelectedSources(selectedSources);
       eventPlaylistLastActiveKey.clear();
       scheduleUiConfigAutosave();
     }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9411,19 +9411,10 @@ void SubtrActorPlugin::renderCameraWindow() {
     scheduleUiConfigAutosave();
   }
 
-  bool nextBallCamEnabled = cameraBallCamEnabled;
-  pushCameraDisabledStyle(!hasAttachedCamera);
-  const bool ballCamChanged = ImGui::Checkbox("Ball cam", &nextBallCamEnabled);
-  popCameraDisabledStyle(!hasAttachedCamera);
-  if (hasAttachedCamera && ballCamChanged) {
-    cameraBallCamEnabled = nextBallCamEnabled;
-    scheduleUiConfigAutosave();
-  }
-
   bool nextCustomSettingsEnabled = cameraCustomSettingsEnabled;
   pushCameraDisabledStyle(!hasAttachedCamera);
   const bool customSettingsChanged =
-      ImGui::Checkbox("Custom settings", &nextCustomSettingsEnabled);
+      ImGui::Checkbox("Custom camera settings", &nextCustomSettingsEnabled);
   popCameraDisabledStyle(!hasAttachedCamera);
   if (hasAttachedCamera && customSettingsChanged) {
     cameraCustomSettingsEnabled = nextCustomSettingsEnabled;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -4198,12 +4198,7 @@ std::string SubtrActorPlugin::uiConfigJson() {
          << ",\"height\":" << window.viewport_height << "}"
          << ",\"zIndex\":" << window.z_index
          << ",\"visible\":" << (window.open ? "true" : "false") << "}";
-    file << ",\"playerId\":";
-    if (window.kind == UiStatsWindowKind::Player) {
-      file << "\"" << escapeJsonString(webPlayerIdForWindow(window)) << "\"";
-    } else {
-      file << "null";
-    }
+    file << ",\"playerId\":\"" << escapeJsonString(webPlayerIdForWindow(window)) << "\"";
     file << ",\"team\":\"" << (window.selected_team_is_team_0 != 0 ? "blue" : "orange") << "\"";
     file << ",\"entries\":[";
     for (size_t j = 0; j < window.entries.size(); j += 1) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10601,7 +10601,6 @@ void SubtrActorPlugin::createStatsWindow(UiStatsWindowKind kind, bool initialize
   window.config_id = std::format("stats-{}", window.id);
   window.kind = kind;
   initializeStatsWindowPlacement(window);
-  focusStatsWindow(window);
   if (kind == UiStatsWindowKind::StatsModule) {
     const std::vector<std::string> &moduleNames = statsModuleNames();
     if (!moduleNames.empty()) {
@@ -10628,7 +10627,6 @@ void SubtrActorPlugin::createStatsModuleWindow(std::string moduleName, int modul
   window.module_name = std::move(moduleName);
   window.module_view = std::clamp(moduleView, 0, 2);
   initializeStatsWindowPlacement(window);
-  focusStatsWindow(window);
   uiStatsWindows.push_back(std::move(window));
   scheduleUiConfigAutosave();
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11782,6 +11782,11 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   ImGui::Separator();
 }
 
+void renderStatsWindowEmpty(std::string_view message) {
+  ImGui::Spacing();
+  ImGui::TextDisabled("%s", std::string{message}.c_str());
+}
+
 void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
   if (window.kind == UiStatsWindowKind::StatsModule) {
     renderStatsModuleWindow(window);
@@ -11800,7 +11805,7 @@ void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
         return statsWindowSupportsStat(window, entry.stat_id);
       });
   if (!hasSupportedEntries) {
-    ImGui::Text("No stats added.");
+    renderStatsWindowEmpty("No stats added.");
     return;
   }
 
@@ -11814,7 +11819,7 @@ void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
     break;
   case UiStatsWindowKind::Team:
     if (sampledPlayers.empty() && currentStatsJson().empty()) {
-      ImGui::Text("Load a replay to show stats.");
+      renderStatsWindowEmpty("Load a replay to show stats.");
       break;
     }
     renderTeamStatsTable(window, window.selected_team_is_team_0);
@@ -11824,7 +11829,7 @@ void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
     break;
   case UiStatsWindowKind::AllTeams:
     if (sampledPlayers.empty() && currentStatsJson().empty()) {
-      ImGui::Text("Load a replay to show stats.");
+      renderStatsWindowEmpty("Load a replay to show stats.");
       break;
     }
     renderAllTeamsStatsTable(window);
@@ -11928,7 +11933,7 @@ void SubtrActorPlugin::renderTeamStatsTable(UiStatsWindow &window, uint8_t isTea
 
 void SubtrActorPlugin::renderAllPlayersStatsTable(UiStatsWindow &window) {
   if (sampledPlayers.empty()) {
-    ImGui::Text("Load a replay to show stats.");
+    renderStatsWindowEmpty("Load a replay to show stats.");
     return;
   }
 
@@ -12078,7 +12083,11 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
     ImGui::PopID();
   }
   if (goalEventIndexes.empty()) {
-    ImGui::Text("No goals loaded.");
+    if (!replayAnnotations && (!gameWrapper || !gameWrapper->IsInReplay())) {
+      renderStatsWindowEmpty("Load a replay to show goal labels.");
+    } else {
+      renderStatsWindowEmpty("No goals loaded.");
+    }
   }
 }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7889,7 +7889,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
   renderWebWindowToggleControls("launcher-web-windows", true, false, true);
-  renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);
+  renderStatsWindowCreationControls("launcher-stats-windows", true, false, false, true);
 
   ImGui::Separator();
   renderModuleSummaryControls("launcher-module-summary", false, 0.0f);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11321,7 +11321,9 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
     const SaPlayerFrame *selected = sampledPlayerByIndex(window.selected_player_index);
     const std::string selectedLabel =
         selected ? playerLabel(selected->player_index, selected->is_team_0) : "Select player";
-    if (ImGui::BeginCombo("Player", selectedLabel.c_str())) {
+    if (ImGui::BeginCombo(
+            std::format("##stats-window-player-scope-{}", window.id).c_str(),
+            selectedLabel.c_str())) {
       for (uint8_t isTeam0 : {uint8_t{1}, uint8_t{0}}) {
         const bool hasTeamPlayers = std::any_of(
             sampledPlayers.begin(),
@@ -11358,7 +11360,9 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
 
   if (window.kind == UiStatsWindowKind::Team) {
     const char *selectedTeam = window.selected_team_is_team_0 != 0 ? "Blue" : "Orange";
-    if (ImGui::BeginCombo("Team", selectedTeam)) {
+    if (ImGui::BeginCombo(
+            std::format("##stats-window-team-scope-{}", window.id).c_str(),
+            selectedTeam)) {
       for (uint8_t isTeam0 : {uint8_t{1}, uint8_t{0}}) {
         const LinearColor color =
             isTeam0 != 0 ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255};

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9233,8 +9233,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     const bool active = i == static_cast<size_t>(mechanicsReviewIndex);
     const std::string title = mechanicsReviewItemTitle(event, i);
     const std::string label = std::format(
-        "{}  {}##mechanics-review-item",
-        formatEventPlaylistTime(event.time),
+        "{}##mechanics-review-item",
         title);
     if (ImGui::Selectable(label.c_str(), active)) {
       mechanicsReviewIndex = static_cast<int>(i);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3702,7 +3702,7 @@ void SubtrActorPlugin::applyUiConfigJson(
   cameraSelectedPlayerIndex = static_cast<uint32_t>(
       std::max(0.0, parseJsonNumberProperty(json, "camera_selected_player_index").value_or(0.0)));
   cameraDistanceScale = static_cast<float>(std::clamp(
-      parseJsonNumberProperty(json, "camera_distance_scale").value_or(1.0),
+      parseJsonNumberProperty(json, "camera_distance_scale").value_or(cameraDistanceScale),
       0.75,
       4.0));
   cameraCustomSettingsEnabled =

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7715,13 +7715,6 @@ void SubtrActorPlugin::renderStatsWindowCreationControls(
       }
     }
   }
-  if (!statsModuleNames().empty() &&
-      ImGui::Button("New stats module", ImVec2{170.0f, 0.0f})) {
-    createStatsWindow(UiStatsWindowKind::StatsModule);
-    if (closeLauncherOnCreate) {
-      hideLauncherWindow();
-    }
-  }
   if (uiStatsWindows.empty()) {
     ImGui::PopID();
     return;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9181,41 +9181,6 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
     return;
   }
 
-  const int activePadTypes = static_cast<int>(boostPickupPadBig) +
-                             static_cast<int>(boostPickupPadSmall) +
-                             static_cast<int>(boostPickupPadAmbiguous);
-  const int activeActivities = static_cast<int>(boostPickupActivityActive) +
-                               static_cast<int>(boostPickupActivityInactive) +
-                               static_cast<int>(boostPickupActivityUnknown);
-  const int activeFieldHalves = static_cast<int>(boostPickupFieldOwn) +
-                                static_cast<int>(boostPickupFieldOpponent) +
-                                static_cast<int>(boostPickupFieldUnknown);
-  const size_t activePlayers =
-      boostPickupPlayerFilterEnabled ? boostPickupPlayerIds.size() : sampledPlayers.size();
-  const bool hidden =
-      activePadTypes == 0 || activeActivities == 0 || activeFieldHalves == 0 ||
-      (boostPickupPlayerFilterEnabled && boostPickupPlayerIds.empty());
-  const int constrainedGroups = static_cast<int>(activePadTypes < 3) +
-                                static_cast<int>(activeActivities < 3) +
-                                static_cast<int>(activeFieldHalves < 3) +
-                                static_cast<int>(
-                                    boostPickupPlayerFilterEnabled &&
-                                    activePlayers < sampledPlayers.size());
-  const std::string pickupReadout =
-      hidden ? "Hidden"
-             : constrainedGroups == 0 ? "All labels"
-                                      : std::format("{} filters", constrainedGroups);
-
-  ImGui::Text("Pickup labels: %s", pickupReadout.c_str());
-  ImGui::Text("Known pads: %zu", boostPadIds.size());
-  ImGui::Text("Pending pad events: %zu", pendingBoostPadEvents.size());
-  ImGui::Text("Recent boost pickups: %d", recentEventCountForType("boost_pickup"));
-
-  ImGui::Separator();
-  if (ImGui::Checkbox("Boost pickup animation", &boostPickupAnimationEnabled)) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::Separator();
   if (ImGui::Button("All filters")) {
     boostPickupPadBig = true;
     boostPickupPadSmall = true;
@@ -9247,7 +9212,7 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
   }
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PAD TYPE");
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Pad type");
   if (ImGui::Checkbox("Big pads", &boostPickupPadBig)) {
     scheduleUiConfigAutosave();
   }
@@ -9260,7 +9225,7 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
   }
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ACTIVITY");
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Activity");
   if (ImGui::Checkbox("Active play", &boostPickupActivityActive)) {
     scheduleUiConfigAutosave();
   }
@@ -9273,7 +9238,7 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
   }
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "FIELD HALF");
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Field half");
   if (ImGui::Checkbox("Own half", &boostPickupFieldOwn)) {
     scheduleUiConfigAutosave();
   }
@@ -9287,7 +9252,7 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
 
   if (!sampledPlayers.empty()) {
     ImGui::Separator();
-    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PLAYER");
+    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Player");
     if (ImGui::Button("All players")) {
       boostPickupPlayerFilterEnabled = false;
       boostPickupPlayerIds.clear();
@@ -9327,28 +9292,6 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
         scheduleUiConfigAutosave();
       }
     }
-  }
-
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ACTIONS");
-  if (ImGui::Button("Show boost pickups")) {
-    setCvarString("subtr_actor_overlay_event_types", "boost_pickup");
-    showSingletonWindow(uiEventPlaylistOpen, eventPlaylistPlacement);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Open boost stats")) {
-    createStatsModuleWindow("boost", 0);
-  }
-  if (ImGui::Button("Inspect boost nodes")) {
-    graphInspectorView = 1;
-    graphInspectorNodeQuery = "boost";
-    showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Boost output")) {
-    graphInspectorView = 0;
-    selectedGraphOutput = "events";
-    showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
   }
 
   ImGui::End();
@@ -9392,18 +9335,22 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
     return readout.empty() ? std::string{"Total only"} : readout;
   };
 
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "TOUCH MARKERS");
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Touch markers");
+  ImGui::Text("Touch decay");
   ImGui::SameLine();
   ImGui::TextColored(
       ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
       "%.1fs",
       touchMarkerDecaySeconds);
+  ImGui::TextDisabled("Keep each marker visible after the touch");
   if (ImGui::SliderFloat(
           "Marker decay seconds", &touchMarkerDecaySeconds, 1.0f, 10.0f, "%.1fs")) {
     scheduleUiConfigAutosave();
   }
 
-  ImGui::TextDisabled("Touch mode");
+  ImGui::Separator();
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Overlay");
+  ImGui::Text("Touch mode");
   ImGui::SameLine();
   ImGui::TextColored(
       ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
@@ -9420,7 +9367,8 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
   }
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STAT BREAKDOWN");
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Stat display");
+  ImGui::Text("Touch breakdown");
   ImGui::SameLine();
   ImGui::TextColored(
       ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
@@ -9439,43 +9387,6 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
   ImGui::SameLine();
   if (ImGui::Checkbox("Dodge", &touchBreakdownDodge)) {
     scheduleUiConfigAutosave();
-  }
-
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "LIVE TOUCH STATE");
-  if (lastTouch) {
-    ImGui::Text(
-        "Last touch: %s",
-        playerLabel(lastTouch->player_index, lastTouch->is_team_0).c_str());
-  } else {
-    ImGui::Text("Last touch: --");
-  }
-  ImGui::Text("Pending touches: %zu", pendingTouches.size());
-  ImGui::Text("Pending dodge refreshes: %zu", pendingDodgeRefreshes.size());
-  ImGui::Text("Recent touch events: %d", recentEventCountForType("touch"));
-  ImGui::Text(
-      "Recent touch movement: %d",
-      recentEventCountForType("touch_ball_movement"));
-
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ACTIONS");
-  if (ImGui::Button("Show touches")) {
-    setCvarString("subtr_actor_overlay_event_types", "touch");
-    showSingletonWindow(uiEventPlaylistOpen, eventPlaylistPlacement);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Show movement")) {
-    setCvarString("subtr_actor_overlay_event_types", "touch_ball_movement");
-    showSingletonWindow(uiEventPlaylistOpen, eventPlaylistPlacement);
-  }
-  if (ImGui::Button("Open touch stats")) {
-    createStatsModuleWindow("touch", 0);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Inspect touch nodes")) {
-    graphInspectorView = 1;
-    graphInspectorNodeQuery = "touch";
-    showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
   }
 
   ImGui::End();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7568,6 +7568,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   for (const SingletonWindowControl &window : webSingletonWindowControls()) {
     renderLauncherWindowToggle(window);
   }
+  renderSingletonWindowManager();
 
   ImGui::Separator();
   renderLauncherStatsWindowControls();
@@ -7626,14 +7627,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
     if (ImGui::Button("Close launcher", ImVec2{170.0f, 0.0f})) {
       uiLauncherOpen = false;
     }
-
-    ImGui::Separator();
-    for (const SingletonWindowControl &window : singletonWindowControls()) {
-      if (!window.web_config) {
-        renderLauncherWindowToggle(window);
-      }
-    }
-    renderSingletonWindowManager();
 
     ImGui::Separator();
     renderSharedSettingsControls();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3592,6 +3592,12 @@ void SubtrActorPlugin::applyUiConfigJson(
         boostPickupFieldOpponent = containsString(fieldHalves, "opponent");
         boostPickupFieldUnknown = containsString(fieldHalves, "unknown");
       }
+      if (jsonPropertyExists(*boostConfig, "playerIds")) {
+        boostPickupPlayerFilterEnabled = !jsonPropertyIsNull(*boostConfig, "playerIds");
+        boostPickupPlayerIds = boostPickupPlayerFilterEnabled
+                                   ? parseJsonStringArrayProperty(*boostConfig, "playerIds")
+                                   : std::vector<std::string>{};
+      }
     }
     if (const auto touchConfig = parseJsonObjectProperty(*moduleConfigs, "touch")) {
       touchMarkerDecaySeconds = static_cast<float>(std::clamp(
@@ -3920,6 +3926,16 @@ std::string SubtrActorPlugin::uiConfigJson() {
         }
         out << "]";
       };
+  auto writeStringArray = [](std::ostream &out, const std::vector<std::string> &values) {
+    out << "[";
+    for (size_t index = 0; index < values.size(); ++index) {
+      if (index > 0) {
+        out << ",";
+      }
+      out << "\"" << escapeJsonString(values[index]) << "\"";
+    }
+    out << "]";
+  };
 
   std::ostringstream file;
   file << "{\n";
@@ -4093,7 +4109,13 @@ std::string SubtrActorPlugin::uiConfigJson() {
       {{"own", boostPickupFieldOwn},
        {"opponent", boostPickupFieldOpponent},
        {"unknown", boostPickupFieldUnknown}});
-  file << ",\"playerIds\":null},\n";
+  file << ",\"playerIds\":";
+  if (boostPickupPlayerFilterEnabled) {
+    writeStringArray(file, boostPickupPlayerIds);
+  } else {
+    file << "null";
+  }
+  file << "},\n";
   file << "    \"touch\": {\"decaySeconds\":" << touchMarkerDecaySeconds
        << ",\"overlayMode\":\"" << (touchControlsMode == 0 ? "markers" : "advancement")
        << "\",\"breakdownClasses\":";
@@ -9107,11 +9129,17 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
   const int activeFieldHalves = static_cast<int>(boostPickupFieldOwn) +
                                 static_cast<int>(boostPickupFieldOpponent) +
                                 static_cast<int>(boostPickupFieldUnknown);
+  const size_t activePlayers =
+      boostPickupPlayerFilterEnabled ? boostPickupPlayerIds.size() : sampledPlayers.size();
   const bool hidden =
-      activePadTypes == 0 || activeActivities == 0 || activeFieldHalves == 0;
+      activePadTypes == 0 || activeActivities == 0 || activeFieldHalves == 0 ||
+      (boostPickupPlayerFilterEnabled && boostPickupPlayerIds.empty());
   const int constrainedGroups = static_cast<int>(activePadTypes < 3) +
                                 static_cast<int>(activeActivities < 3) +
-                                static_cast<int>(activeFieldHalves < 3);
+                                static_cast<int>(activeFieldHalves < 3) +
+                                static_cast<int>(
+                                    boostPickupPlayerFilterEnabled &&
+                                    activePlayers < sampledPlayers.size());
   const std::string pickupReadout =
       hidden ? "Hidden"
              : constrainedGroups == 0 ? "All labels"
@@ -9137,6 +9165,8 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
     boostPickupFieldOwn = true;
     boostPickupFieldOpponent = true;
     boostPickupFieldUnknown = true;
+    boostPickupPlayerFilterEnabled = false;
+    boostPickupPlayerIds.clear();
     scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
@@ -9150,6 +9180,8 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
     boostPickupFieldOwn = false;
     boostPickupFieldOpponent = false;
     boostPickupFieldUnknown = false;
+    boostPickupPlayerFilterEnabled = true;
+    boostPickupPlayerIds.clear();
     scheduleUiConfigAutosave();
   }
 
@@ -9190,6 +9222,50 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
   }
   if (ImGui::Checkbox("Unknown half", &boostPickupFieldUnknown)) {
     scheduleUiConfigAutosave();
+  }
+
+  if (!sampledPlayers.empty()) {
+    ImGui::Separator();
+    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PLAYER");
+    if (ImGui::Button("All players")) {
+      boostPickupPlayerFilterEnabled = false;
+      boostPickupPlayerIds.clear();
+      scheduleUiConfigAutosave();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("No players")) {
+      boostPickupPlayerFilterEnabled = true;
+      boostPickupPlayerIds.clear();
+      scheduleUiConfigAutosave();
+    }
+    for (const SaPlayerFrame &player : sampledPlayers) {
+      const std::string playerId = webPlayerIdForIndex(player.player_index);
+      bool selected =
+          !boostPickupPlayerFilterEnabled || containsString(boostPickupPlayerIds, playerId);
+      const std::string label = std::format(
+          "{}##boost-pickup-player-{}",
+          playerLabel(player.player_index, player.is_team_0),
+          player.player_index);
+      if (ImGui::Checkbox(label.c_str(), &selected)) {
+        if (!boostPickupPlayerFilterEnabled) {
+          boostPickupPlayerIds.clear();
+          for (const SaPlayerFrame &candidate : sampledPlayers) {
+            boostPickupPlayerIds.push_back(webPlayerIdForIndex(candidate.player_index));
+          }
+          boostPickupPlayerFilterEnabled = true;
+        }
+        if (selected) {
+          if (!containsString(boostPickupPlayerIds, playerId)) {
+            boostPickupPlayerIds.push_back(playerId);
+          }
+        } else {
+          boostPickupPlayerIds.erase(
+              std::remove(boostPickupPlayerIds.begin(), boostPickupPlayerIds.end(), playerId),
+              boostPickupPlayerIds.end());
+        }
+        scheduleUiConfigAutosave();
+      }
+    }
   }
 
   ImGui::Separator();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7835,8 +7835,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   renderModuleSummaryControls("launcher-module-summary", false);
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "MODULE SETTINGS");
-  renderModuleSettingsControls("launcher-module-settings", true);
+  renderModuleSettingsControls("launcher-module-settings", false);
 
   if (ImGui::TreeNode("Plugin tools##launcher-plugin-tools")) {
     if (ImGui::Button("Verify graph", ImVec2{170.0f, 0.0f})) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -6711,14 +6711,16 @@ void SubtrActorPlugin::Render() {
     ImGui::SetCurrentContext(reinterpret_cast<ImGuiContext *>(imguiContext));
   }
 
-  renderLauncherToggleChrome();
-  renderLauncherWindow();
   if (!uiEnabled()) {
+    renderLauncherToggleChrome();
+    renderLauncherWindow();
     return;
   }
 
   renderEmptyStateWindow();
   renderFloatingWindowLayer();
+  renderLauncherToggleChrome();
+  renderLauncherWindow();
   maybeAutosaveUiConfig();
 }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -2861,6 +2861,11 @@ void SubtrActorPlugin::onLoad() {
       },
       "Toggles the subtr-actor in-game launcher window.",
       PERMISSION_ALL);
+  cvarManager->registerNotifier(
+      "subtr_actor_apply_ui_config",
+      [this](std::vector<std::string> params) { applyUiConfigParams(std::move(params)); },
+      "Applies a subtr-actor UI config. Usage: subtr_actor_apply_ui_config <json|cfg|url>",
+      PERMISSION_ALL);
   hookGameEvents();
 
   cvarManager->log("subtr-actor: mechanic overlay loaded");
@@ -3235,6 +3240,27 @@ void SubtrActorPlugin::loadUiConfig() {
 
   const std::string json((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
   applyUiConfigJson(json, path.string());
+}
+
+void SubtrActorPlugin::applyUiConfigParams(std::vector<std::string> params) {
+  if (params.size() < 2) {
+    cvarManager->log(
+        "subtr-actor: usage: subtr_actor_apply_ui_config <json|cfg|stats-player-url>");
+    return;
+  }
+
+  std::vector<std::string> configParts(params.begin() + 1, params.end());
+  const std::string configText = joinStrings(configParts, " ");
+  if (const std::optional<std::string> configJson =
+          statsPlayerCfgJsonFromClipboard(configText)) {
+    applyUiConfigJson(*configJson, "console");
+    saveUiConfig();
+    cvarManager->log("subtr-actor: applied UI config from console");
+    return;
+  }
+
+  cvarManager->log(
+      "subtr-actor: console argument does not contain UI config JSON or a stats-player cfg value");
 }
 
 void SubtrActorPlugin::applyUiConfigJson(

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1032,6 +1032,29 @@ std::string clippedDisplayText(std::string value, size_t maxBytes = 24000) {
   return value;
 }
 
+std::string formatGraphStatNumber(double value) {
+  if (!std::isfinite(value)) {
+    return "--";
+  }
+  if (std::trunc(value) == value) {
+    return std::format("{:.0f}", value);
+  }
+
+  double rounded = std::round(value * 1000.0) / 1000.0;
+  if (rounded == 0.0) {
+    rounded = 0.0;
+  }
+
+  std::string formatted = std::format("{:.3f}", rounded);
+  while (!formatted.empty() && formatted.back() == '0') {
+    formatted.pop_back();
+  }
+  if (!formatted.empty() && formatted.back() == '.') {
+    formatted.pop_back();
+  }
+  return formatted.empty() ? "--" : formatted;
+}
+
 std::string formatByteSize(size_t bytes) {
   constexpr double KIB = 1024.0;
   constexpr double MIB = KIB * 1024.0;
@@ -1208,6 +1231,56 @@ std::vector<std::string_view> dotPathSegments(std::string_view path) {
   return segments;
 }
 
+std::string formatGraphStatJsonValueAt(const std::string &json, size_t offset) {
+  skipJsonWhitespace(json, offset);
+  if (offset >= json.size()) {
+    return "--";
+  }
+
+  if (json.compare(offset, 4, "null") == 0) {
+    return "--";
+  }
+  if (json.compare(offset, 4, "true") == 0) {
+    return "true";
+  }
+  if (json.compare(offset, 5, "false") == 0) {
+    return "false";
+  }
+
+  if (json[offset] == '"') {
+    auto value = parseJsonString(json, offset);
+    return value ? clippedDisplayText(*value, 240) : "--";
+  }
+
+  if (json[offset] == '[') {
+    const auto count = parseJsonArrayElementCountAt(json, offset);
+    if (count && *count == 0) {
+      return "[]";
+    }
+    const size_t start = offset;
+    size_t end = offset;
+    if (!skipJsonValue(json, end)) {
+      return "--";
+    }
+    return clippedDisplayText(json.substr(start, end - start), 240);
+  }
+
+  if (json[offset] == '{') {
+    return "object";
+  }
+
+  const size_t start = offset;
+  size_t end = offset;
+  if (!skipJsonValue(json, end)) {
+    return "--";
+  }
+  try {
+    return formatGraphStatNumber(std::stod(json.substr(start, end - start)));
+  } catch (...) {
+    return "--";
+  }
+}
+
 std::optional<std::string> jsonDisplayValueAtPath(
     const std::string &json,
     std::string_view path) {
@@ -1222,7 +1295,7 @@ std::optional<std::string> jsonDisplayValueAtPath(
       return std::nullopt;
     }
     if (index + 1 == segments.size()) {
-      return summarizeJsonValueAt(*value, 0);
+      return formatGraphStatJsonValueAt(*value, 0);
     }
     size_t offset = 0;
     skipJsonWhitespace(*value, offset);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3448,6 +3448,7 @@ void SubtrActorPlugin::applyUiConfigJson(
       recordingPlaybackRateIndex = recordingPlaybackRateIndexForValue(*playbackRate);
     }
   }
+  bool applyPlaybackConfig = false;
   if (const auto playback = parseJsonObjectProperty(json, "playback")) {
     playbackCurrentTime = static_cast<float>(std::max(
         0.0,
@@ -3461,6 +3462,7 @@ void SubtrActorPlugin::applyUiConfigJson(
     playbackSkipKickoffs =
         parseJsonBoolProperty(*playback, "skipKickoffs").value_or(playbackSkipKickoffs);
     playbackStatus = parseJsonStringProperty(*playback, "status").value_or(playbackStatus);
+    applyPlaybackConfig = true;
   }
   touchControlsMode = static_cast<int>(
       std::clamp(
@@ -3775,6 +3777,9 @@ void SubtrActorPlugin::applyUiConfigJson(
         sourceLabel));
   }
   focusTopLoadedWindow();
+  if (applyPlaybackConfig) {
+    applyPlaybackConfigToReplay(sourceLabel);
+  }
   lastSavedUiConfigJson = uiConfigJson();
   nextUiConfigAutosave = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 }
@@ -9166,6 +9171,41 @@ void SubtrActorPlugin::renderCameraWindow() {
   }
 
   ImGui::End();
+}
+
+void SubtrActorPlugin::applyPlaybackConfigToReplay(std::string_view sourceLabel) {
+  if (!gameWrapper || !gameWrapper->IsInReplay()) {
+    playbackStatus = std::format("Loaded playback config from {}", sourceLabel);
+    return;
+  }
+
+  ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
+  if (replayServer.IsNull()) {
+    playbackStatus =
+        std::format("Loaded playback config from {}; replay controls unavailable", sourceLabel);
+    return;
+  }
+
+  mechanicsReviewClipActive = false;
+  playbackCurrentTime = std::max(0.0f, playbackCurrentTime);
+  if (playbackPlaying) {
+    replayServer.StartPlaybackAtTime(playbackCurrentTime);
+    playbackStatus = std::format(
+        "Applied {} playback config: playing from {:.2f}s",
+        sourceLabel,
+        playbackCurrentTime);
+    return;
+  }
+
+  replayServer.SkipToTime(playbackCurrentTime);
+  ReplayWrapper replay = replayServer.GetReplay();
+  if (!replay.IsNull()) {
+    replay.StopPlayback();
+  }
+  playbackStatus = std::format(
+      "Applied {} playback config: paused at {:.2f}s",
+      sourceLabel,
+      playbackCurrentTime);
 }
 
 void SubtrActorPlugin::renderPlaybackControlsWindow() {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7605,18 +7605,18 @@ void SubtrActorPlugin::renderModuleSummaryControls(
         idSuffix,
         toggleWidth);
     renderBoolModuleSummaryToggle(
-        "Possession timeline",
+        "Possession",
         timelineRangePossessionEnabled,
         idSuffix,
         toggleWidth);
     renderBoolModuleSummaryToggle(
-        "Half control timeline",
+        "Half control",
         timelineRangePressureEnabled,
         idSuffix,
         toggleWidth);
-    renderBoolModuleSummaryToggle("Rush timeline", timelineRangeRushEnabled, idSuffix, toggleWidth);
+    renderBoolModuleSummaryToggle("Rush", timelineRangeRushEnabled, idSuffix, toggleWidth);
     renderBoolModuleSummaryToggle(
-        "Position zones timeline",
+        "Position zones",
         timelineRangeAbsolutePositioningEnabled,
         idSuffix,
         toggleWidth);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -6717,6 +6717,7 @@ void SubtrActorPlugin::Render() {
     return;
   }
 
+  renderEmptyStateWindow();
   renderScoreboardWindow();
   renderEventsWindow();
   renderStatusWindow();
@@ -7569,6 +7570,48 @@ void SubtrActorPlugin::renderLauncherWindow() {
   }
 
   ImGui::End();
+}
+
+void SubtrActorPlugin::renderEmptyStateWindow() {
+  if (uiLauncherOpen || uiReplayLoadingOpen || liveProcessingEnabled() || replayAnnotations ||
+      !sampledPlayers.empty()) {
+    return;
+  }
+
+  const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+  ImGui::SetNextWindowPos(
+      ImVec2{displaySize.x * 0.5f, displaySize.y * 0.5f},
+      ImGuiCond_Always,
+      ImVec2{0.5f, 0.5f});
+  ImGui::SetNextWindowBgAlpha(0.88f);
+  constexpr ImGuiWindowFlags emptyStateFlags =
+      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize |
+      ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings;
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{18.0f, 14.0f});
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f);
+  if (!ImGui::Begin("subtr-actor empty state##subtr-actor", nullptr, emptyStateFlags)) {
+    ImGui::End();
+    ImGui::PopStyleVar(2);
+    return;
+  }
+
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "subtr-actor");
+  ImGui::TextUnformatted("Load a replay to start.");
+  if (ImGui::Button("Load Replay...", ImVec2{150.0f, 0.0f})) {
+    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
+    resetReplayAnnotations();
+    tickReplayAnnotations();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Start live analysis", ImVec2{150.0f, 0.0f})) {
+    setCvarBool("subtr_actor_enabled", true);
+  }
+  if (ImGui::Button("Open menu", ImVec2{150.0f, 0.0f})) {
+    showSingletonWindow(uiLauncherOpen, launcherPlacement);
+  }
+
+  ImGui::End();
+  ImGui::PopStyleVar(2);
 }
 
 void SubtrActorPlugin::renderScoreboardWindow() {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11608,12 +11608,12 @@ void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
     if (const SaPlayerFrame *player = sampledPlayerByIndex(window.selected_player_index)) {
       renderPlayerStatsTable(window, *player);
     } else {
-      ImGui::Text("Waiting for selected player.");
+      renderMissingStatsRows(window);
     }
     break;
   case UiStatsWindowKind::Team:
     if (sampledPlayers.empty() && currentStatsJson().empty()) {
-      ImGui::TextWrapped("Start live analysis or load replay stats to show team stats.");
+      ImGui::Text("Load a replay to show stats.");
       break;
     }
     renderTeamStatsTable(window, window.selected_team_is_team_0);
@@ -11623,7 +11623,7 @@ void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
     break;
   case UiStatsWindowKind::AllTeams:
     if (sampledPlayers.empty() && currentStatsJson().empty()) {
-      ImGui::TextWrapped("Start live analysis or load replay stats to show team stats.");
+      ImGui::Text("Load a replay to show stats.");
       break;
     }
     renderAllTeamsStatsTable(window);
@@ -11638,14 +11638,41 @@ void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
   }
 }
 
+void SubtrActorPlugin::renderMissingStatsRows(UiStatsWindow &window) {
+  for (size_t i = 0; i < window.entries.size();) {
+    const std::string &statId = window.entries[i].stat_id;
+    if (!statsWindowSupportsStat(window, statId)) {
+      ++i;
+      continue;
+    }
+
+    const float removeWidth = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+    const float valueWidth = std::max(48.0f, ImGui::CalcTextSize("--").x + 18.0f);
+    const float valueX = std::max(
+        ImGui::GetCursorPosX(),
+        ImGui::GetWindowContentRegionMax().x - valueWidth - removeWidth - 12.0f);
+    const float removeX =
+        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - removeWidth);
+
+    ImGui::Text("%s", uiStatLabel(statId).c_str());
+    ImGui::SameLine(valueX);
+    ImGui::Text("--");
+    ImGui::SameLine(removeX);
+    if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
+      window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
+      scheduleUiConfigAutosave();
+      return;
+    }
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("Remove stat");
+    }
+    ++i;
+  }
+}
+
 void SubtrActorPlugin::renderPlayerStatsTable(
     UiStatsWindow &window,
     const SaPlayerFrame &player) {
-  const std::string label = playerLabel(player.player_index, player.is_team_0);
-  const LinearColor color =
-      player.is_team_0 != 0 ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255};
-  ImGui::TextColored(toImVec4(color), "%s", label.c_str());
-  ImGui::Columns(3, "player-stat-rows", false);
   for (size_t i = 0; i < window.entries.size();) {
     const std::string &statId = window.entries[i].stat_id;
     if (!statsWindowSupportsStat(window, statId)) {
@@ -11653,30 +11680,31 @@ void SubtrActorPlugin::renderPlayerStatsTable(
       continue;
     }
     const std::string statLabel = uiStatLabel(statId);
+    const std::string statValue = playerStatValue(player, statId);
+    const float removeWidth = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+    const float valueWidth = std::max(48.0f, ImGui::CalcTextSize(statValue.c_str()).x + 18.0f);
+    const float valueX = std::max(
+        ImGui::GetCursorPosX(),
+        ImGui::GetWindowContentRegionMax().x - valueWidth - removeWidth - 12.0f);
+    const float removeX =
+        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - removeWidth);
     ImGui::Text("%s", statLabel.c_str());
-    ImGui::NextColumn();
-    ImGui::Text("%s", playerStatValue(player, statId).c_str());
-    ImGui::NextColumn();
+    ImGui::SameLine(valueX);
+    ImGui::Text("%s", statValue.c_str());
+    ImGui::SameLine(removeX);
     if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
       window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
       scheduleUiConfigAutosave();
-      ImGui::Columns(1);
       return;
     }
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip("Remove stat");
     }
-    ImGui::NextColumn();
     ++i;
   }
-  ImGui::Columns(1);
 }
 
 void SubtrActorPlugin::renderTeamStatsTable(UiStatsWindow &window, uint8_t isTeam0) {
-  const LinearColor color =
-      isTeam0 != 0 ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255};
-  ImGui::TextColored(toImVec4(color), "%s", teamLabel(isTeam0).c_str());
-  ImGui::Columns(3, "team-stat-rows", false);
   for (size_t i = 0; i < window.entries.size();) {
     const std::string &statId = window.entries[i].stat_id;
     if (!statsWindowSupportsStat(window, statId)) {
@@ -11684,28 +11712,33 @@ void SubtrActorPlugin::renderTeamStatsTable(UiStatsWindow &window, uint8_t isTea
       continue;
     }
     const std::string statLabel = uiStatLabel(statId);
+    const std::string statValue = teamStatValue(isTeam0, statId);
+    const float removeWidth = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+    const float valueWidth = std::max(48.0f, ImGui::CalcTextSize(statValue.c_str()).x + 18.0f);
+    const float valueX = std::max(
+        ImGui::GetCursorPosX(),
+        ImGui::GetWindowContentRegionMax().x - valueWidth - removeWidth - 12.0f);
+    const float removeX =
+        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - removeWidth);
     ImGui::Text("%s", statLabel.c_str());
-    ImGui::NextColumn();
-    ImGui::Text("%s", teamStatValue(isTeam0, statId).c_str());
-    ImGui::NextColumn();
+    ImGui::SameLine(valueX);
+    ImGui::Text("%s", statValue.c_str());
+    ImGui::SameLine(removeX);
     if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
       window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
       scheduleUiConfigAutosave();
-      ImGui::Columns(1);
       return;
     }
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip("Remove stat");
     }
-    ImGui::NextColumn();
     ++i;
   }
-  ImGui::Columns(1);
 }
 
 void SubtrActorPlugin::renderAllPlayersStatsTable(UiStatsWindow &window) {
   if (sampledPlayers.empty()) {
-    ImGui::Text("Waiting for sampled players.");
+    ImGui::Text("Load a replay to show stats.");
     return;
   }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1182,15 +1182,22 @@ std::string formatGraphStatNumber(double value) {
 }
 
 std::string formatByteSize(size_t bytes) {
-  constexpr double KIB = 1024.0;
-  constexpr double MIB = KIB * 1024.0;
-  if (bytes >= static_cast<size_t>(MIB)) {
-    return std::format("{:.1f} MiB", static_cast<double>(bytes) / MIB);
+  if (bytes == 0) {
+    return "--";
   }
-  if (bytes >= static_cast<size_t>(KIB)) {
-    return std::format("{:.1f} KiB", static_cast<double>(bytes) / KIB);
+
+  constexpr std::array<const char *, 4> units{{"B", "KB", "MB", "GB"}};
+  double value = static_cast<double>(bytes);
+  size_t unitIndex = 0;
+  while (value >= 1024.0 && unitIndex + 1 < units.size()) {
+    value /= 1024.0;
+    unitIndex += 1;
   }
-  return std::format("{} B", bytes);
+  if (unitIndex == 0) {
+    return std::format("{} {}", bytes, units[unitIndex]);
+  }
+  return value >= 10.0 ? std::format("{:.1f} {}", value, units[unitIndex])
+                       : std::format("{:.2f} {}", value, units[unitIndex]);
 }
 
 bool findJsonPropertyValueOffset(

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8395,29 +8395,39 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
         return left < right;
       });
 
-  ImGui::Text("Filters %zu/%zu", selectedSourceCount, playlistSources.size());
-  if (ImGui::Button("All##event-playlist-sources-all")) {
-    eventPlaylistMechanicsEnabled = true;
-    eventPlaylistTeamEventsEnabled = true;
-    eventPlaylistGoalContextEnabled = true;
-    setCvarString("subtr_actor_overlay_event_types", "all");
+  if (playlistSources.empty()) {
+    ImGui::TextDisabled(
+        recentUiEvents.empty() && replayAnnotations == nullptr ? "Load a replay to see events."
+                                                               : "No events loaded.");
+    ImGui::End();
+    return;
   }
+
+  const std::string filterSummary = std::format(
+      "Filters {}/{}##event-playlist-filter",
+      selectedSourceCount,
+      playlistSources.size());
+  const bool filtersOpen = ImGui::TreeNode(filterSummary.c_str());
   ImGui::SameLine();
-  if (ImGui::Button("None##event-playlist-sources-none")) {
-    eventPlaylistMechanicsEnabled = false;
-    eventPlaylistTeamEventsEnabled = false;
-    eventPlaylistGoalContextEnabled = false;
-    setCvarString("subtr_actor_overlay_event_types", "none");
-  }
   if (ImGui::Checkbox("Auto-follow", &eventPlaylistAutoFollow)) {
     scheduleUiConfigAutosave();
   }
 
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "FILTERS");
-  if (playlistSources.empty()) {
-    ImGui::TextDisabled("No events loaded.");
-  } else {
+  if (filtersOpen) {
+    if (ImGui::Button("All##event-playlist-sources-all")) {
+      eventPlaylistMechanicsEnabled = true;
+      eventPlaylistTeamEventsEnabled = true;
+      eventPlaylistGoalContextEnabled = true;
+      setCvarString("subtr_actor_overlay_event_types", "all");
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("None##event-playlist-sources-none")) {
+      eventPlaylistMechanicsEnabled = false;
+      eventPlaylistTeamEventsEnabled = false;
+      eventPlaylistGoalContextEnabled = false;
+      setCvarString("subtr_actor_overlay_event_types", "none");
+    }
+
     ImGui::BeginChild("event-playlist-source-list", ImVec2{0.0f, 170.0f}, true);
     std::string_view currentGroup;
     for (const PlaylistSource &source : playlistSources) {
@@ -8450,6 +8460,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
       ImGui::PopID();
     }
     ImGui::EndChild();
+    ImGui::TreePop();
   }
 
   ImGui::Text("%zu selected / %zu recent", playlistEventIndexes.size(), recentUiEvents.size());

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -37,7 +37,8 @@ constexpr ImGuiWindowFlags UI_CHROME_WINDOW_FLAGS =
     ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings;
 constexpr ImGuiWindowFlags UI_LAUNCHER_MENU_WINDOW_FLAGS =
     ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
-    ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings;
+    ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize |
+    ImGuiWindowFlags_NoSavedSettings;
 constexpr wchar_t RUST_DLL_NAME[] = L"subtr_actor_bakkesmod.dll";
 constexpr char BALL_TOUCH_EVENT[] = "Function TAGame.Ball_TA.OnCarTouch";
 constexpr char BOOST_PICKED_UP_EVENT[] = "Function TAGame.VehiclePickup_TA.EventPickedUp";
@@ -7723,9 +7724,10 @@ void SubtrActorPlugin::renderLauncherToggleChrome() {
 void SubtrActorPlugin::applyLauncherMenuPlacement() {
   const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
   const float width = 352.0f;
-  const float height = std::max(320.0f, displaySize.y > 0.0f ? displaySize.y - 120.0f : 650.0f);
+  const float maxHeight = std::max(320.0f, displaySize.y > 0.0f ? displaySize.y - 120.0f : 650.0f);
   ImGui::SetNextWindowPos(ImVec2{12.0f, 64.0f}, ImGuiCond_Always);
-  ImGui::SetNextWindowSize(ImVec2{width, height}, ImGuiCond_Always);
+  ImGui::SetNextWindowSizeConstraints(ImVec2{width, 0.0f}, ImVec2{width, maxHeight});
+  ImGui::SetNextWindowSize(ImVec2{width, 0.0f}, ImGuiCond_Always);
   ImGui::SetNextWindowBgAlpha(0.92f);
   if (launcherPlacement.pending_focus) {
     ImGui::SetNextWindowFocus();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10031,7 +10031,7 @@ void SubtrActorPlugin::renderRecordingWindow() {
     scheduleUiConfigAutosave();
   }
 
-  if (recordingButton("Start", recordingActive)) {
+  if (recordingButton("Start", recordingActive || !loaded || !engine)) {
     recordingActive = true;
     recordingStartedAt = std::chrono::steady_clock::now();
     recordingStatus = "Recording analysis snapshots";

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1712,6 +1712,14 @@ static_assert(offsetof(SaLiveFrame, player_stat_event_count) == 208);
 static_assert(offsetof(SaLiveFrame, demolishes) == 216);
 static_assert(offsetof(SaLiveFrame, demolish_count) == 224);
 
+static_assert(std::is_standard_layout_v<SaReplayScore>);
+static_assert(sizeof(SaReplayScore) == 16);
+static_assert(alignof(SaReplayScore) == 4);
+static_assert(offsetof(SaReplayScore, team_zero_score) == 0);
+static_assert(offsetof(SaReplayScore, has_team_zero_score) == 4);
+static_assert(offsetof(SaReplayScore, team_one_score) == 8);
+static_assert(offsetof(SaReplayScore, has_team_one_score) == 12);
+
 static_assert(std::is_standard_layout_v<SaMechanicEvent>);
 static_assert(sizeof(SaMechanicEvent) == 32);
 static_assert(alignof(SaMechanicEvent) == 8);
@@ -3154,6 +3162,8 @@ bool SubtrActorPlugin::loadRustLibrary() {
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_replay_annotation_player_count"));
   writeReplayAnnotationPlayers = reinterpret_cast<WriteReplayAnnotationPlayers>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_replay_annotation_players"));
+  replayAnnotationScoreAtTime = reinterpret_cast<ReplayAnnotationScoreAtTime>(
+      GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_replay_annotation_score_at_time"));
   pollReplayAnnotations = reinterpret_cast<PollReplayAnnotations>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_poll_replay_annotations"));
 
@@ -3170,7 +3180,7 @@ bool SubtrActorPlugin::loadRustLibrary() {
       !drainEvents || !drainTeamEvents || !drainGoalContextEvents ||
       !replayAnnotationsCreate || !replayAnnotationsDestroy || !replayAnnotationCount ||
       !replayAnnotationPlayerCount || !writeReplayAnnotationPlayers ||
-      !pollReplayAnnotations) {
+      !replayAnnotationScoreAtTime || !pollReplayAnnotations) {
     unloadRustLibrary();
     return false;
   }
@@ -3232,6 +3242,7 @@ void SubtrActorPlugin::unloadRustLibrary() {
   replayAnnotationCount = nullptr;
   replayAnnotationPlayerCount = nullptr;
   writeReplayAnnotationPlayers = nullptr;
+  replayAnnotationScoreAtTime = nullptr;
   pollReplayAnnotations = nullptr;
 }
 
@@ -8264,6 +8275,25 @@ void SubtrActorPlugin::renderEmptyStateWindow() {
   ImGui::PopStyleVar(2);
 }
 
+std::optional<std::pair<int32_t, int32_t>> SubtrActorPlugin::currentScoreboardScore() const {
+  if (lastTeamScores) {
+    return lastTeamScores;
+  }
+  if (!replayAnnotations || !replayAnnotationScoreAtTime || !gameWrapper->IsInReplay()) {
+    return std::nullopt;
+  }
+
+  ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
+  const float replayTime =
+      replayServer.IsNull() ? playbackCurrentTime : replayServer.GetReplayTimeElapsed();
+  SaReplayScore score{};
+  if (replayAnnotationScoreAtTime(replayAnnotations, replayTime, &score) != 0 ||
+      score.has_team_zero_score == 0 || score.has_team_one_score == 0) {
+    return std::nullopt;
+  }
+  return std::make_pair(score.team_zero_score, score.team_one_score);
+}
+
 void SubtrActorPlugin::renderScoreboardWindow() {
   if (!uiScoreboardOpen) {
     return;
@@ -8282,14 +8312,15 @@ void SubtrActorPlugin::renderScoreboardWindow() {
   }
   captureWindowPlacement(scoreboardPlacement);
 
-  if (lastTeamScores) {
+  const auto score = currentScoreboardScore();
+  if (score) {
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2{8.0f, 0.0f});
     ImGui::SetWindowFontScale(1.2f);
-    ImGui::TextColored(ImVec4{0.31f, 0.75f, 1.0f, 1.0f}, "%d", lastTeamScores->first);
+    ImGui::TextColored(ImVec4{0.31f, 0.75f, 1.0f, 1.0f}, "%d", score->first);
     ImGui::SameLine();
     ImGui::TextDisabled("-");
     ImGui::SameLine();
-    ImGui::TextColored(ImVec4{1.0f, 0.69f, 0.31f, 1.0f}, "%d", lastTeamScores->second);
+    ImGui::TextColored(ImVec4{1.0f, 0.69f, 0.31f, 1.0f}, "%d", score->second);
     ImGui::SetWindowFontScale(1.0f);
     ImGui::PopStyleVar();
   } else {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8929,17 +8929,8 @@ void SubtrActorPlugin::renderGraphInspectorWindow() {
   ImGui::End();
 }
 
-void SubtrActorPlugin::renderSingletonWindowManager() {
-  struct SingletonWindowControl {
-    const char *label;
-    bool *open;
-    UiWindowPlacement *placement;
-    float x;
-    float y;
-    float width;
-    float height;
-  };
-
+std::array<SubtrActorPlugin::SingletonWindowControl, 13>
+SubtrActorPlugin::singletonWindowControls() {
   const float eventPlaylistX = rightAnchoredUiX(430.0f);
   const float statusX = rightAnchoredUiX(330.0f);
   const float playbackX = rightAnchoredUiX(336.0f, 32.0f);
@@ -8949,7 +8940,7 @@ void SubtrActorPlugin::renderSingletonWindowManager() {
   const float moduleControlsX = rightAnchoredUiX(430.0f);
   const float touchControlsX = rightAnchoredUiX(410.0f);
 
-  std::array<SingletonWindowControl, 13> windows{{
+  return {{
       {"Scoreboard", &uiScoreboardOpen, &scoreboardPlacement, 0.0f, 11.0f, 88.0f, 34.0f},
       {"Events", &uiEventsOpen, &eventsPlacement, 16.0f, 256.0f, 520.0f, 360.0f},
       {"Event playlist",
@@ -9012,6 +9003,10 @@ void SubtrActorPlugin::renderSingletonWindowManager() {
        544.0f,
        420.0f},
   }};
+}
+
+void SubtrActorPlugin::renderSingletonWindowManager() {
+  std::array<SingletonWindowControl, 13> windows = singletonWindowControls();
 
   const size_t visibleCount = static_cast<size_t>(std::count_if(
       windows.begin(),
@@ -9229,59 +9224,18 @@ void SubtrActorPlugin::focusTopLoadedWindow() {
 void SubtrActorPlugin::resetWindowPlacements() {
   nextUiWindowZIndex = 1;
   resetSingletonWindowPlacement(launcherPlacement, 16.0f, 68.0f, 340.0f, 430.0f, true);
-  resetScoreboardWindowPlacement();
-  resetSingletonWindowPlacement(eventsPlacement, 16.0f, 256.0f, 520.0f, 360.0f);
-  resetSingletonWindowPlacement(
-      eventPlaylistPlacement,
-      rightAnchoredUiX(430.0f),
-      256.0f,
-      430.0f,
-      430.0f);
-  resetSingletonWindowPlacement(statusPlacement, rightAnchoredUiX(330.0f), 68.0f, 330.0f, 220.0f);
-  resetSingletonWindowPlacement(cameraPlacement, 16.0f, 68.0f, 416.0f, 500.0f);
-  resetSingletonWindowPlacement(
-      playbackControlsPlacement,
-      rightAnchoredUiX(336.0f, 32.0f),
-      68.0f,
-      336.0f,
-      430.0f);
-  resetSingletonWindowPlacement(
-      recordingPlacement,
-      rightAnchoredUiX(416.0f, 32.0f),
-      384.0f,
-      416.0f,
-      380.0f);
-  resetSingletonWindowPlacement(graphInspectorPlacement, 360.0f, 68.0f, 700.0f, 520.0f);
-  resetSingletonWindowPlacement(
-      mechanicsReviewPlacement,
-      rightAnchoredUiX(500.0f),
-      256.0f,
-      500.0f,
-      560.0f);
-  resetSingletonWindowPlacement(
-      replayLoadingPlacement,
-      rightAnchoredUiX(520.0f),
-      68.0f,
-      520.0f,
-      360.0f);
-  resetSingletonWindowPlacement(
-      moduleControlsPlacement,
-      rightAnchoredUiX(430.0f),
-      305.0f,
-      430.0f,
-      520.0f);
-  resetSingletonWindowPlacement(
-      touchControlsPlacement,
-      rightAnchoredUiX(410.0f),
-      256.0f,
-      410.0f,
-      380.0f);
-  resetSingletonWindowPlacement(
-      boostPickupControlsPlacement,
-      16.0f,
-      448.0f,
-      544.0f,
-      420.0f);
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    if (window.placement == &scoreboardPlacement) {
+      resetScoreboardWindowPlacement();
+      continue;
+    }
+    resetSingletonWindowPlacement(
+        *window.placement,
+        window.x,
+        window.y,
+        window.width,
+        window.height);
+  }
   for (size_t index = 0; index < uiStatsWindows.size(); index += 1) {
     resetStatsWindowPlacement(uiStatsWindows[index], index);
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9329,7 +9329,19 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
                                                            : replayAnnotationPath;
     const std::string title = replaySourceDisplayLabel(titlePath);
     const float replayLoadProgress = replayAnnotations ? 1.0f : 0.0f;
-    ImGui::TextWrapped("%s", title.c_str());
+    const ImVec4 statusColor =
+        replayAnnotations ? ImVec4{0.50f, 0.86f, 0.62f, 1.0f}
+                          : replayAnnotationLoadFailed
+                              ? ImVec4{0.95f, 0.45f, 0.45f, 1.0f}
+                              : ImVec4{0.72f, 0.78f, 0.86f, 1.0f};
+    const float statusWidth = ImGui::CalcTextSize(status).x;
+    const float statusX =
+        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - statusWidth);
+    ImGui::PushTextWrapPos(std::max(ImGui::GetCursorPosX(), statusX - 12.0f));
+    ImGui::TextUnformatted(title.c_str());
+    ImGui::PopTextWrapPos();
+    ImGui::SameLine(statusX);
+    ImGui::TextColored(statusColor, "%s", status);
     std::vector<std::string> replayMeta;
     if (!rawReplayPath.empty()) {
       replayMeta.push_back(std::format("raw: {}", rawReplayPath));
@@ -9346,13 +9358,6 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
     if (!replayMeta.empty()) {
       ImGui::TextDisabled("%s", joinStrings(replayMeta, " · ").c_str());
     }
-    ImGui::TextColored(
-        replayAnnotations ? ImVec4{0.50f, 0.86f, 0.62f, 1.0f}
-                          : replayAnnotationLoadFailed
-                              ? ImVec4{0.95f, 0.45f, 0.45f, 1.0f}
-                              : ImVec4{0.72f, 0.78f, 0.86f, 1.0f},
-        "%s",
-        status);
     ImGui::ProgressBar(replayLoadProgress, ImVec2{-1.0f, 0.0f}, "");
   }
   ImGui::EndChild();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3475,8 +3475,8 @@ void SubtrActorPlugin::applyUiConfigJson(
     UiStatsWindow window{};
     window.kind = *parsedKind;
 
-    window.id = static_cast<uint32_t>(parseJsonNumberProperty(object, "id").value_or(0.0));
     if (const auto idString = parseJsonStringProperty(object, "id")) {
+      window.config_id = *idString;
       const size_t digitOffset = idString->find_first_of("0123456789");
       if (digitOffset != std::string::npos) {
         try {
@@ -3486,8 +3486,15 @@ void SubtrActorPlugin::applyUiConfigJson(
         }
       }
     }
+    if (const auto configId = parseJsonStringProperty(object, "config_id")) {
+      window.config_id = *configId;
+    }
+    window.id = static_cast<uint32_t>(parseJsonNumberProperty(object, "id").value_or(window.id));
     if (window.id == 0) {
       window.id = nextUiStatsWindowId;
+    }
+    if (window.config_id.empty()) {
+      window.config_id = std::format("stats-{}", window.id);
     }
     nextUiStatsWindowId = std::max(nextUiStatsWindowId, window.id + 1);
     window.open = parseJsonBoolProperty(object, "open").value_or(true);
@@ -3944,6 +3951,10 @@ std::string SubtrActorPlugin::uiConfigJson() {
          << statsWindowKindConfigId(window.kind)
          << "\",\"open\":" << (window.open ? "true" : "false")
          << ",\"visible\":" << (window.open ? "true" : "false")
+         << ",\"config_id\":\""
+         << escapeJsonString(window.config_id.empty() ? std::format("stats-{}", window.id)
+                                                      : window.config_id)
+         << "\""
          << ",\"placement\":{\"x\":" << window.x << ",\"y\":" << window.y
          << ",\"viewport\":{\"width\":" << window.viewport_width
          << ",\"height\":" << window.viewport_height << "}"
@@ -3993,7 +4004,9 @@ std::string SubtrActorPlugin::uiConfigJson() {
     if (wroteWebStatsWindow) {
       file << ",\n";
     }
-    file << "    {\"id\":\"stats-" << window.id << "\",\"kind\":\""
+    const std::string configId =
+        window.config_id.empty() ? std::format("stats-{}", window.id) : window.config_id;
+    file << "    {\"id\":\"" << escapeJsonString(configId) << "\",\"kind\":\""
          << statsWindowKindConfigId(window.kind)
          << "\",\"placement\":{\"x\":" << window.x << ",\"y\":" << window.y
          << ",\"viewport\":{\"width\":" << window.viewport_width
@@ -9729,6 +9742,7 @@ void SubtrActorPlugin::renderStatsWindowManager() {
     if (ImGui::SmallButton("Duplicate")) {
       UiStatsWindow copy = window;
       copy.id = nextUiStatsWindowId++;
+      copy.config_id = std::format("stats-{}", copy.id);
       copy.open = true;
       copy.pending_focus = true;
       copy.picker_open = false;
@@ -9884,6 +9898,7 @@ void SubtrActorPlugin::applyRecordingUiWorkspace() {
 void SubtrActorPlugin::createStatsWindow(UiStatsWindowKind kind, bool initializeEntries) {
   UiStatsWindow window{};
   window.id = nextUiStatsWindowId++;
+  window.config_id = std::format("stats-{}", window.id);
   window.kind = kind;
   initializeStatsWindowPlacement(window);
   focusStatsWindow(window);
@@ -9901,6 +9916,7 @@ void SubtrActorPlugin::createStatsWindow(UiStatsWindowKind kind, bool initialize
 void SubtrActorPlugin::createStatsModuleWindow(std::string moduleName, int moduleView) {
   UiStatsWindow window{};
   window.id = nextUiStatsWindowId++;
+  window.config_id = std::format("stats-{}", window.id);
   window.kind = UiStatsWindowKind::StatsModule;
   window.module_name = std::move(moduleName);
   window.module_view = std::clamp(moduleView, 0, 2);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7756,8 +7756,10 @@ void SubtrActorPlugin::renderModuleSummaryControls(
 void SubtrActorPlugin::renderModuleSettingsControls(
     const char *idSuffix,
     bool includeOpenButtons,
-    bool webCardHeaders) {
+    bool webCardHeaders,
+    bool onlyWebActivePanels) {
   ImGui::PushID(idSuffix);
+  bool renderedPanel = false;
 
   auto settingReadout = [](std::initializer_list<std::pair<bool, const char *>> parts,
                            std::string_view separator) {
@@ -7785,39 +7787,44 @@ void SubtrActorPlugin::renderModuleSettingsControls(
     ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", readout.c_str());
   };
 
-  renderSettingsHeader(
-      "Movement breakdown",
-      settingReadout(
-          {{movementBreakdownSpeed, "Speed band"}, {movementBreakdownHeight, "Height band"}},
-          " + "));
-  if (ImGui::Checkbox("Speed band##movement-breakdown", &movementBreakdownSpeed)) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::Checkbox("Height band##movement-breakdown", &movementBreakdownHeight)) {
-    scheduleUiConfigAutosave();
-  }
-  if (includeOpenButtons && ImGui::Button("Open movement stats")) {
-    createStatsModuleWindow("movement", 0);
+  if (!onlyWebActivePanels) {
+    renderSettingsHeader(
+        "Movement breakdown",
+        settingReadout(
+            {{movementBreakdownSpeed, "Speed band"}, {movementBreakdownHeight, "Height band"}},
+            " + "));
+    if (ImGui::Checkbox("Speed band##movement-breakdown", &movementBreakdownSpeed)) {
+      scheduleUiConfigAutosave();
+    }
+    ImGui::SameLine();
+    if (ImGui::Checkbox("Height band##movement-breakdown", &movementBreakdownHeight)) {
+      scheduleUiConfigAutosave();
+    }
+    if (includeOpenButtons && ImGui::Button("Open movement stats")) {
+      createStatsModuleWindow("movement", 0);
+    }
+    renderedPanel = true;
   }
 
-  if (webCardHeaders) {
+  if (webCardHeaders && renderedPanel && (!onlyWebActivePanels || timelineRangePossessionEnabled)) {
     ImGui::Spacing();
   }
-  renderSettingsHeader(
-      "Possession breakdown",
-      settingReadout(
-          {{possessionBreakdownState, "Control"}, {possessionBreakdownThird, "Third"}},
-          " x "));
-  if (ImGui::Checkbox("Control##possession-breakdown", &possessionBreakdownState)) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::Checkbox("Third##possession-breakdown", &possessionBreakdownThird)) {
-    scheduleUiConfigAutosave();
-  }
-  if (includeOpenButtons && ImGui::Button("Open possession stats")) {
-    createStatsModuleWindow("possession", 0);
+  if (!onlyWebActivePanels || timelineRangePossessionEnabled) {
+    renderSettingsHeader(
+        "Possession breakdown",
+        settingReadout(
+            {{possessionBreakdownState, "Control"}, {possessionBreakdownThird, "Third"}},
+            " x "));
+    if (ImGui::Checkbox("Control##possession-breakdown", &possessionBreakdownState)) {
+      scheduleUiConfigAutosave();
+    }
+    ImGui::SameLine();
+    if (ImGui::Checkbox("Third##possession-breakdown", &possessionBreakdownThird)) {
+      scheduleUiConfigAutosave();
+    }
+    if (includeOpenButtons && ImGui::Button("Open possession stats")) {
+      createStatsModuleWindow("possession", 0);
+    }
   }
 
   ImGui::PopID();
@@ -8041,8 +8048,10 @@ void SubtrActorPlugin::renderLauncherWindow() {
   ImGui::Separator();
   renderModuleSummaryControls("launcher-module-summary", false, 0.0f, false);
 
-  ImGui::Separator();
-  renderModuleSettingsControls("launcher-module-settings", false, true);
+  if (timelineRangePossessionEnabled) {
+    ImGui::Separator();
+    renderModuleSettingsControls("launcher-module-settings", false, true, true);
+  }
 
   if (ImGui::TreeNode("Plugin tools##launcher-plugin-tools")) {
     const float pluginToolButtonWidth = ImGui::GetContentRegionAvail().x;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7361,14 +7361,15 @@ void SubtrActorPlugin::showStatsWindow(UiStatsWindow &window) {
 bool SubtrActorPlugin::renderModuleSummaryToggle(
     const char *label,
     bool active,
-    const char *idSuffix) {
+    const char *idSuffix,
+    float width) {
   const std::string buttonLabel =
       std::format("{}   {}##{}-{}", label, active ? "On" : "Off", idSuffix, label);
   if (active) {
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.16f, 0.35f, 0.28f, 1.0f});
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
   }
-  const bool clicked = ImGui::Button(buttonLabel.c_str(), ImVec2{230.0f, 0.0f});
+  const bool clicked = ImGui::Button(buttonLabel.c_str(), ImVec2{width, 0.0f});
   if (active) {
     ImGui::PopStyleColor(2);
   }
@@ -7792,14 +7793,19 @@ void SubtrActorPlugin::renderLauncherWindow() {
   const bool launcherHovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
 
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ACTIONS");
-  if (ImGui::Button("Load Replay...")) {
+  const float actionButtonWidth = ImGui::GetContentRegionAvail().x;
+  if (ImGui::Button("Load Replay...", ImVec2{actionButtonWidth, 0.0f})) {
     showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
     resetReplayAnnotations();
     tickReplayAnnotations();
     hideLauncherWindow();
   }
   const bool liveAnalysis = liveProcessingEnabled();
-  if (renderModuleSummaryToggle("Live analysis graph", liveAnalysis, "launcher-actions")) {
+  if (renderModuleSummaryToggle(
+          "Live analysis graph",
+          liveAnalysis,
+          "launcher-actions",
+          actionButtonWidth)) {
     setCvarBool("subtr_actor_enabled", !liveAnalysis);
   }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8463,6 +8463,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
 
   if (ImGui::Button("Prev") && mechanicsReviewIndex > 0) {
     mechanicsReviewIndex -= 1;
+    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (ImGui::Button("Replay clip")) {
@@ -8486,6 +8487,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
       cvarManager->log(
           "subtr-actor: replay clip selected; open a replay to seek in Rocket League");
     }
+    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (mechanicsReviewClipActive && ImGui::Button("Stop clip")) {
@@ -8499,6 +8501,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
         replay.StopPlayback();
       }
     }
+    scheduleUiConfigAutosave();
   }
   if (mechanicsReviewClipActive) {
     ImGui::SameLine();
@@ -8506,6 +8509,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   if (ImGui::Button("Next") &&
       mechanicsReviewIndex < static_cast<int>(candidates.size()) - 1) {
     mechanicsReviewIndex += 1;
+    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (ImGui::Button("Show playlist")) {
@@ -8551,6 +8555,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
         mechanicsReviewDecisionLabel(event));
     if (ImGui::Selectable(label.c_str(), i == static_cast<size_t>(mechanicsReviewIndex))) {
       mechanicsReviewIndex = static_cast<int>(i);
+      scheduleUiConfigAutosave();
     }
     ImGui::PopID();
   }
@@ -9823,11 +9828,17 @@ void SubtrActorPlugin::renderGraphInspectorWindow() {
     return;
   }
 
-  ImGui::RadioButton("Outputs##graph-inspector-view", &graphInspectorView, 0);
+  if (ImGui::RadioButton("Outputs##graph-inspector-view", &graphInspectorView, 0)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::RadioButton("Analysis nodes##graph-inspector-view", &graphInspectorView, 1);
+  if (ImGui::RadioButton("Analysis nodes##graph-inspector-view", &graphInspectorView, 1)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::RadioButton("Graph info##graph-inspector-view", &graphInspectorView, 2);
+  if (ImGui::RadioButton("Graph info##graph-inspector-view", &graphInspectorView, 2)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::Separator();
 
   if (graphInspectorView == 0) {
@@ -9846,6 +9857,7 @@ void SubtrActorPlugin::renderGraphInspectorWindow() {
         const bool isSelected = name == selectedGraphOutput;
         if (ImGui::Selectable(name.c_str(), isSelected)) {
           selectedGraphOutput = name;
+          scheduleUiConfigAutosave();
         }
       }
       ImGui::EndCombo();
@@ -9877,11 +9889,13 @@ void SubtrActorPlugin::renderGraphInspectorWindow() {
     ImGui::SetNextItemWidth(-1.0f);
     if (ImGui::InputText("Search nodes", queryBuffer.data(), queryBuffer.size())) {
       graphInspectorNodeQuery = queryBuffer.data();
+      scheduleUiConfigAutosave();
     }
     if (!graphInspectorNodeQuery.empty()) {
       ImGui::SameLine();
       if (ImGui::SmallButton("Clear##graph-node-search")) {
         graphInspectorNodeQuery.clear();
+        scheduleUiConfigAutosave();
       }
     }
 
@@ -9906,6 +9920,7 @@ void SubtrActorPlugin::renderGraphInspectorWindow() {
       const bool isSelected = name == selectedAnalysisNode;
       if (ImGui::Selectable(name.c_str(), isSelected)) {
         selectedAnalysisNode = name;
+        scheduleUiConfigAutosave();
       }
     }
     if (visibleCount == 0) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9979,24 +9979,39 @@ void SubtrActorPlugin::renderRecordingWindow() {
     return clicked && !disabled;
   };
 
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "RECORDING");
+  ImGui::TextDisabled("FPS");
+  ImGui::SameLine();
   int nextRecordingFps = recordingFps;
   pushRecordingDisabledStyle(recordingSettingsLocked);
-  const bool fpsChanged = ImGui::SliderInt("FPS", &nextRecordingFps, 1, 120);
+  ImGui::SetNextItemWidth(88.0f);
+  const bool fpsChanged = ImGui::InputInt("##recording-fps", &nextRecordingFps, 1, 10);
   popRecordingDisabledStyle(recordingSettingsLocked);
   if (!recordingSettingsLocked && fpsChanged) {
-    recordingFps = nextRecordingFps;
+    recordingFps = std::clamp(nextRecordingFps, 1, 120);
     scheduleUiConfigAutosave();
   }
+  ImGui::SameLine();
+  ImGui::TextDisabled("Playback rate");
+  ImGui::SameLine();
   const std::array<const char *, 4> rates{{"0.5x", "1.0x", "1.5x", "2.0x"}};
   recordingPlaybackRateIndex = std::clamp(recordingPlaybackRateIndex, 0, 3);
   int nextRecordingPlaybackRateIndex = recordingPlaybackRateIndex;
   pushRecordingDisabledStyle(recordingSettingsLocked);
-  if (ImGui::BeginCombo("Playback rate", rates[static_cast<size_t>(recordingPlaybackRateIndex)])) {
-    for (int index = 0; index < static_cast<int>(rates.size()); index += 1) {
-      const bool selected = index == recordingPlaybackRateIndex;
-      if (ImGui::Selectable(rates[static_cast<size_t>(index)], selected)) {
-        nextRecordingPlaybackRateIndex = index;
+  ImGui::SetNextItemWidth(96.0f);
+  if (ImGui::BeginCombo(
+          "##recording-playback-rate",
+          rates[static_cast<size_t>(recordingPlaybackRateIndex)])) {
+    if (recordingSettingsLocked) {
+      ImGui::TextDisabled("%s", rates[static_cast<size_t>(recordingPlaybackRateIndex)]);
+    } else {
+      for (int index = 0; index < static_cast<int>(rates.size()); index += 1) {
+        const bool selected = index == recordingPlaybackRateIndex;
+        if (ImGui::Selectable(rates[static_cast<size_t>(index)], selected)) {
+          nextRecordingPlaybackRateIndex = index;
+        }
+        if (selected) {
+          ImGui::SetItemDefaultFocus();
+        }
       }
     }
     ImGui::EndCombo();
@@ -10006,17 +10021,7 @@ void SubtrActorPlugin::renderRecordingWindow() {
     recordingPlaybackRateIndex = nextRecordingPlaybackRateIndex;
     scheduleUiConfigAutosave();
   }
-  bool nextFinishBeforeDump = recordingFinishBeforeDump;
-  pushRecordingDisabledStyle(recordingSettingsLocked);
-  const bool finishBeforeDumpChanged =
-      ImGui::Checkbox("Finalize before dump", &nextFinishBeforeDump);
-  popRecordingDisabledStyle(recordingSettingsLocked);
-  if (!recordingSettingsLocked && finishBeforeDumpChanged) {
-    recordingFinishBeforeDump = nextFinishBeforeDump;
-    scheduleUiConfigAutosave();
-  }
 
-  ImGui::Separator();
   if (recordingButton("Start", recordingActive)) {
     recordingActive = true;
     recordingStartedAt = std::chrono::steady_clock::now();
@@ -10032,14 +10037,11 @@ void SubtrActorPlugin::renderRecordingWindow() {
     recordingActive = false;
     dumpSnapshot(recordingFinishBeforeDump);
   }
-  if (ImGui::Button("Snapshot")) {
-    dumpSnapshot(false);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Log folder")) {
+  if (recordingButton("Download", recordingActive || !hasGraphSnapshot)) {
     cvarManager->log(std::format(
         "subtr-actor: recording snapshots are written to {}",
         outputDirectory.string()));
+    recordingStatus = "Snapshot location logged";
   }
   ImGui::SameLine();
   if (recordingButton("Clear", recordingActive || !hasGraphSnapshot)) {
@@ -10050,21 +10052,19 @@ void SubtrActorPlugin::renderRecordingWindow() {
   }
 
   ImGui::Separator();
-  ImGui::Text("Status: %s", recordingStatus.c_str());
-  ImGui::Text("Elapsed: %.1fs", elapsedSeconds);
-  ImGui::Text("Size: %s", formatByteSize(recordingLastBytes).c_str());
-  ImGui::Text("Type: JSON snapshots");
-  ImGui::Text("Snapshots: %d", recordingSnapshotCount);
-  ImGui::TextWrapped("Folder: %s", outputDirectory.string().c_str());
-
-  ImGui::Separator();
-  if (ImGui::Button("Open graph inspector")) {
-    showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Open replay loading")) {
-    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
-  }
+  ImGui::Columns(2, "recording-detail-grid", false);
+  ImGui::TextDisabled("Status");
+  ImGui::Text("%s", recordingStatus.c_str());
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Elapsed");
+  ImGui::Text("%.1fs", elapsedSeconds);
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Size");
+  ImGui::Text("%s", formatByteSize(recordingLastBytes).c_str());
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Type");
+  ImGui::Text("JSON snapshots");
+  ImGui::Columns(1);
 
   ImGui::End();
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7345,6 +7345,72 @@ void SubtrActorPlugin::applyLauncherMenuPlacement() {
   }
 }
 
+void SubtrActorPlugin::renderLauncherWorkspaceControls() {
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WORKSPACES");
+  if (ImGui::Button("Default workspace")) {
+    applyDefaultUiWorkspace();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Review workspace")) {
+    applyReplayReviewUiWorkspace();
+  }
+  if (ImGui::Button("Debug workspace")) {
+    applyGraphDebugUiWorkspace();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Recording workspace")) {
+    applyRecordingUiWorkspace();
+  }
+  if (ImGui::Button("Reset positions")) {
+    resetWindowPlacements();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Default stats windows")) {
+    resetDefaultStatsWindows();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Hide side windows")) {
+    for (const SingletonWindowControl &window : singletonWindowControls()) {
+      if (std::string_view{window.config_id} == "scoreboard") {
+        continue;
+      }
+      *window.open = false;
+    }
+  }
+  if (ImGui::Button("Save layout")) {
+    saveUiConfig();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Reload layout")) {
+    loadUiConfig();
+  }
+  if (ImGui::Button("Copy layout JSON")) {
+    const std::string json = uiConfigJson();
+    ImGui::SetClipboardText(json.c_str());
+    cvarManager->log(std::format("subtr-actor: copied {} UI config bytes", json.size()));
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Copy layout cfg")) {
+    const std::string json = uiConfigJson();
+    const std::string cfg = std::format("#cfg={}", urlEncode(json));
+    ImGui::SetClipboardText(cfg.c_str());
+    cvarManager->log(std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Paste layout")) {
+    const char *clipboardText = ImGui::GetClipboardText();
+    if (clipboardText == nullptr || clipboardText[0] == '\0') {
+      cvarManager->log("subtr-actor: clipboard does not contain UI config JSON or cfg");
+    } else if (const std::optional<std::string> configJson =
+                   statsPlayerCfgJsonFromClipboard(clipboardText)) {
+      applyUiConfigJson(*configJson, "clipboard");
+    } else {
+      cvarManager->log(
+          "subtr-actor: clipboard does not contain raw UI config JSON or a raw JSON cfg value");
+    }
+  }
+}
+
 void SubtrActorPlugin::renderLauncherWindow() {
   if (!uiLauncherOpen) {
     return;
@@ -7426,69 +7492,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   }
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WORKSPACES");
-  if (ImGui::Button("Default workspace")) {
-    applyDefaultUiWorkspace();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Review workspace")) {
-    applyReplayReviewUiWorkspace();
-  }
-  if (ImGui::Button("Debug workspace")) {
-    applyGraphDebugUiWorkspace();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Recording workspace")) {
-    applyRecordingUiWorkspace();
-  }
-  if (ImGui::Button("Reset positions")) {
-    resetWindowPlacements();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Default stats windows")) {
-    resetDefaultStatsWindows();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Hide side windows")) {
-    for (const SingletonWindowControl &window : singletonWindowControls()) {
-      if (std::string_view{window.config_id} == "scoreboard") {
-        continue;
-      }
-      *window.open = false;
-    }
-  }
-  if (ImGui::Button("Save layout")) {
-    saveUiConfig();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Reload layout")) {
-    loadUiConfig();
-  }
-  if (ImGui::Button("Copy layout JSON")) {
-    const std::string json = uiConfigJson();
-    ImGui::SetClipboardText(json.c_str());
-    cvarManager->log(std::format("subtr-actor: copied {} UI config bytes", json.size()));
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Copy layout cfg")) {
-    const std::string json = uiConfigJson();
-    const std::string cfg = std::format("#cfg={}", urlEncode(json));
-    ImGui::SetClipboardText(cfg.c_str());
-    cvarManager->log(std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Paste layout")) {
-    const char *clipboardText = ImGui::GetClipboardText();
-    if (clipboardText == nullptr || clipboardText[0] == '\0') {
-      cvarManager->log("subtr-actor: clipboard does not contain UI config JSON or cfg");
-    } else if (const std::optional<std::string> configJson =
-                   statsPlayerCfgJsonFromClipboard(clipboardText)) {
-      applyUiConfigJson(*configJson, "clipboard");
-    } else {
-      cvarManager->log(
-          "subtr-actor: clipboard does not contain raw UI config JSON or a raw JSON cfg value");
-    }
-  }
+  renderLauncherWorkspaceControls();
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "VISUALIZATIONS");

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10855,10 +10855,10 @@ void SubtrActorPlugin::resetWindowPlacements() {
   nextUiWindowZIndex = 1;
   launcherPlacement = {};
   launcherPlacement.pending_focus = uiLauncherOpen;
-  for (const SingletonWindowControl &window : singletonWindowControls()) {
+  auto resetSingletonPlacement = [&](const SingletonWindowControl &window) {
     if (window.placement == &scoreboardPlacement) {
       resetScoreboardWindowPlacement();
-      continue;
+      return;
     }
     resetSingletonWindowPlacement(
         *window.placement,
@@ -10866,6 +10866,15 @@ void SubtrActorPlugin::resetWindowPlacements() {
         window.y,
         window.width,
         window.height);
+  };
+  for (const SingletonWindowControl &window : webSingletonWindowControls()) {
+    resetSingletonPlacement(window);
+  }
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    if (window.web_config) {
+      continue;
+    }
+    resetSingletonPlacement(window);
   }
   for (size_t index = 0; index < uiStatsWindows.size(); index += 1) {
     resetStatsWindowPlacement(uiStatsWindows[index], index);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7583,44 +7583,13 @@ void SubtrActorPlugin::renderModuleSummaryControls(
     float toggleWidth,
     bool includePluginControls) {
   auto renderTimelineControls = [&]() {
-    renderEventFilterModuleSummaryToggle("Touch", "touch", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Dodge refresh", "dodge_reset", idSuffix, toggleWidth);
     renderEventFilterModuleSummaryToggle("Backboard", "backboard", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Speed flip", "speed_flip", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Half flip", "half_flip", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Powerslide", "powerslide", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Wavedash", "wavedash", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Ball carry", "ball_carry", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Ceiling shot", "ceiling_shot", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Flip reset", "flip_reset", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Double tap", "double_tap", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("50/50", "fifty_fifty", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Musty flick", "musty_flick", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Whiff", "whiff", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Bump", "bump", idSuffix, toggleWidth);
-    renderEventFilterModuleSummaryToggle("Demo", "demo", idSuffix, toggleWidth);
-    if (includePluginControls) {
-      renderBoolModuleSummaryToggle(
-          "Team event playlist",
-          eventPlaylistTeamEventsEnabled,
-          idSuffix,
-          toggleWidth);
-      renderBoolModuleSummaryToggle(
-          "Goal context playlist",
-          eventPlaylistGoalContextEnabled,
-          idSuffix,
-          toggleWidth);
-    }
-    renderBoolModuleSummaryToggle(
-        "Boost pickup timeline",
-        timelineRangeBoostEnabled,
-        idSuffix,
-        toggleWidth);
     renderBoolModuleSummaryToggle(
         "Possession",
         timelineRangePossessionEnabled,
         idSuffix,
         toggleWidth);
+    renderEventFilterModuleSummaryToggle("50/50", "fifty_fifty", idSuffix, toggleWidth);
     renderBoolModuleSummaryToggle(
         "Half control",
         timelineRangePressureEnabled,
@@ -7632,7 +7601,36 @@ void SubtrActorPlugin::renderModuleSummaryControls(
         timelineRangeAbsolutePositioningEnabled,
         idSuffix,
         toggleWidth);
+    renderEventFilterModuleSummaryToggle("Wavedash", "wavedash", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Touch", "touch", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Whiff", "whiff", idSuffix, toggleWidth);
+    renderBoolModuleSummaryToggle(
+        "Boost pickup timeline",
+        timelineRangeBoostEnabled,
+        idSuffix,
+        toggleWidth);
+    renderEventFilterModuleSummaryToggle("Powerslide", "powerslide", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Bump", "bump", idSuffix, toggleWidth);
     if (includePluginControls) {
+      renderEventFilterModuleSummaryToggle("Dodge refresh", "dodge_reset", idSuffix, toggleWidth);
+      renderEventFilterModuleSummaryToggle("Speed flip", "speed_flip", idSuffix, toggleWidth);
+      renderEventFilterModuleSummaryToggle("Half flip", "half_flip", idSuffix, toggleWidth);
+      renderEventFilterModuleSummaryToggle("Ball carry", "ball_carry", idSuffix, toggleWidth);
+      renderEventFilterModuleSummaryToggle("Ceiling shot", "ceiling_shot", idSuffix, toggleWidth);
+      renderEventFilterModuleSummaryToggle("Flip reset", "flip_reset", idSuffix, toggleWidth);
+      renderEventFilterModuleSummaryToggle("Double tap", "double_tap", idSuffix, toggleWidth);
+      renderEventFilterModuleSummaryToggle("Musty flick", "musty_flick", idSuffix, toggleWidth);
+      renderEventFilterModuleSummaryToggle("Demo", "demo", idSuffix, toggleWidth);
+      renderBoolModuleSummaryToggle(
+          "Team event playlist",
+          eventPlaylistTeamEventsEnabled,
+          idSuffix,
+          toggleWidth);
+      renderBoolModuleSummaryToggle(
+          "Goal context playlist",
+          eventPlaylistGoalContextEnabled,
+          idSuffix,
+          toggleWidth);
       renderBoolModuleSummaryToggle(
           "Playlist follow",
           eventPlaylistAutoFollow,

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9088,13 +9088,6 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     }
     return std::format("Review item {}", index + 1);
   };
-  ImGui::Text("%d / %zu", current == nullptr ? 0 : mechanicsReviewIndex + 1, candidates.size());
-  const std::string currentTitle =
-      current == nullptr ? "No candidate selected"
-                         : mechanicsReviewItemTitle(
-                               *current,
-                               static_cast<size_t>(mechanicsReviewIndex));
-  ImGui::TextWrapped("%s", currentTitle.c_str());
   const std::string statusReadout =
       mechanicsReviewClipActive
           ? std::format(
@@ -9105,6 +9098,13 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
       : candidates.empty()             ? "Load a review playlist."
                                        : "Loaded review playlist.";
   ImGui::TextWrapped("%s", statusReadout.c_str());
+  ImGui::Text("%d / %zu", current == nullptr ? 0 : mechanicsReviewIndex + 1, candidates.size());
+  const std::string currentTitle =
+      current == nullptr ? "No candidate selected"
+                         : mechanicsReviewItemTitle(
+                               *current,
+                               static_cast<size_t>(mechanicsReviewIndex));
+  ImGui::TextWrapped("%s", currentTitle.c_str());
   const std::string clipReadout =
       current == nullptr
           ? "--"

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7407,6 +7407,19 @@ void SubtrActorPlugin::renderLauncherWindow() {
       renderStatsWindowCreateButton(kind.create_label, kind.kind);
     }
   }
+  if (!uiStatsWindows.empty()) {
+    const size_t visibleStatsWindows = static_cast<size_t>(std::count_if(
+        uiStatsWindows.begin(),
+        uiStatsWindows.end(),
+        [](const UiStatsWindow &window) { return window.open; }));
+    ImGui::Separator();
+    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STATS WINDOWS");
+    ImGui::Text(
+        "%zu visible / %zu stats windows",
+        visibleStatsWindows,
+        uiStatsWindows.size());
+    renderStatsWindowManager();
+  }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "VISUALIZATIONS");
@@ -7507,18 +7520,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
             "subtr-actor: clipboard does not contain raw UI config JSON or a raw JSON cfg value");
       }
     }
-
-    ImGui::Separator();
-    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STATS WINDOWS");
-    const size_t visibleStatsWindows = static_cast<size_t>(std::count_if(
-        uiStatsWindows.begin(),
-        uiStatsWindows.end(),
-        [](const UiStatsWindow &window) { return window.open; }));
-    ImGui::Text(
-        "%zu visible / %zu stats windows",
-        visibleStatsWindows,
-        uiStatsWindows.size());
-    renderStatsWindowManager();
 
     ImGui::Separator();
     ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "GRAPH MODULES");

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9447,6 +9447,15 @@ void SubtrActorPlugin::renderCameraWindow() {
         "%.2f");
   }
 
+  bool nextBallCamEnabled = cameraBallCamEnabled;
+  pushCameraDisabledStyle(!hasAttachedCamera);
+  const bool ballCamChanged = ImGui::Checkbox("Ball cam", &nextBallCamEnabled);
+  popCameraDisabledStyle(!hasAttachedCamera);
+  if (hasAttachedCamera && ballCamChanged) {
+    cameraBallCamEnabled = nextBallCamEnabled;
+    scheduleUiConfigAutosave();
+  }
+
   const float fov = cameraCustomSettingsEnabled ? cameraCustomFov : 110.0f;
   const float height = cameraCustomSettingsEnabled ? cameraCustomHeight : 100.0f;
   const float pitch = cameraCustomSettingsEnabled ? cameraCustomPitch : -4.0f;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -208,8 +208,9 @@ std::string normalizeUiStatId(std::string_view statId);
 
 constexpr std::array<EventFilterOption, 34> EVENT_FILTER_OPTIONS{{
     {"all", "All events", "All"},
-    {"goal", "Goal", "Replay"},
+    {"goal", "Goals", "Replay"},
     {"core", "Shots, saves, assists", "Replay"},
+    {"demo", "Demos", "Replay"},
     {"mechanics", "All mechanics", "Sources"},
     {"team", "Team events", "Sources"},
     {"goal_context", "Goal context", "Sources"},
@@ -240,7 +241,6 @@ constexpr std::array<EventFilterOption, 34> EVENT_FILTER_OPTIONS{{
     {"half_volley", "Half volley", "Mechanics"},
     {"whiff", "Whiff", "Mechanics"},
     {"bump", "Bump", "Mechanics"},
-    {"demo", "Demo", "Mechanics"},
 }};
 
 constexpr std::array<const char *, 24> MECHANIC_FILTER_TOKENS{{
@@ -2099,6 +2099,36 @@ std::vector<std::string> eventFilterTokens(std::string_view rawFilter) {
   return tokens;
 }
 
+bool eventPlaylistUsesDefaultSources(std::string_view rawFilter) {
+  const std::vector<std::string> tokens = eventFilterTokens(rawFilter);
+  return tokens.size() == 1 && tokens.front() == "default";
+}
+
+bool defaultEventPlaylistSourceOption(std::string_view optionValue) {
+  return optionValue != "all" && optionValue != "mechanics" && optionValue != "touch" &&
+         optionValue != "powerslide";
+}
+
+std::vector<std::string> defaultEventPlaylistSourceTokens() {
+  std::vector<std::string> tokens;
+  for (const EventFilterOption &option : EVENT_FILTER_OPTIONS) {
+    if (defaultEventPlaylistSourceOption(option.value)) {
+      tokens.emplace_back(option.value);
+    }
+  }
+  return tokens;
+}
+
+bool defaultEventPlaylistSourceAllows(std::string_view category, std::string_view type) {
+  for (const EventFilterOption &option : EVENT_FILTER_OPTIONS) {
+    if (defaultEventPlaylistSourceOption(option.value) &&
+        eventFilterAllows(option.value, category, type)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool allEventSourcesSelected(std::string_view rawFilter) {
   const std::vector<std::string> tokens = eventFilterTokens(rawFilter);
   return tokens.empty() || containsString(tokens, "all");
@@ -2106,6 +2136,9 @@ bool allEventSourcesSelected(std::string_view rawFilter) {
 
 std::vector<std::string> selectedEventSourceTokens(std::string_view rawFilter) {
   std::vector<std::string> tokens;
+  if (eventPlaylistUsesDefaultSources(rawFilter)) {
+    return defaultEventPlaylistSourceTokens();
+  }
   if (allEventSourcesSelected(rawFilter)) {
     for (const EventFilterOption &option : EVENT_FILTER_OPTIONS) {
       if (std::string_view{option.value} != "all") {
@@ -2152,6 +2185,9 @@ const char *eventFilterLabel(std::string_view value) {
 }
 
 std::string eventFilterPreview(std::string_view rawFilter) {
+  if (eventPlaylistUsesDefaultSources(rawFilter)) {
+    return "Default events";
+  }
   const std::vector<std::string> selected = selectedEventSourceTokens(rawFilter);
   if (allEventSourcesSelected(rawFilter)) {
     return "All events";
@@ -7767,7 +7803,7 @@ void SubtrActorPlugin::renderModuleSummaryControls(
       renderEventFilterModuleSummaryToggle("Flip reset", "flip_reset", idSuffix, toggleWidth);
       renderEventFilterModuleSummaryToggle("Double tap", "double_tap", idSuffix, toggleWidth);
       renderEventFilterModuleSummaryToggle("Musty flick", "musty_flick", idSuffix, toggleWidth);
-      renderEventFilterModuleSummaryToggle("Demo", "demo", idSuffix, toggleWidth);
+      renderEventFilterModuleSummaryToggle("Demos", "demo", idSuffix, toggleWidth);
       renderBoolModuleSummaryToggle(
           "Team event playlist",
           eventPlaylistTeamEventsEnabled,
@@ -8382,6 +8418,9 @@ void SubtrActorPlugin::renderEventSourceControls() {
 }
 
 bool SubtrActorPlugin::eventPlaylistSourceEnabled(const UiEventRecord &event) const {
+  if (eventPlaylistUsesDefaultSources(eventPlaylistSourceFilter)) {
+    return defaultEventPlaylistSourceAllows(event.category, event.type);
+  }
   return eventFilterAllows(eventPlaylistSourceFilter, event.category, event.type);
 }
 
@@ -10414,7 +10453,7 @@ void SubtrActorPlugin::applyReplayReviewUiWorkspace() {
   eventPlaylistTeamEventsEnabled = true;
   eventPlaylistGoalContextEnabled = true;
   eventPlaylistAutoFollow = true;
-  eventPlaylistSourceFilter = "all";
+  eventPlaylistSourceFilter = "default";
   resetWindowPlacements();
   mechanicsReviewPlacement.pending_focus = true;
   replayLoadingPlacement.pending_focus = true;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7900,16 +7900,17 @@ void SubtrActorPlugin::renderLauncherWindow() {
   renderModuleSettingsControls("launcher-module-settings", false, true);
 
   if (ImGui::TreeNode("Plugin tools##launcher-plugin-tools")) {
-    if (ImGui::Button("Verify graph", ImVec2{170.0f, 0.0f})) {
+    const float pluginToolButtonWidth = ImGui::GetContentRegionAvail().x;
+    if (ImGui::Button("Verify graph", ImVec2{pluginToolButtonWidth, 0.0f})) {
       showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
       verifyGraphRuntime({"subtr_actor_verify_graph"});
       hideLauncherWindow();
     }
-    if (ImGui::Button("Open modules", ImVec2{170.0f, 0.0f})) {
+    if (ImGui::Button("Open modules", ImVec2{pluginToolButtonWidth, 0.0f})) {
       showSingletonWindow(uiModuleControlsOpen, moduleControlsPlacement);
       hideLauncherWindow();
     }
-    if (ImGui::Button("Close launcher", ImVec2{170.0f, 0.0f})) {
+    if (ImGui::Button("Close launcher", ImVec2{pluginToolButtonWidth, 0.0f})) {
       hideLauncherWindow();
     }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -65,6 +65,27 @@ float rightAnchoredUiX(float width, float margin = 16.0f) {
   return std::max(16.0f, viewportWidth - width - margin);
 }
 
+std::string formatEventPlaylistTime(float seconds) {
+  if (!std::isfinite(seconds)) {
+    return "--";
+  }
+  const float clampedSeconds = std::max(0.0f, seconds);
+  const int minutes = static_cast<int>(std::floor(clampedSeconds / 60.0f));
+  const float remainingSeconds = clampedSeconds - static_cast<float>(minutes * 60);
+  return std::format("{}:{:04.1f}", minutes, remainingSeconds);
+}
+
+std::string joinStrings(const std::vector<std::string> &parts, std::string_view separator) {
+  std::string joined;
+  for (const std::string &part : parts) {
+    if (!joined.empty()) {
+      joined.append(separator);
+    }
+    joined.append(part);
+  }
+  return joined;
+}
+
 constexpr char FRAME_EVENTS_STATE_NODE[] = "frame_events_state";
 constexpr std::array<const char *, 7> FRAME_EVENTS_STATE_EVENT_FIELDS{
     "active_demos",
@@ -8461,9 +8482,9 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
       (!eventPlaylistMechanicsEnabled && !eventPlaylistTeamEventsEnabled &&
        !eventPlaylistGoalContextEnabled) ||
       selectedSources.empty();
-  ImGui::Text("Filters %zu / %zu", selectedSourceCount, playlistSources.size());
+  ImGui::Text("Filters %zu/%zu", selectedSourceCount, playlistSources.size());
   if (renderModuleSummaryToggle(
-          std::format("All ({})", recentUiEvents.size()).c_str(),
+          "All",
           allSourcesEnabled,
           "event-playlist-sources")) {
     eventPlaylistMechanicsEnabled = true;
@@ -8555,9 +8576,14 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     const ImVec4 color = toImVec4(event.color);
     const bool active = activeEventIndex && *activeEventIndex == index;
     const float seekTime = eventSeekTime(event);
-    const std::string buttonLabel =
-        std::format("{} {:.2f}s##event-playlist-cue", active ? ">" : "Cue", event.time);
-    if (ImGui::SmallButton(buttonLabel.c_str())) {
+    const std::string timeLabel = formatEventPlaylistTime(event.time);
+    const std::string eventLabel = event.label.empty() ? event.type : event.label;
+    const std::string itemLabel =
+        std::format("{}  {}##event-playlist-item", timeLabel, eventLabel);
+    ImGui::PushStyleColor(ImGuiCol_Text, color);
+    const bool selected = ImGui::Selectable(itemLabel.c_str(), active);
+    ImGui::PopStyleColor();
+    if (selected) {
       mechanicsReviewClipActive = false;
       playbackCurrentTime = seekTime;
       playbackSkipPostGoalTransitions = false;
@@ -8572,16 +8598,23 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
             std::format("Selected {} at {:.2f}s; open a replay to seek", event.label, seekTime);
       }
     }
-    ImGui::SameLine();
-    ImGui::TextColored(color, "%.2fs", event.time);
-    ImGui::SameLine();
-    ImGui::TextColored(color, "%s", event.actor.c_str());
-    ImGui::SameLine();
-    ImGui::TextWrapped("%s", event.label.c_str());
+    std::vector<std::string> metaParts;
+    if (!event.actor.empty()) {
+      metaParts.push_back(event.actor);
+    }
+    if (event.frame_number != 0) {
+      metaParts.push_back(std::format("frame {}", event.frame_number));
+    }
+    if (!event.type.empty()) {
+      metaParts.push_back(event.type);
+    }
+    if (!metaParts.empty()) {
+      ImGui::TextDisabled("%s", joinStrings(metaParts, " / ").c_str());
+    }
     if (!event.details.empty()) {
       ImGui::TextDisabled("%s", event.details.c_str());
     }
-    ImGui::TextDisabled("%s / %s", event.category.c_str(), event.type.c_str());
+    ImGui::TextDisabled("%s", event.category.c_str());
     if (active && eventPlaylistAutoFollow) {
       ImGui::SetScrollHereY(0.5f);
     }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7160,6 +7160,14 @@ void SubtrActorPlugin::showSingletonWindow(bool &open, UiWindowPlacement &placem
   focusSingletonWindow(placement);
 }
 
+void SubtrActorPlugin::hideSingletonWindow(bool &open) {
+  if (!open) {
+    return;
+  }
+  open = false;
+  scheduleUiConfigAutosave();
+}
+
 void SubtrActorPlugin::hideLauncherWindow() {
   if (!uiLauncherOpen) {
     return;
@@ -7216,8 +7224,7 @@ bool SubtrActorPlugin::renderSingletonWindowHeader(const char *label, bool &open
     ImGui::SetCursorPosX(rightAlignedX);
   }
   if (ImGui::SmallButton(hideLabel.c_str())) {
-    open = false;
-    scheduleUiConfigAutosave();
+    hideSingletonWindow(open);
     return true;
   }
   ImGui::Separator();
@@ -7656,9 +7663,8 @@ void SubtrActorPlugin::renderLauncherWorkspaceControls() {
       if (std::string_view{window.config_id} == "scoreboard") {
         continue;
       }
-      *window.open = false;
+      hideSingletonWindow(*window.open);
     }
-    scheduleUiConfigAutosave();
   }
   renderLayoutConfigControls("launcher-workspace-layout");
 }
@@ -7679,8 +7685,7 @@ void SubtrActorPlugin::renderWebWindowToggleControls(
         std::format("{}   {}", window.label, isOpen ? "Hide" : "Show");
     if (ImGui::Button(buttonLabel.c_str(), ImVec2{210.0f, 0.0f})) {
       if (*window.open) {
-        *window.open = false;
-        scheduleUiConfigAutosave();
+        hideSingletonWindow(*window.open);
       } else {
         showSingletonWindow(*window.open, *window.placement);
       }
@@ -10192,9 +10197,8 @@ void SubtrActorPlugin::renderSingletonWindowManager() {
   ImGui::SameLine();
   if (ImGui::SmallButton("Hide all##singleton-windows")) {
     for (SingletonWindowControl &window : windows) {
-      *window.open = false;
+      hideSingletonWindow(*window.open);
     }
-    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (ImGui::SmallButton("Focus visible##singleton-windows")) {
@@ -10210,8 +10214,7 @@ void SubtrActorPlugin::renderSingletonWindowManager() {
     ImGui::PushID(window.label);
     if (*window.open) {
       if (ImGui::SmallButton("Hide")) {
-        *window.open = false;
-        scheduleUiConfigAutosave();
+        hideSingletonWindow(*window.open);
       }
       ImGui::SameLine();
       if (ImGui::SmallButton("Focus")) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -419,8 +419,8 @@ int recordingPlaybackRateIndexForValue(double value) {
 ImVec2 mapWindowPositionToViewport(
     float x,
     float y,
-    float width,
-    float height,
+    float /*width*/,
+    float /*height*/,
     float sourceViewportWidth,
     float sourceViewportHeight) {
   const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
@@ -429,12 +429,12 @@ ImVec2 mapWindowPositionToViewport(
   }
 
   constexpr float margin = 8.0f;
+  constexpr float minimumVisibleWidth = 120.0f;
+  constexpr float minimumVisibleHeight = 100.0f;
   const float scaleX = sourceViewportWidth > 0.0f ? displaySize.x / sourceViewportWidth : 1.0f;
   const float scaleY = sourceViewportHeight > 0.0f ? displaySize.y / sourceViewportHeight : 1.0f;
-  const float clampedWidth = std::max(120.0f, width);
-  const float clampedHeight = std::max(80.0f, height);
-  const float maxX = std::max(margin, displaySize.x - clampedWidth);
-  const float maxY = std::max(margin, displaySize.y - clampedHeight);
+  const float maxX = std::max(margin, displaySize.x - minimumVisibleWidth);
+  const float maxY = std::max(margin, displaySize.y - minimumVisibleHeight);
   return ImVec2{
       std::clamp(x * scaleX, margin, maxX),
       std::clamp(y * scaleY, margin, maxY),

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -6935,6 +6935,7 @@ void SubtrActorPlugin::RenderSettings() {
     ImGui::SetCurrentContext(reinterpret_cast<ImGuiContext *>(imguiContext));
   }
   renderSharedSettingsControls();
+  renderSettingsWindowControls();
 }
 
 void SubtrActorPlugin::renderSharedSettingsControls() {
@@ -7580,7 +7581,42 @@ void SubtrActorPlugin::renderLauncherWorkspaceControls() {
   renderLayoutConfigControls("launcher-workspace-layout");
 }
 
-void SubtrActorPlugin::renderLauncherStatsWindowControls() {
+void SubtrActorPlugin::renderWebWindowToggleControls(
+    const char *idSuffix,
+    bool closeLauncherOnToggle) {
+  ImGui::PushID(idSuffix);
+  for (const SingletonWindowControl &window : webSingletonWindowControls()) {
+    ImGui::PushID(window.label);
+    const bool isOpen = window.open != nullptr && *window.open;
+    if (isOpen) {
+      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.16f, 0.35f, 0.28f, 1.0f});
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.25f, 0.55f, 0.43f, 1.0f});
+    }
+    const std::string buttonLabel =
+        std::format("{}   {}", window.label, isOpen ? "Hide" : "Show");
+    if (ImGui::Button(buttonLabel.c_str(), ImVec2{210.0f, 0.0f})) {
+      if (*window.open) {
+        *window.open = false;
+      } else {
+        showSingletonWindow(*window.open, *window.placement);
+      }
+      if (closeLauncherOnToggle) {
+        uiLauncherOpen = false;
+      }
+    }
+    if (isOpen) {
+      ImGui::PopStyleColor(3);
+    }
+    ImGui::PopID();
+  }
+  ImGui::PopID();
+}
+
+void SubtrActorPlugin::renderStatsWindowCreationControls(
+    const char *idSuffix,
+    bool closeLauncherOnCreate) {
+  ImGui::PushID(idSuffix);
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STATS WINDOWS");
   for (const StatsWindowKindControl &kind : statsWindowKindControls()) {
     if (!kind.web_config) {
@@ -7588,15 +7624,20 @@ void SubtrActorPlugin::renderLauncherStatsWindowControls() {
     }
     if (ImGui::Button(kind.create_label, ImVec2{170.0f, 0.0f})) {
       createStatsWindow(kind.kind);
-      uiLauncherOpen = false;
+      if (closeLauncherOnCreate) {
+        uiLauncherOpen = false;
+      }
     }
   }
   if (!statsModuleNames().empty() &&
       ImGui::Button("New stats module", ImVec2{170.0f, 0.0f})) {
     createStatsWindow(UiStatsWindowKind::StatsModule);
-    uiLauncherOpen = false;
+    if (closeLauncherOnCreate) {
+      uiLauncherOpen = false;
+    }
   }
   if (uiStatsWindows.empty()) {
+    ImGui::PopID();
     return;
   }
 
@@ -7609,6 +7650,17 @@ void SubtrActorPlugin::renderLauncherStatsWindowControls() {
       visibleStatsWindows,
       uiStatsWindows.size());
   renderStatsWindowManager();
+  ImGui::PopID();
+}
+
+void SubtrActorPlugin::renderSettingsWindowControls() {
+  ImGui::Separator();
+  ImGui::Text("Windows");
+  renderWebWindowToggleControls("settings-web-windows", false);
+  renderSingletonWindowManager();
+
+  ImGui::Separator();
+  renderStatsWindowCreationControls("settings-stats-windows", false);
 }
 
 void SubtrActorPlugin::renderLauncherWindow() {
@@ -7639,36 +7691,11 @@ void SubtrActorPlugin::renderLauncherWindow() {
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
-  auto renderLauncherWindowToggle = [&](const SingletonWindowControl &window) {
-    ImGui::PushID(window.label);
-    const bool isOpen = window.open != nullptr && *window.open;
-    if (isOpen) {
-      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.16f, 0.35f, 0.28f, 1.0f});
-      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
-      ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.25f, 0.55f, 0.43f, 1.0f});
-    }
-    const std::string buttonLabel =
-        std::format("{}   {}", window.label, isOpen ? "Hide" : "Show");
-    if (ImGui::Button(buttonLabel.c_str(), ImVec2{210.0f, 0.0f})) {
-      if (*window.open) {
-        *window.open = false;
-      } else {
-        showSingletonWindow(*window.open, *window.placement);
-      }
-      uiLauncherOpen = false;
-    }
-    if (isOpen) {
-      ImGui::PopStyleColor(3);
-    }
-    ImGui::PopID();
-  };
-  for (const SingletonWindowControl &window : webSingletonWindowControls()) {
-    renderLauncherWindowToggle(window);
-  }
+  renderWebWindowToggleControls("launcher-web-windows", true);
   renderSingletonWindowManager();
 
   ImGui::Separator();
-  renderLauncherStatsWindowControls();
+  renderStatsWindowCreationControls("launcher-stats-windows", true);
 
   ImGui::Separator();
   renderLauncherWorkspaceControls();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7822,36 +7822,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "MODULE SETTINGS");
   renderModuleSettingsControls("launcher-module-settings", true);
 
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "GRAPH STATS MODULES");
-  const std::vector<std::string> &moduleNames = statsModuleNames();
-  if (moduleNames.empty()) {
-    ImGui::TextWrapped("Start live analysis to list graph-backed stats modules.");
-  } else {
-    ImGui::BeginChild("launcher-graph-stats-modules", ImVec2{0.0f, 130.0f}, true);
-    for (const std::string &moduleName : moduleNames) {
-      ImGui::PushID(moduleName.c_str());
-      if (ImGui::SmallButton("Frame")) {
-        createStatsModuleWindow(moduleName, 0);
-        hideLauncherWindow();
-      }
-      ImGui::SameLine();
-      if (ImGui::SmallButton("Module")) {
-        createStatsModuleWindow(moduleName, 1);
-        hideLauncherWindow();
-      }
-      ImGui::SameLine();
-      if (ImGui::SmallButton("Config")) {
-        createStatsModuleWindow(moduleName, 2);
-        hideLauncherWindow();
-      }
-      ImGui::SameLine();
-      ImGui::TextWrapped("%s", moduleName.c_str());
-      ImGui::PopID();
-    }
-    ImGui::EndChild();
-  }
-
   if (ImGui::TreeNode("Plugin tools##launcher-plugin-tools")) {
     if (ImGui::Button("Verify graph", ImVec2{170.0f, 0.0f})) {
       showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
@@ -7864,6 +7834,36 @@ void SubtrActorPlugin::renderLauncherWindow() {
     }
     if (ImGui::Button("Close launcher", ImVec2{170.0f, 0.0f})) {
       hideLauncherWindow();
+    }
+
+    ImGui::Separator();
+    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "GRAPH STATS MODULES");
+    const std::vector<std::string> &moduleNames = statsModuleNames();
+    if (moduleNames.empty()) {
+      ImGui::TextWrapped("Start live analysis to list graph-backed stats modules.");
+    } else {
+      ImGui::BeginChild("launcher-graph-stats-modules", ImVec2{0.0f, 130.0f}, true);
+      for (const std::string &moduleName : moduleNames) {
+        ImGui::PushID(moduleName.c_str());
+        if (ImGui::SmallButton("Frame")) {
+          createStatsModuleWindow(moduleName, 0);
+          hideLauncherWindow();
+        }
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Module")) {
+          createStatsModuleWindow(moduleName, 1);
+          hideLauncherWindow();
+        }
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Config")) {
+          createStatsModuleWindow(moduleName, 2);
+          hideLauncherWindow();
+        }
+        ImGui::SameLine();
+        ImGui::TextWrapped("%s", moduleName.c_str());
+        ImGui::PopID();
+      }
+      ImGui::EndChild();
     }
 
     ImGui::Separator();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8266,6 +8266,11 @@ void SubtrActorPlugin::renderModuleSettingsControls(
     if (webCardHeaders) {
       ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STAT DISPLAY");
       ImGui::Text("%s", title);
+      ImGui::SameLine(std::max(
+          ImGui::GetCursorPosX(),
+          ImGui::GetWindowContentRegionMax().x - ImGui::CalcTextSize(readout.c_str()).x));
+      ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", readout.c_str());
+      return;
     } else {
       ImGui::TextDisabled("%s", title);
     }
@@ -8273,7 +8278,31 @@ void SubtrActorPlugin::renderModuleSettingsControls(
     ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", readout.c_str());
   };
 
+  auto beginModuleSettingsCard = [&](const char *cardId, float height) {
+    if (!webCardHeaders) {
+      return false;
+    }
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{12.0f, 10.0f});
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4{1.0f, 1.0f, 1.0f, 0.035f});
+    ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{1.0f, 1.0f, 1.0f, 0.08f});
+    ImGui::BeginChild(cardId, ImVec2{0.0f, height}, true);
+    return true;
+  };
+
+  auto endModuleSettingsCard = [&]() {
+    if (!webCardHeaders) {
+      return;
+    }
+    ImGui::EndChild();
+    ImGui::PopStyleColor(2);
+    ImGui::PopStyleVar(2);
+  };
+
   if (!onlyWebActivePanels) {
+    const bool movementCard = beginModuleSettingsCard(
+        "module-settings-card-movement",
+        includeOpenButtons ? 116.0f : 84.0f);
     renderSettingsHeader(
         "Movement breakdown",
         settingReadout(
@@ -8289,6 +8318,9 @@ void SubtrActorPlugin::renderModuleSettingsControls(
     if (includeOpenButtons && ImGui::Button("Open movement stats")) {
       createStatsModuleWindow("movement", 0);
     }
+    if (movementCard) {
+      endModuleSettingsCard();
+    }
     renderedPanel = true;
   }
 
@@ -8296,6 +8328,9 @@ void SubtrActorPlugin::renderModuleSettingsControls(
     ImGui::Spacing();
   }
   if (!onlyWebActivePanels || timelineRangePossessionEnabled) {
+    const bool possessionCard = beginModuleSettingsCard(
+        "module-settings-card-possession",
+        includeOpenButtons ? 116.0f : 84.0f);
     renderSettingsHeader(
         "Possession breakdown",
         settingReadout(
@@ -8311,6 +8346,10 @@ void SubtrActorPlugin::renderModuleSettingsControls(
     if (includeOpenButtons && ImGui::Button("Open possession stats")) {
       createStatsModuleWindow("possession", 0);
     }
+    if (possessionCard) {
+      endModuleSettingsCard();
+    }
+    renderedPanel = true;
   }
 
   ImGui::PopID();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -12113,6 +12113,63 @@ void SubtrActorPlugin::renderAllTeamsStatsTable(UiStatsWindow &window) {
 
 void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
   (void)window;
+  auto isGoalTagEvent = [](const UiEventRecord &event) {
+    if (event.category != "mechanics") {
+      return false;
+    }
+    return event.type == "aerial_goal" || event.type == "high_aerial_goal" ||
+           event.type == "long_distance_goal" || event.type == "own_half_goal" ||
+           event.type == "empty_net_goal" || event.type == "counter_attack_goal" ||
+           event.type == "flick_goal" || event.type == "double_tap_goal" ||
+           event.type == "one_timer_goal" || event.type == "passing_goal" ||
+           event.type == "air_dribble_goal" || event.type == "flip_reset_goal" ||
+           event.type == "half_volley_goal";
+  };
+  auto goalTagText = [](const UiEventRecord &event) {
+    std::string label = event.label;
+    if (!event.actor.empty()) {
+      const std::string actorPrefix = event.actor + " ";
+      if (label.rfind(actorPrefix, 0) == 0) {
+        label = label.substr(actorPrefix.size());
+      }
+    }
+
+    std::string confidence = "100%";
+    const size_t parenthesizedConfidence = label.rfind(" (");
+    if (parenthesizedConfidence != std::string::npos && !label.empty() &&
+        label.back() == ')' &&
+        label.find('%', parenthesizedConfidence) != std::string::npos) {
+      confidence = label.substr(
+          parenthesizedConfidence + 2,
+          label.size() - parenthesizedConfidence - 3);
+      label = label.substr(0, parenthesizedConfidence);
+    } else if (const size_t percent = event.details.find('%');
+               percent != std::string::npos) {
+      const size_t start = event.details.rfind(' ', percent);
+      confidence = event.details.substr(start == std::string::npos ? 0 : start + 1, percent + 1);
+    }
+
+    return std::format("{} {}", label, confidence);
+  };
+  auto goalTagsForEvent = [&](const UiEventRecord &goalEvent) {
+    std::vector<std::string> tags;
+    for (const UiEventRecord &candidate : recentUiEvents) {
+      if (!isGoalTagEvent(candidate)) {
+        continue;
+      }
+      const bool samePlayer = goalEvent.has_player == 0 || candidate.has_player == 0 ||
+                              goalEvent.player_index == candidate.player_index;
+      const bool sameFrame = candidate.frame_number == goalEvent.frame_number;
+      const bool nearbyTime = std::fabs(candidate.time - goalEvent.time) <= 0.25f;
+      if (samePlayer && (sameFrame || nearbyTime)) {
+        tags.push_back(goalTagText(candidate));
+      }
+    }
+    std::sort(tags.begin(), tags.end());
+    tags.erase(std::unique(tags.begin(), tags.end()), tags.end());
+    return tags;
+  };
+
   std::vector<size_t> goalEventIndexes;
   goalEventIndexes.reserve(recentUiEvents.size());
   for (size_t index = 0; index < recentUiEvents.size(); index += 1) {
@@ -12143,7 +12200,8 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
         "%s · %s",
         formatEventPlaylistTime(event.time).c_str(),
         event.actor.empty() ? "Unknown scorer" : event.actor.c_str());
-    ImGui::TextDisabled("%s", event.details.empty() ? "Unlabeled" : event.details.c_str());
+    const std::vector<std::string> tags = goalTagsForEvent(event);
+    ImGui::TextDisabled("%s", tags.empty() ? "Unlabeled" : joinStrings(tags, " · ").c_str());
     if (ImGui::SmallButton("Watch")) {
       mechanicsReviewClipActive = false;
       playbackCurrentTime = seekTime;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8593,16 +8593,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
   }
   const bool launcherHovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
 
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ACTIONS");
-  const float actionButtonWidth = ImGui::GetContentRegionAvail().x;
-  if (ImGui::Button("Load Replay...", ImVec2{actionButtonWidth, 0.0f})) {
-    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
-    resetReplayAnnotations();
-    tickReplayAnnotations();
-    hideLauncherWindow();
-  }
-
-  ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
   renderWebWindowToggleControls("launcher-web-windows", true, false, true);
   renderStatsWindowCreationControls("launcher-stats-windows", true, false, false, true);
@@ -8646,9 +8636,8 @@ void SubtrActorPlugin::renderEmptyStateWindow() {
     return;
   }
 
-  ImGui::TextUnformatted("Load a replay to start.");
-  if (ImGui::Button("Load Replay...", ImVec2{150.0f, 0.0f})) {
-    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
+  ImGui::TextUnformatted("Open a replay in Rocket League to start.");
+  if (gameWrapper->IsInReplay() && ImGui::Button("Refresh current replay", ImVec2{190.0f, 0.0f})) {
     resetReplayAnnotations();
     tickReplayAnnotations();
   }
@@ -9690,24 +9679,12 @@ void SubtrActorPlugin::renderModuleControlsWindow() {
     showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
   }
   ImGui::SameLine();
-  if (ImGui::Button("Open camera")) {
-    showSingletonWindow(uiCameraOpen, cameraPlacement);
-  }
-  ImGui::SameLine();
   if (ImGui::Button("Open event playlist")) {
     showSingletonWindow(uiEventPlaylistOpen, eventPlaylistPlacement);
   }
   ImGui::SameLine();
-  if (ImGui::Button("Open review")) {
-    showSingletonWindow(uiMechanicsReviewOpen, mechanicsReviewPlacement);
-  }
-  ImGui::SameLine();
   if (ImGui::Button("Open recording")) {
     showSingletonWindow(uiRecordingOpen, recordingPlacement);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Open replay loading")) {
-    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
   }
   ImGui::SameLine();
   if (ImGui::Button("Open touch controls")) {
@@ -10841,7 +10818,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "camera",
        "camera_open",
        "camera",
-       true,
+       false,
        0,
        &uiCameraOpen,
        &cameraPlacement,
@@ -10853,7 +10830,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "playback",
        "playback_controls_open",
        "playback_controls",
-       true,
+       false,
        2,
        &uiPlaybackControlsOpen,
        &playbackControlsPlacement,
@@ -10889,7 +10866,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "mechanics-review",
        "mechanics_review_open",
        "mechanics_review",
-       true,
+       false,
        6,
        &uiMechanicsReviewOpen,
        &mechanicsReviewPlacement,
@@ -10901,7 +10878,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "replay-loading",
        "replay_loading_open",
        "replay_loading",
-       true,
+       false,
        7,
        &uiReplayLoadingOpen,
        &replayLoadingPlacement,
@@ -11238,9 +11215,8 @@ void SubtrActorPlugin::applyWorkspaceWindowVisibility(
 }
 
 void SubtrActorPlugin::applyDefaultUiWorkspace() {
-  applyWorkspaceWindowVisibility(false, {"scoreboard", "camera"});
+  applyWorkspaceWindowVisibility(false, {"scoreboard"});
   resetWindowPlacements();
-  cameraPlacement.pending_focus = true;
 }
 
 void SubtrActorPlugin::applyReplayReviewUiWorkspace() {
@@ -11249,10 +11225,6 @@ void SubtrActorPlugin::applyReplayReviewUiWorkspace() {
       {"scoreboard",
        "mechanics",
        "event-playlist",
-       "camera",
-       "playback",
-       "mechanics-review",
-       "replay-loading",
        "touch-controls",
        "boost-pickups"});
   eventPlaylistMechanicsEnabled = true;
@@ -11262,8 +11234,7 @@ void SubtrActorPlugin::applyReplayReviewUiWorkspace() {
   eventPlaylistSourceFilter = "default";
   eventPlaylistLastActiveKey.clear();
   resetWindowPlacements();
-  mechanicsReviewPlacement.pending_focus = true;
-  replayLoadingPlacement.pending_focus = true;
+  eventPlaylistPlacement.pending_focus = true;
 }
 
 void SubtrActorPlugin::applyGraphDebugUiWorkspace() {
@@ -11272,7 +11243,6 @@ void SubtrActorPlugin::applyGraphDebugUiWorkspace() {
       {"mechanics",
        "event-playlist",
        "status",
-       "playback",
        "graph-inspector",
        "module-controls"});
   resetWindowPlacements();
@@ -11281,12 +11251,9 @@ void SubtrActorPlugin::applyGraphDebugUiWorkspace() {
 }
 
 void SubtrActorPlugin::applyRecordingUiWorkspace() {
-  applyWorkspaceWindowVisibility(
-      true,
-      {"scoreboard", "status", "camera", "playback", "recording"});
+  applyWorkspaceWindowVisibility(true, {"scoreboard", "status", "recording"});
   resetWindowPlacements();
   recordingPlacement.pending_focus = true;
-  cameraPlacement.pending_focus = true;
 }
 
 void SubtrActorPlugin::createStatsWindow(UiStatsWindowKind kind, bool initializeEntries) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1979,6 +1979,19 @@ bool isMechanicFilterToken(std::string_view token) {
       [token](const char *option) { return token == std::string_view{option}; });
 }
 
+std::string webTimelineEventSourceIdForFilterToken(std::string_view token) {
+  if (token == "goal" || token == "mechanics" || token == "team" || token == "goal_context") {
+    return {};
+  }
+  if (token != "touch" && !isMechanicFilterToken(token)) {
+    return {};
+  }
+
+  std::string id{token};
+  std::replace(id.begin(), id.end(), '_', '-');
+  return id;
+}
+
 void appendUniqueFilterToken(std::vector<std::string> &tokens, std::string_view token) {
   if (token.empty() || token == "all" || containsString(tokens, token)) {
     return;
@@ -4024,30 +4037,34 @@ std::string SubtrActorPlugin::uiConfigJson() {
       selectedEventSourceTokens(currentEventFilter);
   file << "    \"timelineEvents\": [";
   bool wroteOverlayValue = false;
-  auto writeOverlayId = [&](const char *id, bool enabled) {
+  std::unordered_set<std::string> wroteOverlayIds;
+  auto resetOverlayWriter = [&]() {
+    wroteOverlayValue = false;
+    wroteOverlayIds.clear();
+  };
+  auto writeOverlayId = [&](std::string_view id, bool enabled) {
     if (!enabled) {
+      return;
+    }
+    std::string idString{id};
+    if (!wroteOverlayIds.insert(idString).second) {
       return;
     }
     if (wroteOverlayValue) {
       file << ",";
     }
-    file << "\"" << id << "\"";
+    file << "\"" << escapeJsonString(id) << "\"";
     wroteOverlayValue = true;
   };
-  writeOverlayId("team", eventPlaylistTeamEventsEnabled);
-  writeOverlayId("goal_context", eventPlaylistGoalContextEnabled);
-  if (!allEventSourcesSelected(currentEventFilter)) {
-    for (const std::string &token : currentEventFilterTokens) {
-      if (token == "mechanics" || token == "team" || token == "goal_context" ||
-          isMechanicFilterToken(token)) {
-        continue;
-      }
-      writeOverlayId(token.c_str(), true);
+  for (const std::string &token : currentEventFilterTokens) {
+    if (const std::string sourceId = webTimelineEventSourceIdForFilterToken(token);
+        !sourceId.empty()) {
+      writeOverlayId(sourceId, true);
     }
   }
   file << "],\n";
   file << "    \"timelineRanges\": [";
-  wroteOverlayValue = false;
+  resetOverlayWriter();
   writeOverlayId("boost", timelineRangeBoostEnabled);
   writeOverlayId("possession", timelineRangePossessionEnabled);
   writeOverlayId("pressure", timelineRangePressureEnabled);
@@ -4081,7 +4098,7 @@ std::string SubtrActorPlugin::uiConfigJson() {
   }
   file << "],\n";
   file << "    \"renderEffects\": [";
-  wroteOverlayValue = false;
+  resetOverlayWriter();
   const bool hudOverlayEnabled = cvarBool("subtr_actor_overlay_enabled", true);
   writeOverlayId("ceiling-shot", hudOverlayEnabled && renderEffectCeilingShotEnabled);
   writeOverlayId("fifty-fifty", hudOverlayEnabled && renderEffectFiftyFiftyEnabled);
@@ -4096,7 +4113,7 @@ std::string SubtrActorPlugin::uiConfigJson() {
   writeOverlayId("touch", hudOverlayEnabled && renderEffectTouchEnabled);
   file << "],\n";
   file << "    \"pluginRenderEffects\": [";
-  wroteOverlayValue = false;
+  resetOverlayWriter();
   writeOverlayId(
       "mechanics",
       cvarBool("subtr_actor_overlay_mechanics_enabled", true));

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8578,60 +8578,8 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
         static_cast<int>(candidates.size()) - 1);
   }
 
-  int confirmedCount = 0;
-  int rejectedCount = 0;
-  int uncertainCount = 0;
-  for (const size_t index : candidates) {
-    const auto decision = mechanicsReviewDecisions.find(mechanicsReviewKey(recentUiEvents[index]));
-    if (decision == mechanicsReviewDecisions.end()) {
-      continue;
-    }
-    confirmedCount += decision->second == 1 ? 1 : 0;
-    rejectedCount += decision->second == 2 ? 1 : 0;
-    uncertainCount += decision->second == 3 ? 1 : 0;
-  }
-
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REVIEW QUEUE");
-  ImGui::Text(
-      "%zu candidates | %d confirmed | %d rejected | %d uncertain",
-      candidates.size(),
-      confirmedCount,
-      rejectedCount,
-      uncertainCount);
-  if (ImGui::Checkbox("Mechanics", &eventPlaylistMechanicsEnabled)) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::Checkbox("Team", &eventPlaylistTeamEventsEnabled)) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::Checkbox("Goal context", &eventPlaylistGoalContextEnabled)) {
-    scheduleUiConfigAutosave();
-  }
-
-  renderEventFilterCombo("Event filter");
-  ImGui::SetNextItemWidth(120.0f);
-  if (ImGui::SliderFloat("Clip lead", &mechanicsReviewClipLeadSeconds, 0.0f, 10.0f, "%.1fs")) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(120.0f);
-  if (ImGui::SliderFloat(
-          "Clip trail", &mechanicsReviewClipTrailSeconds, 0.0f, 10.0f, "%.1fs")) {
-    scheduleUiConfigAutosave();
-  }
-
-  ImGui::Separator();
   if (candidates.empty()) {
-    ImGui::TextWrapped("No visible events match the current review filters.");
-    if (ImGui::Button("Open events")) {
-      showSingletonWindow(uiEventsOpen, eventsPlacement);
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Open playlist")) {
-      showSingletonWindow(uiEventPlaylistOpen, eventPlaylistPlacement);
-    }
+    ImGui::TextWrapped("No candidate selected");
     ImGui::End();
     return;
   }
@@ -8723,15 +8671,6 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   }
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REPLAY");
-  ImGui::Text(
-      "Replay annotations: %s",
-      replayAnnotations ? "loaded" : replayAnnotationLoadFailed ? "failed" : "idle");
-  if (!replayAnnotationPath.empty()) {
-    ImGui::TextWrapped("%s", replayAnnotationPath.c_str());
-  }
-
-  ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PLAYLIST");
   ImGui::BeginChild("mechanics-review-list", ImVec2{0.0f, 150.0f}, true);
   for (size_t i = 0; i < candidates.size(); i += 1) {
@@ -8752,7 +8691,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
       metaParts.push_back(event.type);
     }
     metaParts.push_back(mechanicsReviewDecisionLabel(event));
-    ImGui::TextDisabled("%s", joinStrings(metaParts, " / ").c_str());
+    ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());
     ImGui::PopID();
   }
   ImGui::EndChild();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -2789,9 +2789,10 @@ void SubtrActorPlugin::onLoad() {
       "subtr_actor_toggle_ui",
       [this](std::vector<std::string>) {
         uiWindowOpen = true;
-        uiLauncherOpen = !uiLauncherOpen;
         if (uiLauncherOpen) {
-          focusSingletonWindow(launcherPlacement);
+          hideLauncherWindow();
+        } else {
+          showSingletonWindow(uiLauncherOpen, launcherPlacement);
         }
       },
       "Toggles the subtr-actor in-game launcher window.",

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9274,11 +9274,22 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   ImGui::TextWrapped("%s", reasonReadout.c_str());
   ImGui::Columns(1);
 
-  auto mechanicsReviewButton = [](const char *label, bool disabled) {
+  auto mechanicsReviewButton = [](const char *label,
+                                  bool disabled,
+                                  float width,
+                                  std::optional<ImVec4> borderColor = std::nullopt) {
     if (disabled) {
       ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.45f);
     }
-    const bool clicked = ImGui::Button(label);
+    if (borderColor) {
+      ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
+      ImGui::PushStyleColor(ImGuiCol_Border, *borderColor);
+    }
+    const bool clicked = ImGui::Button(label, ImVec2{width, 0.0f});
+    if (borderColor) {
+      ImGui::PopStyleColor();
+      ImGui::PopStyleVar();
+    }
     if (disabled) {
       ImGui::PopStyleVar();
     }
@@ -9289,13 +9300,16 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   const bool nextDisabled =
       current == nullptr || mechanicsReviewIndex >= static_cast<int>(candidates.size()) - 1;
   const bool decisionDisabled = current == nullptr;
+  const float actionGap = ImGui::GetStyle().ItemSpacing.x;
+  const float actionButtonWidth =
+      std::max(72.0f, (ImGui::GetContentRegionAvail().x - actionGap * 2.0f) / 3.0f);
 
-  if (mechanicsReviewButton("Prev", prevDisabled)) {
+  if (mechanicsReviewButton("Prev", prevDisabled, actionButtonWidth)) {
     mechanicsReviewIndex -= 1;
     scheduleUiConfigAutosave();
   }
-  ImGui::SameLine();
-  if (mechanicsReviewButton("Replay clip", replayDisabled)) {
+  ImGui::SameLine(0.0f, actionGap);
+  if (mechanicsReviewButton("Replay clip", replayDisabled, actionButtonWidth)) {
     if (current != nullptr && current->has_player != 0) {
       cameraSelectedPlayerIndex = current->player_index;
       cameraSelectedPlayerId = webPlayerIdForIndex(cameraSelectedPlayerIndex);
@@ -9324,21 +9338,29 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     }
     scheduleUiConfigAutosave();
   }
-  ImGui::SameLine();
-  if (mechanicsReviewButton("Next", nextDisabled)) {
+  ImGui::SameLine(0.0f, actionGap);
+  if (mechanicsReviewButton("Next", nextDisabled, actionButtonWidth)) {
     mechanicsReviewIndex += 1;
     scheduleUiConfigAutosave();
   }
 
-  if (mechanicsReviewButton("Confirm", decisionDisabled)) {
+  if (mechanicsReviewButton(
+          "Confirm",
+          decisionDisabled,
+          actionButtonWidth,
+          ImVec4{0.30f, 0.69f, 0.47f, 0.52f})) {
     mechanicsReviewDecisions[currentKey] = 1;
   }
-  ImGui::SameLine();
-  if (mechanicsReviewButton("Reject", decisionDisabled)) {
+  ImGui::SameLine(0.0f, actionGap);
+  if (mechanicsReviewButton(
+          "Reject",
+          decisionDisabled,
+          actionButtonWidth,
+          ImVec4{0.86f, 0.37f, 0.37f, 0.58f})) {
     mechanicsReviewDecisions[currentKey] = 2;
   }
-  ImGui::SameLine();
-  if (mechanicsReviewButton("Uncertain", decisionDisabled)) {
+  ImGui::SameLine(0.0f, actionGap);
+  if (mechanicsReviewButton("Uncertain", decisionDisabled, actionButtonWidth)) {
     mechanicsReviewDecisions[currentKey] = 3;
   }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9051,6 +9051,16 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   const float clipEnd = current == nullptr ? 0.0f : current->time + mechanicsReviewClipTrailSeconds;
   ImGui::Text("%d / %zu", current == nullptr ? 0 : mechanicsReviewIndex + 1, candidates.size());
   ImGui::TextWrapped("%s", current == nullptr ? "No candidate selected" : current->label.c_str());
+  const std::string statusReadout =
+      mechanicsReviewClipActive
+          ? std::format(
+                "Playing clip {:.2f}s to {:.2f}s",
+                mechanicsReviewClipStartSeconds,
+                mechanicsReviewClipEndSeconds)
+      : !mechanicsReviewStatus.empty() ? mechanicsReviewStatus
+      : candidates.empty()             ? "Load a review playlist."
+                                       : "Loaded review playlist.";
+  ImGui::TextWrapped("%s", statusReadout.c_str());
   const std::string clipReadout =
       current == nullptr ? "--" : std::format("{:.2f}s to {:.2f}s", clipStart, clipEnd);
   const std::string eventReadout =
@@ -9077,15 +9087,6 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   ImGui::TextDisabled("Reason");
   ImGui::TextWrapped("%s", reasonReadout.c_str());
   ImGui::Columns(1);
-  if (mechanicsReviewClipActive || !mechanicsReviewStatus.empty()) {
-    const std::string status = mechanicsReviewClipActive
-                                   ? std::format(
-                                         "Playing clip {:.2f}s to {:.2f}s",
-                                         mechanicsReviewClipStartSeconds,
-                                         mechanicsReviewClipEndSeconds)
-                                   : mechanicsReviewStatus;
-    ImGui::TextWrapped("%s", status.c_str());
-  }
 
   auto mechanicsReviewButton = [](const char *label, bool disabled) {
     if (disabled) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8838,16 +8838,22 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   for (size_t i = 0; i < candidates.size(); i += 1) {
     const UiEventRecord &event = recentUiEvents[candidates[i]];
     ImGui::PushID(static_cast<int>(i));
+    const bool active = i == static_cast<size_t>(mechanicsReviewIndex);
+    const std::string title = event.label.empty() ? event.type : event.label;
     const std::string label = std::format(
-        "{} {:.2f}s {} ({})",
-        i == static_cast<size_t>(mechanicsReviewIndex) ? ">" : " ",
-        event.time,
-        event.label,
-        mechanicsReviewDecisionLabel(event));
-    if (ImGui::Selectable(label.c_str(), i == static_cast<size_t>(mechanicsReviewIndex))) {
+        "{}  {}##mechanics-review-item",
+        formatEventPlaylistTime(event.time),
+        title);
+    if (ImGui::Selectable(label.c_str(), active)) {
       mechanicsReviewIndex = static_cast<int>(i);
       scheduleUiConfigAutosave();
     }
+    std::vector<std::string> metaParts;
+    if (!event.type.empty()) {
+      metaParts.push_back(event.type);
+    }
+    metaParts.push_back(mechanicsReviewDecisionLabel(event));
+    ImGui::TextDisabled("%s", joinStrings(metaParts, " / ").c_str());
     ImGui::PopID();
   }
   ImGui::EndChild();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8522,12 +8522,11 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
       metaParts.push_back(event.type);
     }
     if (!metaParts.empty()) {
-      ImGui::TextDisabled("%s", joinStrings(metaParts, " / ").c_str());
+      ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());
     }
     if (!event.details.empty()) {
       ImGui::TextDisabled("%s", event.details.c_str());
     }
-    ImGui::TextDisabled("%s", event.category.c_str());
     if (active && eventPlaylistAutoFollow) {
       ImGui::SetScrollHereY(0.5f);
     }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8031,7 +8031,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
   renderWebWindowToggleControls("launcher-web-windows", true, false, true);
-  renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);
+  renderStatsWindowCreationControls("launcher-stats-windows", true, false, false, true);
 
   ImGui::Separator();
   renderModuleSummaryControls("launcher-module-summary", false, 0.0f, false);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8323,22 +8323,17 @@ void SubtrActorPlugin::renderEmptyStateWindow() {
 }
 
 std::optional<std::pair<int32_t, int32_t>> SubtrActorPlugin::currentScoreboardScore() const {
-  if (lastTeamScores) {
-    return lastTeamScores;
+  if (replayAnnotations && replayAnnotationScoreAtTime && gameWrapper->IsInReplay()) {
+    ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
+    const float replayTime =
+        replayServer.IsNull() ? playbackCurrentTime : replayServer.GetReplayTimeElapsed();
+    SaReplayScore score{};
+    if (replayAnnotationScoreAtTime(replayAnnotations, replayTime, &score) == 0 &&
+        score.has_team_zero_score != 0 && score.has_team_one_score != 0) {
+      return std::make_pair(score.team_zero_score, score.team_one_score);
+    }
   }
-  if (!replayAnnotations || !replayAnnotationScoreAtTime || !gameWrapper->IsInReplay()) {
-    return std::nullopt;
-  }
-
-  ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
-  const float replayTime =
-      replayServer.IsNull() ? playbackCurrentTime : replayServer.GetReplayTimeElapsed();
-  SaReplayScore score{};
-  if (replayAnnotationScoreAtTime(replayAnnotations, replayTime, &score) != 0 ||
-      score.has_team_zero_score == 0 || score.has_team_one_score == 0) {
-    return std::nullopt;
-  }
-  return std::make_pair(score.team_zero_score, score.team_one_score);
+  return lastTeamScores;
 }
 
 void SubtrActorPlugin::renderScoreboardWindow() {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7366,6 +7366,10 @@ void SubtrActorPlugin::renderLauncherWindow() {
     tickReplayAnnotations();
     uiLauncherOpen = false;
   }
+  const bool liveAnalysis = liveProcessingEnabled();
+  if (renderModuleSummaryToggle("Live analysis graph", liveAnalysis, "launcher-actions")) {
+    setCvarBool("subtr_actor_enabled", !liveAnalysis);
+  }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
@@ -7460,10 +7464,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
   }
 
   if (ImGui::TreeNode("Plugin tools##launcher-plugin-tools")) {
-    const bool liveAnalysis = liveProcessingEnabled();
-    if (ImGui::Button(liveAnalysis ? "Stop analysis" : "Start analysis", ImVec2{170.0f, 0.0f})) {
-      setCvarBool("subtr_actor_enabled", !liveAnalysis);
-    }
     if (ImGui::Button("Verify graph", ImVec2{170.0f, 0.0f})) {
       showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
       verifyGraphRuntime({"subtr_actor_verify_graph"});

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3078,48 +3078,25 @@ void SubtrActorPlugin::applyUiConfigJson(
         boostPickupControlsPlacement,
         &uiBoostPickupControlsOpen);
   }
-  for (const std::string &object : parseJsonObjectArrayProperty(json, "singletonWindows")) {
-    const std::string id = parseJsonStringProperty(object, "id").value_or("");
-    const auto placement = parseJsonObjectProperty(object, "placement");
-    if (!placement) {
-      continue;
-    }
-    if (id == "camera") {
-      loadPlacementObject(*placement, cameraPlacement, &uiCameraOpen);
-    } else if (id == "scoreboard") {
-      loadPlacementObject(*placement, scoreboardPlacement, &uiScoreboardOpen);
-    } else if (id == "playback") {
-      loadPlacementObject(*placement, playbackControlsPlacement, &uiPlaybackControlsOpen);
-    } else if (id == "recording") {
-      loadPlacementObject(*placement, recordingPlacement, &uiRecordingOpen);
-    } else if (id == "mechanics") {
-      loadPlacementObject(*placement, eventsPlacement, &uiEventsOpen);
-    } else if (id == "event-playlist") {
-      loadPlacementObject(*placement, eventPlaylistPlacement, &uiEventPlaylistOpen);
-    } else if (id == "mechanics-review") {
-      loadPlacementObject(*placement, mechanicsReviewPlacement, &uiMechanicsReviewOpen);
-    } else if (id == "replay-loading") {
-      loadPlacementObject(*placement, replayLoadingPlacement, &uiReplayLoadingOpen);
-    } else if (id == "boost-pickups") {
-      loadPlacementObject(*placement, boostPickupControlsPlacement, &uiBoostPickupControlsOpen);
-    } else if (id == "touch-controls") {
-      loadPlacementObject(*placement, touchControlsPlacement, &uiTouchControlsOpen);
-    }
-  }
-  for (const std::string &object : parseJsonObjectArrayProperty(json, "pluginWindows")) {
-    const std::string id = parseJsonStringProperty(object, "id").value_or("");
-    const auto placement = parseJsonObjectProperty(object, "placement");
-    if (!placement) {
-      continue;
-    }
-    for (const SingletonWindowControl &window : singletonWindowControls()) {
-      if (window.web_config || id != window.config_id) {
+  auto loadWindowArray = [&](const char *propertyName, bool webConfig) {
+    for (const std::string &object : parseJsonObjectArrayProperty(json, propertyName)) {
+      const std::string id = parseJsonStringProperty(object, "id").value_or("");
+      const auto placement = parseJsonObjectProperty(object, "placement");
+      if (!placement) {
         continue;
       }
-      loadPlacementObject(*placement, *window.placement, window.open);
-      break;
+      for (const SingletonWindowControl &window : singletonWindowControls()) {
+        if (window.web_config != webConfig || id != window.config_id) {
+          continue;
+        }
+        loadPlacementObject(*placement, *window.placement, window.open);
+        break;
+      }
     }
-  }
+  };
+  loadWindowArray("singletonWindows", true);
+  loadWindowArray("pluginWindows", false);
+  loadWindowArray("plugin_windows", false);
 
   uiStatsWindows.clear();
   nextUiStatsWindowId = 1;
@@ -6933,12 +6910,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
-  struct LauncherWindowToggle {
-    const char *label;
-    bool *open;
-    UiWindowPlacement *placement;
-  };
-  auto renderLauncherWindowToggle = [&](LauncherWindowToggle &window) {
+  auto renderLauncherWindowToggle = [&](const SingletonWindowControl &window) {
     ImGui::PushID(window.label);
     if (ImGui::Button(window.label, ImVec2{170.0f, 0.0f})) {
       if (*window.open) {
@@ -6957,20 +6929,10 @@ void SubtrActorPlugin::renderLauncherWindow() {
     }
   };
 
-  std::array<LauncherWindowToggle, 10> webLauncherWindows{{
-      {"Camera", &uiCameraOpen, &cameraPlacement},
-      {"Scoreboard", &uiScoreboardOpen, &scoreboardPlacement},
-      {"Playback", &uiPlaybackControlsOpen, &playbackControlsPlacement},
-      {"Recording", &uiRecordingOpen, &recordingPlacement},
-      {"Events", &uiEventsOpen, &eventsPlacement},
-      {"Event playlist", &uiEventPlaylistOpen, &eventPlaylistPlacement},
-      {"Mechanics review", &uiMechanicsReviewOpen, &mechanicsReviewPlacement},
-      {"Replay loading", &uiReplayLoadingOpen, &replayLoadingPlacement},
-      {"Boost pickup filters", &uiBoostPickupControlsOpen, &boostPickupControlsPlacement},
-      {"Touch controls", &uiTouchControlsOpen, &touchControlsPlacement},
-  }};
-  for (LauncherWindowToggle &window : webLauncherWindows) {
-    renderLauncherWindowToggle(window);
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    if (window.web_config) {
+      renderLauncherWindowToggle(window);
+    }
   }
   renderStatsWindowCreateButton("New player stats", UiStatsWindowKind::Player);
   renderStatsWindowCreateButton("New team stats", UiStatsWindowKind::Team);
@@ -7006,13 +6968,10 @@ void SubtrActorPlugin::renderLauncherWindow() {
     }
 
     ImGui::Separator();
-    std::array<LauncherWindowToggle, 3> pluginToolWindows{{
-        {"Status", &uiStatusOpen, &statusPlacement},
-        {"Graph inspector", &uiGraphInspectorOpen, &graphInspectorPlacement},
-        {"Module controls", &uiModuleControlsOpen, &moduleControlsPlacement},
-    }};
-    for (LauncherWindowToggle &window : pluginToolWindows) {
-      renderLauncherWindowToggle(window);
+    for (const SingletonWindowControl &window : singletonWindowControls()) {
+      if (!window.web_config) {
+        renderLauncherWindowToggle(window);
+      }
     }
     renderSingletonWindowManager();
 
@@ -7041,17 +7000,12 @@ void SubtrActorPlugin::renderLauncherWindow() {
     }
     ImGui::SameLine();
     if (ImGui::Button("Hide side windows")) {
-      uiEventsOpen = false;
-      uiEventPlaylistOpen = false;
-      uiStatusOpen = false;
-      uiCameraOpen = false;
-      uiPlaybackControlsOpen = false;
-      uiRecordingOpen = false;
-      uiGraphInspectorOpen = false;
-      uiMechanicsReviewOpen = false;
-      uiReplayLoadingOpen = false;
-      uiTouchControlsOpen = false;
-      uiBoostPickupControlsOpen = false;
+      for (const SingletonWindowControl &window : singletonWindowControls()) {
+        if (std::string_view{window.config_id} == "scoreboard") {
+          continue;
+        }
+        *window.open = false;
+      }
     }
     if (ImGui::Button("Save layout")) {
       saveUiConfig();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9108,6 +9108,7 @@ void SubtrActorPlugin::renderCameraWindow() {
   if (ImGui::BeginCombo("Target", selectedLabel.c_str())) {
     if (ImGui::Selectable("Free camera", cameraViewMode != 1)) {
       cameraViewMode = 0;
+      scheduleUiConfigAutosave();
     }
     for (const SaPlayerFrame &player : sampledPlayers) {
       const std::string label = std::format(
@@ -9120,18 +9121,27 @@ void SubtrActorPlugin::renderCameraWindow() {
         cameraSelectedPlayerIndex = player.player_index;
         cameraSelectedPlayerId = webPlayerIdForIndex(cameraSelectedPlayerIndex);
         cameraViewMode = 1;
+        scheduleUiConfigAutosave();
       }
     }
     ImGui::EndCombo();
   }
 
-  ImGui::RadioButton("Free##camera-view", &cameraViewMode, 0);
+  if (ImGui::RadioButton("Free##camera-view", &cameraViewMode, 0)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::RadioButton("Follow##camera-view", &cameraViewMode, 1);
+  if (ImGui::RadioButton("Follow##camera-view", &cameraViewMode, 1)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::RadioButton("Overhead##camera-view", &cameraViewMode, 2);
+  if (ImGui::RadioButton("Overhead##camera-view", &cameraViewMode, 2)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::RadioButton("Diagonal##camera-view", &cameraViewMode, 3);
+  if (ImGui::RadioButton("Diagonal##camera-view", &cameraViewMode, 3)) {
+    scheduleUiConfigAutosave();
+  }
 
   if (cameraViewMode == 2) {
     cameraFreePreset = 0;
@@ -9158,6 +9168,7 @@ void SubtrActorPlugin::renderCameraWindow() {
   popCameraDisabledStyle(!hasAttachedCamera);
   if (hasAttachedCamera && distanceScaleChanged) {
     cameraDistanceScale = nextDistanceScale;
+    scheduleUiConfigAutosave();
   }
 
   bool nextBallCamEnabled = cameraBallCamEnabled;
@@ -9166,6 +9177,7 @@ void SubtrActorPlugin::renderCameraWindow() {
   popCameraDisabledStyle(!hasAttachedCamera);
   if (hasAttachedCamera && ballCamChanged) {
     cameraBallCamEnabled = nextBallCamEnabled;
+    scheduleUiConfigAutosave();
   }
 
   bool nextCustomSettingsEnabled = cameraCustomSettingsEnabled;
@@ -9175,6 +9187,7 @@ void SubtrActorPlugin::renderCameraWindow() {
   popCameraDisabledStyle(!hasAttachedCamera);
   if (hasAttachedCamera && customSettingsChanged) {
     cameraCustomSettingsEnabled = nextCustomSettingsEnabled;
+    scheduleUiConfigAutosave();
   }
   if (cameraCustomSettingsEnabled) {
     const bool customControlsDisabled = !hasAttachedCamera;
@@ -9186,6 +9199,7 @@ void SubtrActorPlugin::renderCameraWindow() {
       popCameraDisabledStyle(customControlsDisabled);
       if (!customControlsDisabled && changed) {
         value = next;
+        scheduleUiConfigAutosave();
       }
     };
     renderCustomSlider("FOV", cameraCustomFov, 60.0f, 130.0f, "%.0f");
@@ -9357,12 +9371,14 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
     playbackPlaying = shouldPlay;
     if (!hasReplayServer) {
       playbackStatus = "Open a Rocket League replay to control playback";
+      scheduleUiConfigAutosave();
       return;
     }
 
     if (shouldPlay) {
       replayServer.StartPlaybackAtTime(playbackCurrentTime);
       playbackStatus = std::format("Playing from {:.2f}s", playbackCurrentTime);
+      scheduleUiConfigAutosave();
       return;
     }
 
@@ -9372,6 +9388,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
       replay.StopPlayback();
     }
     playbackStatus = std::format("Paused at {:.2f}s", playbackCurrentTime);
+    scheduleUiConfigAutosave();
   };
 
   ImGui::SetNextItemWidth(140.0f);
@@ -9382,6 +9399,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   popPlaybackDisabledStyle(!transportEnabled);
   if (transportEnabled && currentTimeChanged) {
     playbackCurrentTime = nextPlaybackCurrentTime;
+    scheduleUiConfigAutosave();
   }
   playbackCurrentTime = std::max(0.0f, playbackCurrentTime);
   ImGui::SetNextItemWidth(140.0f);
@@ -9392,6 +9410,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   popPlaybackDisabledStyle(!transportEnabled);
   if (transportEnabled && rateChanged) {
     playbackRate = nextPlaybackRate;
+    scheduleUiConfigAutosave();
   }
   if (playbackButton(playbackPlaying ? "Pause" : "Play", !transportEnabled)) {
     applyPlaybackState(!playbackPlaying);
@@ -9404,6 +9423,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   if (playbackButton("Live replay time", !hasReplayServer)) {
     playbackCurrentTime = replayServer.GetReplayTimeElapsed();
     playbackStatus = std::format("Captured {:.2f}s", playbackCurrentTime);
+    scheduleUiConfigAutosave();
   }
   bool nextPlaying = playbackPlaying;
   pushPlaybackDisabledStyle(!transportEnabled);
@@ -9420,6 +9440,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   popPlaybackDisabledStyle(!transportEnabled);
   if (transportEnabled && skipGoalChanged) {
     playbackSkipPostGoalTransitions = nextSkipPostGoalTransitions;
+    scheduleUiConfigAutosave();
   }
   bool nextSkipKickoffs = playbackSkipKickoffs;
   pushPlaybackDisabledStyle(!transportEnabled);
@@ -9427,6 +9448,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   popPlaybackDisabledStyle(!transportEnabled);
   if (transportEnabled && skipKickoffsChanged) {
     playbackSkipKickoffs = nextSkipKickoffs;
+    scheduleUiConfigAutosave();
   }
 
   ImGui::Separator();
@@ -9591,6 +9613,7 @@ void SubtrActorPlugin::renderRecordingWindow() {
   popRecordingDisabledStyle(recordingSettingsLocked);
   if (!recordingSettingsLocked && fpsChanged) {
     recordingFps = nextRecordingFps;
+    scheduleUiConfigAutosave();
   }
   const std::array<const char *, 4> rates{{"0.5x", "1.0x", "1.5x", "2.0x"}};
   recordingPlaybackRateIndex = std::clamp(recordingPlaybackRateIndex, 0, 3);
@@ -9606,8 +9629,9 @@ void SubtrActorPlugin::renderRecordingWindow() {
     ImGui::EndCombo();
   }
   popRecordingDisabledStyle(recordingSettingsLocked);
-  if (!recordingSettingsLocked) {
+  if (!recordingSettingsLocked && nextRecordingPlaybackRateIndex != recordingPlaybackRateIndex) {
     recordingPlaybackRateIndex = nextRecordingPlaybackRateIndex;
+    scheduleUiConfigAutosave();
   }
   bool nextFinishBeforeDump = recordingFinishBeforeDump;
   pushRecordingDisabledStyle(recordingSettingsLocked);
@@ -9616,6 +9640,7 @@ void SubtrActorPlugin::renderRecordingWindow() {
   popRecordingDisabledStyle(recordingSettingsLocked);
   if (!recordingSettingsLocked && finishBeforeDumpChanged) {
     recordingFinishBeforeDump = nextFinishBeforeDump;
+    scheduleUiConfigAutosave();
   }
 
   ImGui::Separator();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7371,13 +7371,24 @@ void SubtrActorPlugin::renderLauncherWindow() {
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
   auto renderLauncherWindowToggle = [&](const SingletonWindowControl &window) {
     ImGui::PushID(window.label);
-    if (ImGui::Button(window.label, ImVec2{170.0f, 0.0f})) {
+    const bool isOpen = window.open != nullptr && *window.open;
+    if (isOpen) {
+      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.16f, 0.35f, 0.28f, 1.0f});
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.25f, 0.55f, 0.43f, 1.0f});
+    }
+    const std::string buttonLabel =
+        std::format("{}   {}", window.label, isOpen ? "Hide" : "Show");
+    if (ImGui::Button(buttonLabel.c_str(), ImVec2{210.0f, 0.0f})) {
       if (*window.open) {
         *window.open = false;
       } else {
         showSingletonWindow(*window.open, *window.placement);
       }
       uiLauncherOpen = false;
+    }
+    if (isOpen) {
+      ImGui::PopStyleColor(3);
     }
     ImGui::PopID();
   };

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9049,11 +9049,21 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   const float clipStart =
       current == nullptr ? 0.0f : std::max(0.0f, current->time - mechanicsReviewClipLeadSeconds);
   const float clipEnd = current == nullptr ? 0.0f : current->time + mechanicsReviewClipTrailSeconds;
+  auto mechanicsReviewItemTitle = [](const UiEventRecord &event, size_t index) {
+    if (!event.label.empty()) {
+      return event.label;
+    }
+    if (!event.type.empty()) {
+      return eventTypeDisplayLabel(event.type);
+    }
+    return std::format("Review item {}", index + 1);
+  };
   ImGui::Text("%d / %zu", current == nullptr ? 0 : mechanicsReviewIndex + 1, candidates.size());
   const std::string currentTitle =
       current == nullptr ? "No candidate selected"
-      : current->label.empty() ? eventTypeDisplayLabel(current->type)
-                               : current->label;
+                         : mechanicsReviewItemTitle(
+                               *current,
+                               static_cast<size_t>(mechanicsReviewIndex));
   ImGui::TextWrapped("%s", currentTitle.c_str());
   const std::string statusReadout =
       mechanicsReviewClipActive
@@ -9193,7 +9203,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     const UiEventRecord &event = recentUiEvents[candidates[i]];
     ImGui::PushID(static_cast<int>(i));
     const bool active = i == static_cast<size_t>(mechanicsReviewIndex);
-    const std::string title = event.label.empty() ? eventTypeDisplayLabel(event.type) : event.label;
+    const std::string title = mechanicsReviewItemTitle(event, i);
     const std::string label = std::format(
         "{}  {}##mechanics-review-item",
         formatEventPlaylistTime(event.time),

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3111,24 +3111,13 @@ void SubtrActorPlugin::applyUiConfigJson(
       continue;
     }
 
-    UiStatsWindow window{};
-    if (*kind == "player") {
-      window.kind = UiStatsWindowKind::Player;
-    } else if (*kind == "team") {
-      window.kind = UiStatsWindowKind::Team;
-    } else if (*kind == "all-players") {
-      window.kind = UiStatsWindowKind::AllPlayers;
-    } else if (*kind == "all-teams") {
-      window.kind = UiStatsWindowKind::AllTeams;
-    } else if (*kind == "goals-overview") {
-      window.kind = UiStatsWindowKind::GoalsOverview;
-    } else if (*kind == "ad-hoc") {
-      window.kind = UiStatsWindowKind::AdHoc;
-    } else if (*kind == "stats-module") {
-      window.kind = UiStatsWindowKind::StatsModule;
-    } else {
+    const std::optional<UiStatsWindowKind> parsedKind = parseStatsWindowKind(*kind);
+    if (!parsedKind) {
       continue;
     }
+
+    UiStatsWindow window{};
+    window.kind = *parsedKind;
 
     window.id = static_cast<uint32_t>(parseJsonNumberProperty(object, "id").value_or(0.0));
     if (const auto idString = parseJsonStringProperty(object, "id")) {
@@ -3250,27 +3239,6 @@ void SubtrActorPlugin::applyUiConfigJson(
 }
 
 std::string SubtrActorPlugin::uiConfigJson() {
-  auto kindValue = [](UiStatsWindowKind kind) {
-    switch (kind) {
-    case UiStatsWindowKind::Player:
-      return "player";
-    case UiStatsWindowKind::Team:
-      return "team";
-    case UiStatsWindowKind::AllPlayers:
-      return "all-players";
-    case UiStatsWindowKind::AllTeams:
-      return "all-teams";
-    case UiStatsWindowKind::GoalsOverview:
-      return "goals-overview";
-    case UiStatsWindowKind::AdHoc:
-      return "ad-hoc";
-    case UiStatsWindowKind::StatsModule:
-      return "stats-module";
-    default:
-      return "player";
-    }
-  };
-
   auto writePlacement = [](
                             std::ostream &out,
                             const UiWindowPlacement &placement,
@@ -3641,7 +3609,8 @@ std::string SubtrActorPlugin::uiConfigJson() {
   file << "  \"stats_windows\": [\n";
   for (size_t i = 0; i < uiStatsWindows.size(); i += 1) {
     const UiStatsWindow &window = uiStatsWindows[i];
-    file << "    {\"id\":" << window.id << ",\"kind\":\"" << kindValue(window.kind)
+    file << "    {\"id\":" << window.id << ",\"kind\":\""
+         << statsWindowKindConfigId(window.kind)
          << "\",\"open\":" << (window.open ? "true" : "false")
          << ",\"visible\":" << (window.open ? "true" : "false")
          << ",\"placement\":{\"x\":" << window.x << ",\"y\":" << window.y
@@ -3680,15 +3649,21 @@ std::string SubtrActorPlugin::uiConfigJson() {
   file << "  ],\n";
   file << "  \"statsWindows\": [\n";
   bool wroteWebStatsWindow = false;
+  const std::array<StatsWindowKindControl, 7> statsWindowKinds = statsWindowKindControls();
   for (size_t i = 0; i < uiStatsWindows.size(); i += 1) {
     const UiStatsWindow &window = uiStatsWindows[i];
-    if (window.kind == UiStatsWindowKind::StatsModule) {
+    const auto kind = std::find_if(
+        statsWindowKinds.begin(),
+        statsWindowKinds.end(),
+        [&](const StatsWindowKindControl &control) { return control.kind == window.kind; });
+    if (kind == statsWindowKinds.end() || !kind->web_config) {
       continue;
     }
     if (wroteWebStatsWindow) {
       file << ",\n";
     }
-    file << "    {\"id\":\"stats-" << window.id << "\",\"kind\":\"" << kindValue(window.kind)
+    file << "    {\"id\":\"stats-" << window.id << "\",\"kind\":\""
+         << statsWindowKindConfigId(window.kind)
          << "\",\"placement\":{\"x\":" << window.x << ",\"y\":" << window.y
          << ",\"viewport\":{\"width\":" << window.viewport_width
          << ",\"height\":" << window.viewport_height << "}"
@@ -6934,12 +6909,11 @@ void SubtrActorPlugin::renderLauncherWindow() {
       renderLauncherWindowToggle(window);
     }
   }
-  renderStatsWindowCreateButton("New player stats", UiStatsWindowKind::Player);
-  renderStatsWindowCreateButton("New team stats", UiStatsWindowKind::Team);
-  renderStatsWindowCreateButton("New all players stats", UiStatsWindowKind::AllPlayers);
-  renderStatsWindowCreateButton("New all teams stats", UiStatsWindowKind::AllTeams);
-  renderStatsWindowCreateButton("New goal labels", UiStatsWindowKind::GoalsOverview);
-  renderStatsWindowCreateButton("New ad hoc stats", UiStatsWindowKind::AdHoc);
+  for (const StatsWindowKindControl &kind : statsWindowKindControls()) {
+    if (kind.web_config) {
+      renderStatsWindowCreateButton(kind.create_label, kind.kind);
+    }
+  }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "VISUALIZATIONS");
@@ -9395,25 +9369,61 @@ void SubtrActorPlugin::renderStatsWindows() {
   }
 }
 
-const char *SubtrActorPlugin::statsWindowKindLabel(UiStatsWindowKind kind) const {
-  switch (kind) {
-  case UiStatsWindowKind::Player:
-    return "Player stats";
-  case UiStatsWindowKind::Team:
-    return "Team stats";
-  case UiStatsWindowKind::AllPlayers:
-    return "All players stats";
-  case UiStatsWindowKind::AllTeams:
-    return "All teams stats";
-  case UiStatsWindowKind::GoalsOverview:
-    return "Goal labels";
-  case UiStatsWindowKind::AdHoc:
-    return "Ad hoc stats";
-  case UiStatsWindowKind::StatsModule:
-    return "Stats module";
-  default:
-    return "Stats";
+std::array<SubtrActorPlugin::StatsWindowKindControl, 7>
+SubtrActorPlugin::statsWindowKindControls() const {
+  return {{
+      {UiStatsWindowKind::Player, "player", "Player stats", "New player stats", true},
+      {UiStatsWindowKind::Team, "team", "Team stats", "New team stats", true},
+      {UiStatsWindowKind::AllPlayers,
+       "all-players",
+       "All players stats",
+       "New all players stats",
+       true},
+      {UiStatsWindowKind::AllTeams,
+       "all-teams",
+       "All teams stats",
+       "New all teams stats",
+       true},
+      {UiStatsWindowKind::GoalsOverview,
+       "goals-overview",
+       "Goal labels",
+       "New goal labels",
+       true},
+      {UiStatsWindowKind::AdHoc, "ad-hoc", "Ad hoc stats", "New ad hoc stats", true},
+      {UiStatsWindowKind::StatsModule,
+       "stats-module",
+       "Stats module",
+       "New stats module",
+       false},
+  }};
+}
+
+std::optional<SubtrActorPlugin::UiStatsWindowKind>
+SubtrActorPlugin::parseStatsWindowKind(std::string_view value) const {
+  for (const StatsWindowKindControl &control : statsWindowKindControls()) {
+    if (value == control.config_id) {
+      return control.kind;
+    }
   }
+  return std::nullopt;
+}
+
+const char *SubtrActorPlugin::statsWindowKindConfigId(UiStatsWindowKind kind) const {
+  for (const StatsWindowKindControl &control : statsWindowKindControls()) {
+    if (control.kind == kind) {
+      return control.config_id;
+    }
+  }
+  return "player";
+}
+
+const char *SubtrActorPlugin::statsWindowKindLabel(UiStatsWindowKind kind) const {
+  for (const StatsWindowKindControl &control : statsWindowKindControls()) {
+    if (control.kind == kind) {
+      return control.label;
+    }
+  }
+  return "Stats";
 }
 
 std::string SubtrActorPlugin::statsWindowTitle(const UiStatsWindow &window) const {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9182,15 +9182,22 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
                            : replayAnnotations ? "Loaded"
                            : replayAnnotationLoadFailed ? "Failed"
                                                         : "Scanning";
-  const std::string replaySummary = replayPath ? "1 replay" : "0 replays";
+  const bool hasReplaySource =
+      replayPath || !rawReplayPath.empty() || !replayAnnotationPath.empty();
+  const std::string replaySummary = hasReplaySource ? "1 replay" : "0 replays";
+  const char *activeSummary = !hasReplaySource         ? "No playlist"
+                              : replayAnnotations      ? "Complete"
+                              : replayAnnotationLoadFailed ? "1 failed"
+                              : annotationsEnabled && inReplay ? "1 active, 0 pending"
+                                                               : status;
 
   ImGui::Text("%s", replaySummary.c_str());
   ImGui::SameLine();
-  ImGui::Text("%s", status);
+  ImGui::TextDisabled("%s", activeSummary);
 
   ImGui::Separator();
   ImGui::BeginChild("replay-loading-list", ImVec2{0.0f, 112.0f}, true);
-  if (!replayPath && rawReplayPath.empty() && replayAnnotationPath.empty()) {
+  if (!hasReplaySource) {
     ImGui::TextDisabled("No replay sources.");
   } else {
     const std::string title = replayPath ? *replayPath

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -206,9 +206,10 @@ struct UiStatIdAlias {
 
 std::string normalizeUiStatId(std::string_view statId);
 
-constexpr std::array<EventFilterOption, 33> EVENT_FILTER_OPTIONS{{
+constexpr std::array<EventFilterOption, 34> EVENT_FILTER_OPTIONS{{
     {"all", "All events", "All"},
     {"goal", "Goal", "Replay"},
+    {"core", "Shots, saves, assists", "Replay"},
     {"mechanics", "All mechanics", "Sources"},
     {"team", "Team events", "Sources"},
     {"goal_context", "Goal context", "Sources"},
@@ -1983,13 +1984,39 @@ std::string webTimelineEventSourceIdForFilterToken(std::string_view token) {
   if (token == "goal" || token == "mechanics" || token == "team" || token == "goal_context") {
     return {};
   }
-  if (token != "touch" && !isMechanicFilterToken(token)) {
+  if (token != "core" && token != "touch" && !isMechanicFilterToken(token)) {
     return {};
   }
 
   std::string id{token};
   std::replace(id.begin(), id.end(), '_', '-');
   return id;
+}
+
+std::string_view playerStatEventType(SaPlayerStatEventKind kind) {
+  switch (kind) {
+  case SaPlayerStatEventKindShot:
+    return "shot";
+  case SaPlayerStatEventKindSave:
+    return "save";
+  case SaPlayerStatEventKindAssist:
+    return "assist";
+  default:
+    return "core";
+  }
+}
+
+std::string_view playerStatEventLabel(SaPlayerStatEventKind kind) {
+  switch (kind) {
+  case SaPlayerStatEventKindShot:
+    return "Shot";
+  case SaPlayerStatEventKindSave:
+    return "Save";
+  case SaPlayerStatEventKindAssist:
+    return "Assist";
+  default:
+    return "Core event";
+  }
 }
 
 void appendUniqueFilterToken(std::vector<std::string> &tokens, std::string_view token) {
@@ -5332,6 +5359,7 @@ void SubtrActorPlugin::recordPlayerStatDeltas(
           event.shot_player = sampleRigidBody(car);
         }
       }
+      pushPlayerStatEventMessage(event);
       pendingPlayerStatEvents.push_back(event);
     }
   };
@@ -5367,6 +5395,7 @@ void SubtrActorPlugin::recordExplicitPlayerStat(PriWrapper pri, SaPlayerStatEven
   event.player_index = *playerIndex;
   event.is_team_0 = pri.GetTeamNum() == 0 ? 1 : 0;
   event.kind = kind;
+  pushPlayerStatEventMessage(event);
   pendingPlayerStatEvents.push_back(event);
 
   if (lastPlayerStats.find(pri.memory_address) == lastPlayerStats.end()) {
@@ -7050,6 +7079,23 @@ void SubtrActorPlugin::pushGoalContextEventMessage(const SaGoalContextEvent &eve
   while (messages.size() > static_cast<size_t>(overlayMaxMessages())) {
     messages.pop_front();
   }
+}
+
+void SubtrActorPlugin::pushPlayerStatEventMessage(const SaPlayerStatEvent &event) {
+  const bool isBlue = event.is_team_0 != 0;
+  const std::string actor = playerLabel(event.player_index, event.is_team_0);
+  const std::string label =
+      std::format("{} {}", actor, playerStatEventLabel(event.kind));
+  appendUiEvent(UiEventRecord{
+      "core",
+      std::string{playerStatEventType(event.kind)},
+      actor,
+      label,
+      "Shots, saves, assists",
+      isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
+      event.timing.frame_number,
+      event.timing.time,
+  });
 }
 
 void SubtrActorPlugin::Render() {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8072,19 +8072,11 @@ void SubtrActorPlugin::renderEmptyStateWindow() {
     return;
   }
 
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "subtr-actor");
   ImGui::TextUnformatted("Load a replay to start.");
   if (ImGui::Button("Load Replay...", ImVec2{150.0f, 0.0f})) {
     showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
     resetReplayAnnotations();
     tickReplayAnnotations();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Start live analysis", ImVec2{150.0f, 0.0f})) {
-    setCvarBool("subtr_actor_enabled", true);
-  }
-  if (ImGui::Button("Open menu", ImVec2{150.0f, 0.0f})) {
-    showLauncherWindow();
   }
 
   ImGui::End();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -121,6 +121,13 @@ void popWebFloatingWindowStyle() {
   ImGui::PopStyleVar(4);
 }
 
+void renderWebDetailGridCell(std::string_view label, std::string_view value) {
+  const std::string labelString{label};
+  const std::string valueString{value};
+  ImGui::TextColored(ImVec4{0.54f, 0.64f, 0.73f, 1.0f}, "%s", labelString.c_str());
+  ImGui::TextColored(ImVec4{0.93f, 0.96f, 0.98f, 1.0f}, "%s", valueString.c_str());
+}
+
 constexpr char FRAME_EVENTS_STATE_NODE[] = "frame_events_state";
 constexpr std::array<const char *, 7> FRAME_EVENTS_STATE_EVENT_FIELDS{
     "active_demos",
@@ -9962,33 +9969,29 @@ void SubtrActorPlugin::renderCameraWindow() {
                                          : cameraCustomSettingsEnabled
                                                ? std::format("{} custom", activeCameraLabel)
                                                : activeCameraLabel;
-  auto renderAttachedCameraMetric = [&](const char *format, float value) {
+  auto attachedCameraMetric = [&](int precision, float value) {
     if (!hasAttachedCamera) {
-      ImGui::Text("--");
-      return;
+      return std::string{"--"};
     }
-    ImGui::Text(format, value);
+    if (precision == 2) {
+      return std::format("{:.2f}", value);
+    }
+    return precision == 1 ? std::format("{:.1f}", value) : std::format("{:.0f}", value);
   };
 
   ImGui::Separator();
   ImGui::Columns(2, "camera-detail-grid", false);
-  ImGui::TextDisabled("Profile");
-  ImGui::Text("%s", profileReadout.c_str());
+  renderWebDetailGridCell("Profile", profileReadout);
   ImGui::NextColumn();
-  ImGui::TextDisabled("FOV");
-  renderAttachedCameraMetric("%.0f", fov);
+  renderWebDetailGridCell("FOV", attachedCameraMetric(0, fov));
   ImGui::NextColumn();
-  ImGui::TextDisabled("Height");
-  renderAttachedCameraMetric("%.0f", height);
+  renderWebDetailGridCell("Height", attachedCameraMetric(0, height));
   ImGui::NextColumn();
-  ImGui::TextDisabled("Pitch");
-  renderAttachedCameraMetric("%.1f", pitch);
+  renderWebDetailGridCell("Pitch", attachedCameraMetric(1, pitch));
   ImGui::NextColumn();
-  ImGui::TextDisabled("Distance");
-  renderAttachedCameraMetric("%.0f", distance);
+  renderWebDetailGridCell("Distance", attachedCameraMetric(0, distance));
   ImGui::NextColumn();
-  ImGui::TextDisabled("Stiffness");
-  renderAttachedCameraMetric("%.2f", stiffness);
+  renderWebDetailGridCell("Stiffness", attachedCameraMetric(2, stiffness));
   ImGui::Columns(1);
 
   ImGui::End();
@@ -10155,17 +10158,17 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   ImGui::Separator();
   const float durationSeconds = std::max(lastTime, playbackCurrentTime);
   ImGui::Columns(2, "playback-detail-grid", false);
-  ImGui::TextDisabled("Time");
-  ImGui::Text("%.2fs", playbackCurrentTime);
+  renderWebDetailGridCell("Time", std::format("{:.2f}s", playbackCurrentTime));
   ImGui::NextColumn();
-  ImGui::TextDisabled("Frame");
-  ImGui::Text("%llu", static_cast<unsigned long long>(frameNumber));
+  renderWebDetailGridCell(
+      "Frame",
+      std::format("{}", static_cast<unsigned long long>(frameNumber)));
   ImGui::NextColumn();
-  ImGui::TextDisabled("Duration");
-  ImGui::Text("%.2fs", durationSeconds);
+  renderWebDetailGridCell("Duration", std::format("{:.2f}s", durationSeconds));
   ImGui::NextColumn();
-  ImGui::TextDisabled("Status");
-  ImGui::Text("%s", playbackPlaying ? "Playing" : transportEnabled ? "Paused" : "Stopped");
+  renderWebDetailGridCell(
+      "Status",
+      playbackPlaying ? "Playing" : transportEnabled ? "Paused" : "Stopped");
   ImGui::Columns(1);
 
   ImGui::End();
@@ -10366,17 +10369,13 @@ void SubtrActorPlugin::renderRecordingWindow() {
       : !loaded || !engine ? "No replay"
                            : recordingStatus;
   ImGui::Columns(2, "recording-detail-grid", false);
-  ImGui::TextDisabled("Status");
-  ImGui::Text("%s", recordingStatusReadout.c_str());
+  renderWebDetailGridCell("Status", recordingStatusReadout);
   ImGui::NextColumn();
-  ImGui::TextDisabled("Elapsed");
-  ImGui::Text("%.1fs", elapsedSeconds);
+  renderWebDetailGridCell("Elapsed", std::format("{:.1f}s", elapsedSeconds));
   ImGui::NextColumn();
-  ImGui::TextDisabled("Size");
-  ImGui::Text("%s", formatByteSize(recordingLastBytes).c_str());
+  renderWebDetailGridCell("Size", formatByteSize(recordingLastBytes));
   ImGui::NextColumn();
-  ImGui::TextDisabled("Type");
-  ImGui::Text("JSON snapshots");
+  renderWebDetailGridCell("Type", "JSON snapshots");
   ImGui::Columns(1);
 
   ImGui::End();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9175,6 +9175,7 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
     const std::string title = replayPath ? *replayPath
                               : !rawReplayPath.empty() ? rawReplayPath
                                                        : replayAnnotationPath;
+    const float replayLoadProgress = replayAnnotations ? 1.0f : 0.0f;
     ImGui::TextWrapped("%s", title.c_str());
     std::vector<std::string> replayMeta;
     if (!rawReplayPath.empty()) {
@@ -9199,6 +9200,7 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
                               : ImVec4{0.72f, 0.78f, 0.86f, 1.0f},
         "%s",
         status);
+    ImGui::ProgressBar(replayLoadProgress, ImVec2{-1.0f, 0.0f}, "");
   }
   ImGui::EndChild();
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -2506,6 +2506,20 @@ ImVec4 toImVec4(LinearColor color) {
   };
 }
 
+LinearColor eventPlaylistPlayerColor(uint32_t playerIndex) {
+  const std::array<LinearColor, 8> colors{{
+      {0x3b, 0x82, 0xf6, 0xff},
+      {0x06, 0xb6, 0xd4, 0xff},
+      {0x22, 0xc5, 0x5e, 0xff},
+      {0xa8, 0x55, 0xf7, 0xff},
+      {0xf9, 0x73, 0x16, 0xff},
+      {0xef, 0x44, 0x44, 0xff},
+      {0xf5, 0x9e, 0x0b, 0xff},
+      {0xec, 0x48, 0x99, 0xff},
+  }};
+  return colors[playerIndex % colors.size()];
+}
+
 std::string teamEventLabel(const SaTeamEvent &event) {
   switch (event.kind) {
   case SaTeamEventKindRush:
@@ -7231,6 +7245,8 @@ void SubtrActorPlugin::pushGoalEventMessage(const SaGoalEvent &event) {
       isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
       event.timing.frame_number,
       event.timing.time,
+      event.has_player,
+      event.player_index,
   });
 }
 
@@ -7258,6 +7274,8 @@ void SubtrActorPlugin::pushEventMessage(const SaMechanicEvent &event) {
       isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
       event.frame_number,
       event.time,
+      1,
+      event.player_index,
   });
 
   if (isCorePlayerStat) {
@@ -7304,6 +7322,8 @@ void SubtrActorPlugin::pushTeamEventMessage(const SaTeamEvent &event) {
       isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
       event.start_frame,
       event.start_time,
+      0,
+      0,
   });
 
   if (!overlayCategoryEnabled("team")) {
@@ -7338,6 +7358,8 @@ void SubtrActorPlugin::pushGoalContextEventMessage(const SaGoalContextEvent &eve
       isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
       event.frame_number,
       event.time,
+      event.has_scorer,
+      event.scorer_index,
   });
 
   if (!overlayCategoryEnabled("goal_context")) {
@@ -7371,6 +7393,8 @@ void SubtrActorPlugin::pushPlayerStatEventMessage(const SaPlayerStatEvent &event
       isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
       event.timing.frame_number,
       event.timing.time,
+      1,
+      event.player_index,
   });
 }
 
@@ -8869,7 +8893,9 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     const UiEventRecord &event = recentUiEvents[index];
 
     ImGui::PushID(static_cast<int>(index));
-    const ImVec4 color = toImVec4(event.color);
+    const ImVec4 color =
+        toImVec4(event.has_player != 0 ? eventPlaylistPlayerColor(event.player_index)
+                                       : event.color);
     const bool active = activeEventIndex && *activeEventIndex == index;
     const float seekTime = eventSeekTime(event);
     const std::string timeLabel = formatEventPlaylistTime(event.time);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7815,7 +7815,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
   renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "VISUALIZATIONS");
   renderModuleSummaryControls("launcher-module-summary");
 
   ImGui::Separator();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9341,6 +9341,8 @@ SubtrActorPlugin::statsWindowKindControls() const {
        "New player stats",
        UI_STAT_SCOPE_PLAYER,
        true,
+       true,
+       true,
        true},
       {UiStatsWindowKind::Team,
        "team",
@@ -9348,12 +9350,16 @@ SubtrActorPlugin::statsWindowKindControls() const {
        "New team stats",
        UI_STAT_SCOPE_TEAM,
        true,
+       true,
+       true,
        true},
       {UiStatsWindowKind::AllPlayers,
        "all-players",
        "All players stats",
        "New all players stats",
        UI_STAT_SCOPE_PLAYER,
+       false,
+       true,
        true,
        false},
       {UiStatsWindowKind::AllTeams,
@@ -9361,6 +9367,8 @@ SubtrActorPlugin::statsWindowKindControls() const {
        "All teams stats",
        "New all teams stats",
        UI_STAT_SCOPE_TEAM,
+       false,
+       true,
        true,
        false},
       {UiStatsWindowKind::GoalsOverview,
@@ -9368,6 +9376,8 @@ SubtrActorPlugin::statsWindowKindControls() const {
        "Goal labels",
        "New goal labels",
        UI_STAT_SCOPE_EVENT,
+       false,
+       false,
        true,
        true},
       {UiStatsWindowKind::AdHoc,
@@ -9375,6 +9385,8 @@ SubtrActorPlugin::statsWindowKindControls() const {
        "Ad hoc stats",
        "New ad hoc stats",
        static_cast<uint8_t>(UI_STAT_SCOPE_PLAYER | UI_STAT_SCOPE_TEAM | UI_STAT_SCOPE_EVENT),
+       false,
+       true,
        true,
        false},
       {UiStatsWindowKind::StatsModule,
@@ -9382,6 +9394,8 @@ SubtrActorPlugin::statsWindowKindControls() const {
        "Stats module",
        "New stats module",
        0,
+       false,
+       false,
        false,
        false},
   }};
@@ -9422,6 +9436,24 @@ uint8_t SubtrActorPlugin::statsWindowKindStatScopes(UiStatsWindowKind kind) cons
     }
   }
   return 0;
+}
+
+bool SubtrActorPlugin::statsWindowKindHasScopeSelector(UiStatsWindowKind kind) const {
+  for (const StatsWindowKindControl &control : statsWindowKindControls()) {
+    if (control.kind == kind) {
+      return control.scope_selector;
+    }
+  }
+  return false;
+}
+
+bool SubtrActorPlugin::statsWindowKindHasStatPicker(UiStatsWindowKind kind) const {
+  for (const StatsWindowKindControl &control : statsWindowKindControls()) {
+    if (control.kind == kind) {
+      return control.stat_picker;
+    }
+  }
+  return false;
 }
 
 std::string SubtrActorPlugin::statsWindowTitle(const UiStatsWindow &window) const {
@@ -9798,8 +9830,7 @@ void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window) {
   }
   captureStatsWindowPlacement(window);
 
-  const bool scopeHeaderOnly =
-      window.kind == UiStatsWindowKind::Player || window.kind == UiStatsWindowKind::Team;
+  const bool scopeHeaderOnly = statsWindowKindHasScopeSelector(window.kind);
   if (!scopeHeaderOnly) {
     ImGui::TextColored(
         ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
@@ -9923,13 +9954,13 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
     return;
   }
 
-  if (window.kind == UiStatsWindowKind::GoalsOverview) {
+  if (!statsWindowKindHasStatPicker(window.kind)) {
     ImGui::Separator();
     return;
   }
 
   const std::string addButton = std::format("+##add-stat-{}", window.id);
-  if (window.kind == UiStatsWindowKind::Player || window.kind == UiStatsWindowKind::Team) {
+  if (statsWindowKindHasScopeSelector(window.kind)) {
     ImGui::SameLine();
   }
   if (ImGui::Button(addButton.c_str())) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9491,14 +9491,6 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
                           : replayAnnotationLoadFailed
                               ? ImVec4{0.95f, 0.45f, 0.45f, 1.0f}
                               : ImVec4{0.72f, 0.78f, 0.86f, 1.0f};
-    const float statusWidth = ImGui::CalcTextSize(status).x;
-    const float statusX =
-        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - statusWidth);
-    ImGui::PushTextWrapPos(std::max(ImGui::GetCursorPosX(), statusX - 12.0f));
-    ImGui::TextUnformatted(title.c_str());
-    ImGui::PopTextWrapPos();
-    ImGui::SameLine(statusX);
-    ImGui::TextColored(statusColor, "%s", status);
     std::vector<std::string> replayMeta;
     if (!rawReplayPath.empty()) {
       replayMeta.push_back(std::format("raw: {}", rawReplayPath));
@@ -9512,10 +9504,67 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
     if (!annotationPlayers.empty()) {
       replayMeta.push_back(std::format("{} players", annotationPlayers.size()));
     }
-    if (!replayMeta.empty()) {
-      ImGui::TextDisabled("%s", joinStrings(replayMeta, " · ").c_str());
+    const std::string meta = joinStrings(replayMeta, " · ");
+    const float rowWidth = ImGui::GetContentRegionAvail().x;
+    const float rowHeight = 62.0f;
+    ImGui::Dummy(ImVec2{rowWidth, rowHeight});
+    const ImVec2 rowMin = ImGui::GetItemRectMin();
+    const ImVec2 rowMax = ImGui::GetItemRectMax();
+    ImDrawList *drawList = ImGui::GetWindowDrawList();
+    const ImVec4 rowBorder =
+        replayAnnotations ? ImVec4{0.30f, 0.69f, 0.47f, 0.42f}
+                          : replayAnnotationLoadFailed
+                              ? ImVec4{0.86f, 0.37f, 0.37f, 0.58f}
+                              : ImVec4{1.0f, 1.0f, 1.0f, 0.08f};
+    drawList->AddRectFilled(
+        rowMin,
+        rowMax,
+        ImGui::ColorConvertFloat4ToU32(ImVec4{1.0f, 1.0f, 1.0f, 0.035f}),
+        6.0f);
+    drawList->AddRect(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(rowBorder), 6.0f);
+
+    constexpr float rowPadding = 8.0f;
+    const float statusWidth = ImGui::CalcTextSize(status).x;
+    const float statusX = rowMax.x - rowPadding - statusWidth;
+    const float titleY = rowMin.y + rowPadding;
+    const float metaY = titleY + ImGui::GetTextLineHeight() + 3.0f;
+    drawList->PushClipRect(
+        ImVec2{rowMin.x + rowPadding, rowMin.y},
+        ImVec2{std::max(rowMin.x + rowPadding, statusX - 10.0f), rowMax.y},
+        true);
+    drawList->AddText(
+        ImVec2{rowMin.x + rowPadding, titleY},
+        IM_COL32(237, 245, 250, 255),
+        title.c_str());
+    if (!meta.empty()) {
+      drawList->AddText(
+          ImVec2{rowMin.x + rowPadding, metaY},
+          IM_COL32(137, 164, 186, 255),
+          meta.c_str());
     }
-    ImGui::ProgressBar(replayLoadProgress, ImVec2{-1.0f, 0.0f}, "");
+    drawList->PopClipRect();
+    drawList->AddText(
+        ImVec2{statusX, titleY},
+        ImGui::ColorConvertFloat4ToU32(statusColor),
+        status);
+
+    const float progressMinX = rowMin.x + rowPadding;
+    const float progressMaxX = rowMax.x - rowPadding;
+    const float progressY = rowMax.y - rowPadding - 4.0f;
+    drawList->AddRectFilled(
+        ImVec2{progressMinX, progressY},
+        ImVec2{progressMaxX, progressY + 4.0f},
+        IM_COL32(255, 255, 255, 20),
+        999.0f);
+    drawList->AddRectFilled(
+        ImVec2{progressMinX, progressY},
+        ImVec2{progressMinX + (progressMaxX - progressMinX) * replayLoadProgress, progressY + 4.0f},
+        ImGui::ColorConvertFloat4ToU32(
+            replayAnnotations ? ImVec4{0.30f, 0.69f, 0.47f, 1.0f}
+                              : replayAnnotationLoadFailed
+                                  ? ImVec4{0.86f, 0.37f, 0.37f, 1.0f}
+                                  : ImVec4{0.47f, 0.66f, 1.0f, 1.0f}),
+        999.0f);
   }
   ImGui::EndChild();
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3369,7 +3369,7 @@ void SubtrActorPlugin::applyUiConfigJson(
   cameraViewMode = static_cast<int>(
       std::clamp(parseJsonNumberProperty(json, "camera_view_mode").value_or(0.0), 0.0, 3.0));
   cameraFreePreset = static_cast<int>(
-      std::clamp(parseJsonNumberProperty(json, "camera_free_preset").value_or(0.0), 0.0, 1.0));
+      std::clamp(parseJsonNumberProperty(json, "camera_free_preset").value_or(-1.0), -1.0, 1.0));
   cameraSelectedPlayerId =
       parseJsonStringProperty(json, "camera_selected_player_id").value_or("");
   cameraSelectedPlayerIndex = static_cast<uint32_t>(
@@ -3423,8 +3423,10 @@ void SubtrActorPlugin::applyUiConfigJson(
     const std::optional<std::string> mode = parseJsonStringProperty(*camera, "mode");
     if (mode == "follow") {
       cameraViewMode = 1;
+      cameraFreePreset = -1;
     } else if (mode == "free") {
       cameraViewMode = 0;
+      cameraFreePreset = -1;
     }
     const std::optional<std::string> freePreset =
         parseJsonStringProperty(*camera, "freePreset");
@@ -3438,6 +3440,8 @@ void SubtrActorPlugin::applyUiConfigJson(
       if (cameraViewMode != 1) {
         cameraViewMode = 3;
       }
+    } else if (jsonPropertyIsNull(*camera, "freePreset")) {
+      cameraFreePreset = -1;
     }
     if (jsonPropertyExists(*camera, "attachedPlayerId")) {
       cameraSelectedPlayerId.clear();
@@ -9411,6 +9415,7 @@ void SubtrActorPlugin::renderCameraWindow() {
   if (ImGui::BeginCombo("Target", selectedLabel.c_str())) {
     if (ImGui::Selectable("Free camera", cameraViewMode != 1)) {
       cameraViewMode = 0;
+      cameraFreePreset = -1;
       scheduleUiConfigAutosave();
     }
     for (const SaPlayerFrame &player : sampledPlayers) {
@@ -9424,6 +9429,7 @@ void SubtrActorPlugin::renderCameraWindow() {
         cameraSelectedPlayerIndex = player.player_index;
         cameraSelectedPlayerId = webPlayerIdForIndex(cameraSelectedPlayerIndex);
         cameraViewMode = 1;
+        cameraFreePreset = -1;
         scheduleUiConfigAutosave();
       }
     }
@@ -9431,10 +9437,12 @@ void SubtrActorPlugin::renderCameraWindow() {
   }
 
   if (ImGui::RadioButton("Free##camera-view", &cameraViewMode, 0)) {
+    cameraFreePreset = -1;
     scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (ImGui::RadioButton("Follow##camera-view", &cameraViewMode, 1)) {
+    cameraFreePreset = -1;
     scheduleUiConfigAutosave();
   }
   ImGui::SameLine();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10042,13 +10042,17 @@ void SubtrActorPlugin::renderRecordingWindow() {
   const std::array<const char *, 4> rates{{"0.5x", "1.0x", "1.5x", "2.0x"}};
   recordingPlaybackRateIndex = std::clamp(recordingPlaybackRateIndex, 0, 3);
   int nextRecordingPlaybackRateIndex = recordingPlaybackRateIndex;
-  pushRecordingDisabledStyle(recordingSettingsLocked);
+  const bool recordingPlaybackRateDisabled = recordingSettingsLocked;
+  pushRecordingDisabledStyle(recordingPlaybackRateDisabled);
   ImGui::SetNextItemWidth(96.0f);
-  if (ImGui::BeginCombo(
-          "##recording-playback-rate",
-          rates[static_cast<size_t>(recordingPlaybackRateIndex)])) {
-    if (recordingSettingsLocked) {
-      ImGui::TextDisabled("%s", rates[static_cast<size_t>(recordingPlaybackRateIndex)]);
+  const bool recordingPlaybackRateOpen = ImGui::BeginCombo(
+      "##recording-playback-rate",
+      rates[static_cast<size_t>(recordingPlaybackRateIndex)]);
+  popRecordingDisabledStyle(recordingPlaybackRateDisabled);
+  if (recordingPlaybackRateOpen) {
+    if (recordingPlaybackRateDisabled) {
+      ImGui::CloseCurrentPopup();
+      ImGui::EndCombo();
     } else {
       for (int index = 0; index < static_cast<int>(rates.size()); index += 1) {
         const bool selected = index == recordingPlaybackRateIndex;
@@ -10059,11 +10063,11 @@ void SubtrActorPlugin::renderRecordingWindow() {
           ImGui::SetItemDefaultFocus();
         }
       }
+      ImGui::EndCombo();
     }
-    ImGui::EndCombo();
   }
-  popRecordingDisabledStyle(recordingSettingsLocked);
-  if (!recordingSettingsLocked && nextRecordingPlaybackRateIndex != recordingPlaybackRateIndex) {
+  if (!recordingPlaybackRateDisabled &&
+      nextRecordingPlaybackRateIndex != recordingPlaybackRateIndex) {
     recordingPlaybackRateIndex = nextRecordingPlaybackRateIndex;
     scheduleUiConfigAutosave();
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3128,7 +3128,11 @@ bool SubtrActorPlugin::cvarBool(const char *name, bool defaultValue) const {
 void SubtrActorPlugin::setCvarBool(const char *name, bool value) {
   auto cvar = cvarManager->getCvar(name);
   if (static_cast<bool>(cvar)) {
+    const bool changed = cvar.getBoolValue() != value;
     cvar.setValue(value ? 1 : 0);
+    if (changed) {
+      scheduleUiConfigAutosave();
+    }
   }
 }
 
@@ -3140,7 +3144,11 @@ std::string SubtrActorPlugin::cvarString(const char *name, std::string_view defa
 void SubtrActorPlugin::setCvarString(const char *name, std::string_view value) {
   auto cvar = cvarManager->getCvar(name);
   if (static_cast<bool>(cvar)) {
+    const bool changed = cvar.getStringValue() != value;
     cvar.setValue(std::string(value));
+    if (changed) {
+      scheduleUiConfigAutosave();
+    }
   }
 }
 
@@ -7351,6 +7359,7 @@ void SubtrActorPlugin::renderBoolModuleSummaryToggle(
     const char *idSuffix) {
   if (renderModuleSummaryToggle(label, active, idSuffix)) {
     active = !active;
+    scheduleUiConfigAutosave();
   }
 }
 
@@ -7476,6 +7485,7 @@ void SubtrActorPlugin::renderModuleSummaryControls(const char *idSuffix) {
       boostPickupPadBig = next;
       boostPickupPadSmall = next;
       boostPickupPadAmbiguous = next;
+      scheduleUiConfigAutosave();
     }
     ImGui::TreePop();
   }
@@ -7510,9 +7520,13 @@ void SubtrActorPlugin::renderModuleSettingsControls(
           {{movementBreakdownSpeed, "Speed band"}, {movementBreakdownHeight, "Height band"}},
           " + ")
           .c_str());
-  ImGui::Checkbox("Speed band##movement-breakdown", &movementBreakdownSpeed);
+  if (ImGui::Checkbox("Speed band##movement-breakdown", &movementBreakdownSpeed)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::Checkbox("Height band##movement-breakdown", &movementBreakdownHeight);
+  if (ImGui::Checkbox("Height band##movement-breakdown", &movementBreakdownHeight)) {
+    scheduleUiConfigAutosave();
+  }
   if (includeOpenButtons && ImGui::Button("Open movement stats")) {
     createStatsModuleWindow("movement", 0);
   }
@@ -7526,9 +7540,13 @@ void SubtrActorPlugin::renderModuleSettingsControls(
           {{possessionBreakdownState, "Control"}, {possessionBreakdownThird, "Third"}},
           " x ")
           .c_str());
-  ImGui::Checkbox("Control##possession-breakdown", &possessionBreakdownState);
+  if (ImGui::Checkbox("Control##possession-breakdown", &possessionBreakdownState)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::Checkbox("Third##possession-breakdown", &possessionBreakdownThird);
+  if (ImGui::Checkbox("Third##possession-breakdown", &possessionBreakdownThird)) {
+    scheduleUiConfigAutosave();
+  }
   if (includeOpenButtons && ImGui::Button("Open possession stats")) {
     createStatsModuleWindow("possession", 0);
   }
@@ -8201,7 +8219,9 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     eventPlaylistGoalContextEnabled = false;
     setCvarString("subtr_actor_overlay_event_types", "none");
   }
-  ImGui::Checkbox("Auto-follow", &eventPlaylistAutoFollow);
+  if (ImGui::Checkbox("Auto-follow", &eventPlaylistAutoFollow)) {
+    scheduleUiConfigAutosave();
+  }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "FILTERS");
@@ -8375,18 +8395,29 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
       confirmedCount,
       rejectedCount,
       uncertainCount);
-  ImGui::Checkbox("Mechanics", &eventPlaylistMechanicsEnabled);
+  if (ImGui::Checkbox("Mechanics", &eventPlaylistMechanicsEnabled)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::Checkbox("Team", &eventPlaylistTeamEventsEnabled);
+  if (ImGui::Checkbox("Team", &eventPlaylistTeamEventsEnabled)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::Checkbox("Goal context", &eventPlaylistGoalContextEnabled);
+  if (ImGui::Checkbox("Goal context", &eventPlaylistGoalContextEnabled)) {
+    scheduleUiConfigAutosave();
+  }
 
   renderEventFilterCombo("Event filter");
   ImGui::SetNextItemWidth(120.0f);
-  ImGui::SliderFloat("Clip lead", &mechanicsReviewClipLeadSeconds, 0.0f, 10.0f, "%.1fs");
+  if (ImGui::SliderFloat("Clip lead", &mechanicsReviewClipLeadSeconds, 0.0f, 10.0f, "%.1fs")) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
   ImGui::SetNextItemWidth(120.0f);
-  ImGui::SliderFloat("Clip trail", &mechanicsReviewClipTrailSeconds, 0.0f, 10.0f, "%.1fs");
+  if (ImGui::SliderFloat(
+          "Clip trail", &mechanicsReviewClipTrailSeconds, 0.0f, 10.0f, "%.1fs")) {
+    scheduleUiConfigAutosave();
+  }
 
   ImGui::Separator();
   if (candidates.empty()) {
@@ -8851,7 +8882,9 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
   ImGui::Text("Recent boost pickups: %d", recentEventCountForType("boost_pickup"));
 
   ImGui::Separator();
-  ImGui::Checkbox("Boost pickup animation", &boostPickupAnimationEnabled);
+  if (ImGui::Checkbox("Boost pickup animation", &boostPickupAnimationEnabled)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::Separator();
   if (ImGui::Button("All filters")) {
     boostPickupPadBig = true;
@@ -8863,6 +8896,7 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
     boostPickupFieldOwn = true;
     boostPickupFieldOpponent = true;
     boostPickupFieldUnknown = true;
+    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (ImGui::Button("Hide pickups")) {
@@ -8875,28 +8909,47 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
     boostPickupFieldOwn = false;
     boostPickupFieldOpponent = false;
     boostPickupFieldUnknown = false;
+    scheduleUiConfigAutosave();
   }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PAD TYPE");
-  ImGui::Checkbox("Big pads", &boostPickupPadBig);
+  if (ImGui::Checkbox("Big pads", &boostPickupPadBig)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::Checkbox("Small pads", &boostPickupPadSmall);
-  ImGui::Checkbox("Ambiguous pads", &boostPickupPadAmbiguous);
+  if (ImGui::Checkbox("Small pads", &boostPickupPadSmall)) {
+    scheduleUiConfigAutosave();
+  }
+  if (ImGui::Checkbox("Ambiguous pads", &boostPickupPadAmbiguous)) {
+    scheduleUiConfigAutosave();
+  }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ACTIVITY");
-  ImGui::Checkbox("Active play", &boostPickupActivityActive);
+  if (ImGui::Checkbox("Active play", &boostPickupActivityActive)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::Checkbox("Inactive play", &boostPickupActivityInactive);
-  ImGui::Checkbox("Unknown activity", &boostPickupActivityUnknown);
+  if (ImGui::Checkbox("Inactive play", &boostPickupActivityInactive)) {
+    scheduleUiConfigAutosave();
+  }
+  if (ImGui::Checkbox("Unknown activity", &boostPickupActivityUnknown)) {
+    scheduleUiConfigAutosave();
+  }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "FIELD HALF");
-  ImGui::Checkbox("Own half", &boostPickupFieldOwn);
+  if (ImGui::Checkbox("Own half", &boostPickupFieldOwn)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::Checkbox("Opponent half", &boostPickupFieldOpponent);
-  ImGui::Checkbox("Unknown half", &boostPickupFieldUnknown);
+  if (ImGui::Checkbox("Opponent half", &boostPickupFieldOpponent)) {
+    scheduleUiConfigAutosave();
+  }
+  if (ImGui::Checkbox("Unknown half", &boostPickupFieldUnknown)) {
+    scheduleUiConfigAutosave();
+  }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ACTIONS");
@@ -8967,7 +9020,10 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
       ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
       "%.1fs",
       touchMarkerDecaySeconds);
-  ImGui::SliderFloat("Marker decay seconds", &touchMarkerDecaySeconds, 1.0f, 10.0f, "%.1fs");
+  if (ImGui::SliderFloat(
+          "Marker decay seconds", &touchMarkerDecaySeconds, 1.0f, 10.0f, "%.1fs")) {
+    scheduleUiConfigAutosave();
+  }
 
   ImGui::TextDisabled("Touch mode");
   ImGui::SameLine();
@@ -8977,10 +9033,12 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
       touchControlsMode == 1 ? "Advancement" : "Markers");
   if (ImGui::RadioButton("Markers##touch-mode", &touchControlsMode, 0)) {
     setCvarString("subtr_actor_overlay_event_types", "touch");
+    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (ImGui::RadioButton("Advancement##touch-mode", &touchControlsMode, 1)) {
     setCvarString("subtr_actor_overlay_event_types", "touch_ball_movement");
+    scheduleUiConfigAutosave();
   }
 
   ImGui::Separator();
@@ -8990,12 +9048,20 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
       ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
       "%s",
       touchBreakdownReadout().c_str());
-  ImGui::Checkbox("Kind", &touchBreakdownKind);
+  if (ImGui::Checkbox("Kind", &touchBreakdownKind)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::Checkbox("Height", &touchBreakdownHeight);
-  ImGui::Checkbox("Surface", &touchBreakdownSurface);
+  if (ImGui::Checkbox("Height", &touchBreakdownHeight)) {
+    scheduleUiConfigAutosave();
+  }
+  if (ImGui::Checkbox("Surface", &touchBreakdownSurface)) {
+    scheduleUiConfigAutosave();
+  }
   ImGui::SameLine();
-  ImGui::Checkbox("Dodge", &touchBreakdownDodge);
+  if (ImGui::Checkbox("Dodge", &touchBreakdownDodge)) {
+    scheduleUiConfigAutosave();
+  }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "LIVE TOUCH STATE");

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7709,9 +7709,13 @@ void SubtrActorPlugin::renderWebWindowToggleControls(
 
 void SubtrActorPlugin::renderStatsWindowCreationControls(
     const char *idSuffix,
-    bool closeLauncherOnCreate) {
+    bool closeLauncherOnCreate,
+    bool includeHeading,
+    bool includeManager) {
   ImGui::PushID(idSuffix);
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STATS WINDOWS");
+  if (includeHeading) {
+    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STATS WINDOWS");
+  }
   for (const StatsWindowKindControl &kind : statsWindowKindControls()) {
     if (!kind.web_config) {
       continue;
@@ -7723,7 +7727,7 @@ void SubtrActorPlugin::renderStatsWindowCreationControls(
       }
     }
   }
-  if (uiStatsWindows.empty()) {
+  if (!includeManager || uiStatsWindows.empty()) {
     ImGui::PopID();
     return;
   }
@@ -7780,10 +7784,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
   renderWebWindowToggleControls("launcher-web-windows", true);
-  renderSingletonWindowManager();
-
-  ImGui::Separator();
-  renderStatsWindowCreationControls("launcher-stats-windows", false);
+  renderStatsWindowCreationControls("launcher-stats-windows", false, false, false);
 
   ImGui::Separator();
   renderLauncherWorkspaceControls();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9850,9 +9850,9 @@ void SubtrActorPlugin::renderCameraWindow() {
     renderCustomSlider("Pitch", cameraCustomPitch, -30.0f, 30.0f, "%.1f");
     renderCustomSlider("Distance", cameraCustomDistance, 100.0f, 500.0f, "%.0f");
     renderCustomSlider("Stiffness", cameraCustomStiffness, 0.0f, 1.0f, "%.2f");
-    renderCustomSlider("Swivel speed", cameraCustomSwivelSpeed, 1.0f, 10.0f, "%.1f");
+    renderCustomSlider("Swivel", cameraCustomSwivelSpeed, 1.0f, 10.0f, "%.1f");
     renderCustomSlider(
-        "Transition speed",
+        "Transition",
         cameraCustomTransitionSpeed,
         0.5f,
         2.0f,

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3536,6 +3536,14 @@ std::string SubtrActorPlugin::uiConfigJson() {
       pluginWindows.push_back(window);
     }
   }
+  std::sort(
+      webWindows.begin(),
+      webWindows.end(),
+      [](const SingletonWindowControl &left, const SingletonWindowControl &right) {
+        return left.launcher_order == right.launcher_order
+                   ? std::string_view{left.config_id} < std::string_view{right.config_id}
+                   : left.launcher_order < right.launcher_order;
+      });
   for (size_t index = 0; index < webWindows.size(); index += 1) {
     writeWindowConfig(webWindows[index], index + 1 == webWindows.size());
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8578,31 +8578,30 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
         static_cast<int>(candidates.size()) - 1);
   }
 
-  if (candidates.empty()) {
-    ImGui::TextWrapped("No candidate selected");
-    ImGui::End();
-    return;
-  }
-
-  UiEventRecord &current = recentUiEvents[candidates[static_cast<size_t>(mechanicsReviewIndex)]];
-  const std::string currentKey = mechanicsReviewKey(current);
-  const float clipStart = std::max(0.0f, current.time - mechanicsReviewClipLeadSeconds);
-  const float clipEnd = current.time + mechanicsReviewClipTrailSeconds;
-  ImGui::Text(
-      "%d / %zu",
-      mechanicsReviewIndex + 1,
-      candidates.size());
-  ImGui::TextWrapped("%s", current.label.c_str());
-  const std::string clipReadout = std::format("{:.2f}s to {:.2f}s", clipStart, clipEnd);
+  const UiEventRecord *current = candidates.empty()
+                                     ? nullptr
+                                     : &recentUiEvents[candidates[static_cast<size_t>(
+                                           mechanicsReviewIndex)]];
+  const std::string currentKey = current == nullptr ? std::string{} : mechanicsReviewKey(*current);
+  const float clipStart =
+      current == nullptr ? 0.0f : std::max(0.0f, current->time - mechanicsReviewClipLeadSeconds);
+  const float clipEnd = current == nullptr ? 0.0f : current->time + mechanicsReviewClipTrailSeconds;
+  ImGui::Text("%d / %zu", current == nullptr ? 0 : mechanicsReviewIndex + 1, candidates.size());
+  ImGui::TextWrapped("%s", current == nullptr ? "No candidate selected" : current->label.c_str());
+  const std::string clipReadout =
+      current == nullptr ? "--" : std::format("{:.2f}s to {:.2f}s", clipStart, clipEnd);
   const std::string eventReadout =
-      std::format("frame {}", static_cast<unsigned long long>(current.frame_number));
-  const std::string reasonReadout = current.details.empty() ? "--" : current.details;
+      current == nullptr
+          ? "--"
+          : std::format("frame {}", static_cast<unsigned long long>(current->frame_number));
+  const std::string reasonReadout =
+      current == nullptr || current->details.empty() ? "--" : current->details;
   ImGui::Columns(2, "mechanics-review-fields", false);
   ImGui::TextDisabled("Mechanic");
-  ImGui::Text("%s", current.type.empty() ? "--" : current.type.c_str());
+  ImGui::Text("%s", current == nullptr || current->type.empty() ? "--" : current->type.c_str());
   ImGui::NextColumn();
   ImGui::TextDisabled("Player");
-  ImGui::Text("%s", current.actor.empty() ? "--" : current.actor.c_str());
+  ImGui::Text("%s", current == nullptr || current->actor.empty() ? "--" : current->actor.c_str());
   ImGui::NextColumn();
   ImGui::TextDisabled("Clip");
   ImGui::Text("%s", clipReadout.c_str());
@@ -8623,12 +8622,12 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     ImGui::TextWrapped("%s", status.c_str());
   }
 
-  if (ImGui::Button("Prev") && mechanicsReviewIndex > 0) {
+  if (ImGui::Button("Prev") && current != nullptr && mechanicsReviewIndex > 0) {
     mechanicsReviewIndex -= 1;
     scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
-  if (ImGui::Button("Replay clip")) {
+  if (ImGui::Button("Replay clip") && current != nullptr) {
     playbackCurrentTime = clipStart;
     playbackPlaying = true;
     playbackSkipPostGoalTransitions = false;
@@ -8653,26 +8652,36 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   }
   ImGui::SameLine();
   if (ImGui::Button("Next") &&
-      mechanicsReviewIndex < static_cast<int>(candidates.size()) - 1) {
+      current != nullptr && mechanicsReviewIndex < static_cast<int>(candidates.size()) - 1) {
     mechanicsReviewIndex += 1;
     scheduleUiConfigAutosave();
   }
 
-  if (ImGui::Button("Confirm")) {
+  if (ImGui::Button("Confirm") && current != nullptr) {
     mechanicsReviewDecisions[currentKey] = 1;
   }
   ImGui::SameLine();
-  if (ImGui::Button("Reject")) {
+  if (ImGui::Button("Reject") && current != nullptr) {
     mechanicsReviewDecisions[currentKey] = 2;
   }
   ImGui::SameLine();
-  if (ImGui::Button("Uncertain")) {
+  if (ImGui::Button("Uncertain") && current != nullptr) {
     mechanicsReviewDecisions[currentKey] = 3;
   }
 
   ImGui::Separator();
+  ImGui::Text("Replays");
+  ImGui::SameLine();
+  ImGui::TextDisabled("%s", replayAnnotations ? "1 replay" : "0 replays");
+
+  ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PLAYLIST");
+  ImGui::SameLine();
+  ImGui::TextDisabled("%zu %s", candidates.size(), candidates.size() == 1 ? "item" : "items");
   ImGui::BeginChild("mechanics-review-list", ImVec2{0.0f, 150.0f}, true);
+  if (candidates.empty()) {
+    ImGui::TextDisabled("No review playlist loaded.");
+  }
   for (size_t i = 0; i < candidates.size(); i += 1) {
     const UiEventRecord &event = recentUiEvents[candidates[i]];
     ImGui::PushID(static_cast<int>(i));

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1183,6 +1183,12 @@ bool jsonPropertyExists(const std::string &json, const std::string &propertyName
   return findJsonPropertyValueOffset(json, propertyName, offset);
 }
 
+bool jsonPropertyIsNull(const std::string &json, const std::string &propertyName) {
+  size_t offset = 0;
+  return findJsonPropertyValueOffset(json, propertyName, offset) &&
+         json.compare(offset, 4, "null") == 0;
+}
+
 std::optional<std::string> parseJsonStringProperty(
     const std::string &json,
     const std::string &propertyName) {
@@ -3483,7 +3489,7 @@ void SubtrActorPlugin::applyUiConfigJson(
               .value_or(cameraCustomTransitionSpeed),
           0.5,
           2.0));
-    } else if (camera->find("\"customSettings\":null") != std::string::npos) {
+    } else if (jsonPropertyIsNull(*camera, "customSettings")) {
       cameraCustomSettingsEnabled = false;
     }
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8603,6 +8603,12 @@ void SubtrActorPlugin::renderEventSourceControls() {
     }
     displaySources.push_back(DisplaySource{&option, count, enabled});
   }
+  std::sort(
+      displaySources.begin(),
+      displaySources.end(),
+      [](const DisplaySource &left, const DisplaySource &right) {
+        return std::string_view{left.option->label} < std::string_view{right.option->label};
+      });
 
   if (displaySources.empty()) {
     ImGui::TextDisabled("No events loaded.");
@@ -8758,6 +8764,23 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     playlistSources.push_back(
         PlaylistSource{&option, count, selected && sourceHasEnabledPlaylistGroup(option.value)});
   }
+  auto playlistSourceRank = [](const EventFilterOption &option) {
+    const std::string_view group{option.group};
+    const int groupRank = group == "Replay"     ? 0
+                          : group == "Mechanics" ? 1
+                          : group == "Stats"     ? 2
+                                                  : 3;
+    if (group == "Replay" && std::string_view{option.value} == "goal") {
+      return std::tuple{groupRank, 0, std::string_view{option.label}};
+    }
+    return std::tuple{groupRank, 1, std::string_view{option.label}};
+  };
+  std::sort(
+      playlistSources.begin(),
+      playlistSources.end(),
+      [&](const PlaylistSource &left, const PlaylistSource &right) {
+        return playlistSourceRank(*left.option) < playlistSourceRank(*right.option);
+      });
 
   const size_t selectedSourceCount = static_cast<size_t>(std::count_if(
       playlistSources.begin(),

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7169,12 +7169,17 @@ void SubtrActorPlugin::captureWindowPlacement(UiWindowPlacement &placement) {
   const int previousZIndex = placement.z_index;
   const ImVec2 position = ImGui::GetWindowPos();
   const ImVec2 size = ImGui::GetWindowSize();
+  const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+  const ImVec2 clampedPosition =
+      mapWindowPositionToViewport(position.x, position.y, size.x, size.y, 0.0f, 0.0f);
+  if (clampedPosition.x != position.x || clampedPosition.y != position.y) {
+    ImGui::SetWindowPos(clampedPosition, ImGuiCond_Always);
+  }
   placement.has_placement = true;
-  placement.x = position.x;
-  placement.y = position.y;
+  placement.x = clampedPosition.x;
+  placement.y = clampedPosition.y;
   placement.width = size.x;
   placement.height = size.y;
-  const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
   placement.viewport_width = displaySize.x;
   placement.viewport_height = displaySize.y;
   if (ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows) &&
@@ -7293,12 +7298,17 @@ void SubtrActorPlugin::captureStatsWindowPlacement(UiStatsWindow &window) {
   const int previousZIndex = window.z_index;
   const ImVec2 position = ImGui::GetWindowPos();
   const ImVec2 size = ImGui::GetWindowSize();
+  const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+  const ImVec2 clampedPosition =
+      mapWindowPositionToViewport(position.x, position.y, size.x, size.y, 0.0f, 0.0f);
+  if (clampedPosition.x != position.x || clampedPosition.y != position.y) {
+    ImGui::SetWindowPos(clampedPosition, ImGuiCond_Always);
+  }
   window.has_placement = true;
-  window.x = position.x;
-  window.y = position.y;
+  window.x = clampedPosition.x;
+  window.y = clampedPosition.y;
   window.width = size.x;
   window.height = size.y;
-  const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
   window.viewport_width = displaySize.x;
   window.viewport_height = displaySize.y;
   if (ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows) &&

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9018,6 +9018,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
       metaParts.push_back(sourceLabel);
     }
     if (!metaParts.empty()) {
+      ImGui::SetCursorPosX(64.0f);
       ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());
     }
     if (active && eventPlaylistAutoFollow && activeEventKey != eventPlaylistLastActiveKey) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10527,7 +10527,7 @@ std::pair<float, float> SubtrActorPlugin::defaultStatsWindowSize(UiStatsWindowKi
   if (kind == UiStatsWindowKind::StatsModule) {
     return {680.0f, 460.0f};
   }
-  return {540.0f, 330.0f};
+  return {416.0f, 330.0f};
 }
 
 void SubtrActorPlugin::initializeStatsWindowPlacement(UiStatsWindow &window) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10872,12 +10872,20 @@ void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
     }
     break;
   case UiStatsWindowKind::Team:
+    if (sampledPlayers.empty() && currentStatsJson().empty()) {
+      ImGui::TextWrapped("Start live analysis or load replay stats to show team stats.");
+      break;
+    }
     renderTeamStatsTable(window, window.selected_team_is_team_0);
     break;
   case UiStatsWindowKind::AllPlayers:
     renderAllPlayersStatsTable(window);
     break;
   case UiStatsWindowKind::AllTeams:
+    if (sampledPlayers.empty() && currentStatsJson().empty()) {
+      ImGui::TextWrapped("Start live analysis or load replay stats to show team stats.");
+      break;
+    }
     renderAllTeamsStatsTable(window);
     break;
   case UiStatsWindowKind::GoalsOverview:

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -2425,6 +2425,29 @@ std::optional<std::string> SubtrActorPlugin::statsPlayerCfgJsonFromClipboard(
   return json.substr(jsonFirstByte);
 }
 
+std::optional<std::string> SubtrActorPlugin::statsPlayerCfgFromJson(const std::string &json) {
+  if (!encodedStatsPlayerConfigLen || !writeEncodedStatsPlayerConfig ||
+      json.find('\0') != std::string::npos) {
+    return std::nullopt;
+  }
+
+  const size_t byteCount = encodedStatsPlayerConfigLen(json.c_str());
+  if (byteCount == 0) {
+    return std::nullopt;
+  }
+
+  std::string encoded(byteCount, '\0');
+  const size_t written = writeEncodedStatsPlayerConfig(
+      json.c_str(),
+      reinterpret_cast<uint8_t *>(encoded.data()),
+      encoded.size());
+  if (written == 0 || written > encoded.size()) {
+    return std::nullopt;
+  }
+  encoded.resize(written);
+  return std::format("#cfg={}", encoded);
+}
+
 std::string SubtrActorPlugin::webUiStatIdForWindow(
     const UiStatsWindow &window,
     const UiStatsWindow::Entry &entry) const {
@@ -2965,6 +2988,10 @@ bool SubtrActorPlugin::loadRustLibrary() {
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_decoded_stats_player_config_json_len"));
   writeDecodedStatsPlayerConfigJson = reinterpret_cast<WriteDecodedStatsPlayerConfigJson>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_decoded_stats_player_config_json"));
+  encodedStatsPlayerConfigLen = reinterpret_cast<EncodedStatsPlayerConfigLen>(
+      GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_encoded_stats_player_config_len"));
+  writeEncodedStatsPlayerConfig = reinterpret_cast<WriteEncodedStatsPlayerConfig>(
+      GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_encoded_stats_player_config"));
   drainEvents = reinterpret_cast<DrainEvents>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_drain_events"));
   drainTeamEvents = reinterpret_cast<DrainTeamEvents>(
@@ -2993,6 +3020,7 @@ bool SubtrActorPlugin::loadRustLibrary() {
       !analysisNodeJsonLen || !writeAnalysisNodeJson || !analysisNodeNamesJsonLen ||
       !writeAnalysisNodeNamesJson || !graphInfoJsonLen || !writeGraphInfoJson ||
       !decodedStatsPlayerConfigJsonLen || !writeDecodedStatsPlayerConfigJson ||
+      !encodedStatsPlayerConfigLen || !writeEncodedStatsPlayerConfig ||
       !drainEvents || !drainTeamEvents || !drainGoalContextEvents ||
       !replayAnnotationsCreate || !replayAnnotationsDestroy || !replayAnnotationCount ||
       !replayAnnotationPlayerCount || !writeReplayAnnotationPlayers ||
@@ -3048,6 +3076,8 @@ void SubtrActorPlugin::unloadRustLibrary() {
   writeGraphInfoJson = nullptr;
   decodedStatsPlayerConfigJsonLen = nullptr;
   writeDecodedStatsPlayerConfigJson = nullptr;
+  encodedStatsPlayerConfigLen = nullptr;
+  writeEncodedStatsPlayerConfig = nullptr;
   drainEvents = nullptr;
   drainTeamEvents = nullptr;
   drainGoalContextEvents = nullptr;
@@ -7515,7 +7545,9 @@ void SubtrActorPlugin::renderLauncherWorkspaceControls() {
   ImGui::SameLine();
   if (ImGui::Button("Copy layout cfg")) {
     const std::string json = uiConfigJson();
-    const std::string cfg = std::format("#cfg={}", urlEncode(json));
+    const std::optional<std::string> encodedCfg = statsPlayerCfgFromJson(json);
+    const std::string cfg =
+        encodedCfg.value_or(std::format("#cfg={}", urlEncode(json)));
     ImGui::SetClipboardText(cfg.c_str());
     cvarManager->log(std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11456,18 +11456,13 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   std::array<char, 128> queryBuffer{};
   const size_t querySize = std::min(window.picker_query.size(), queryBuffer.size() - 1);
   std::copy_n(window.picker_query.data(), querySize, queryBuffer.data());
+  ImGui::TextDisabled("Search stats");
   ImGui::SetNextItemWidth(-1.0f);
   if (ImGui::InputText(
-          std::format("Search stats##{}", window.id).c_str(),
+          std::format("##stats-window-search-{}", window.id).c_str(),
           queryBuffer.data(),
           queryBuffer.size())) {
     window.picker_query = queryBuffer.data();
-  }
-  if (!window.picker_query.empty()) {
-    ImGui::SameLine();
-    if (ImGui::SmallButton(std::format("Clear##stat-search-{}", window.id).c_str())) {
-      window.picker_query.clear();
-    }
   }
 
   std::vector<UiStatDefinitionCandidate> definitions;
@@ -11525,7 +11520,7 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
       continue;
     }
     const std::string label =
-        std::format("Add all {} ({})##{}-{}", category, count, window.id, category);
+        std::format("Add all {}   {}##{}-{}", category, count, window.id, category);
     if (ImGui::SmallButton(label.c_str())) {
       bool added = false;
       for (const UiStatDefinitionMatch &match : matches) {
@@ -11557,14 +11552,14 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
     const UiStatDefinitionCandidate &definition = match.definition;
     const bool alreadySelected = statsWindowHasStat(window, definition.id);
     const std::string itemLabel = std::format(
-        "{}  [{}]##{}-{}",
+        "{}   {}##{}-{}",
         definition.label,
         uiStatScopeLabel(definition),
         window.id,
         definition.id);
     if (alreadySelected && window.kind != UiStatsWindowKind::AdHoc) {
       ImGui::TextDisabled(
-          "%s  [%s selected]",
+          "%s   %s",
           definition.label.c_str(),
           uiStatScopeLabel(definition));
       continue;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <tuple>
 #include <type_traits>
+#include <unordered_set>
 
 #include "imgui/imgui.h"
 
@@ -160,8 +161,17 @@ struct UiStatDefinition {
   bool event;
 };
 
+struct UiStatDefinitionCandidate {
+  std::string id;
+  std::string label;
+  std::string category;
+  bool player = false;
+  bool team = false;
+  bool event = false;
+};
+
 struct UiStatDefinitionMatch {
-  const UiStatDefinition *definition = nullptr;
+  UiStatDefinitionCandidate definition;
   double score = 0.0;
   size_t index = 0;
 };
@@ -170,6 +180,8 @@ struct UiStatIdAlias {
   const char *external_id;
   const char *local_id;
 };
+
+std::string normalizeUiStatId(std::string_view statId);
 
 constexpr std::array<EventFilterOption, 33> EVENT_FILTER_OPTIONS{{
     {"all", "All events", "All"},
@@ -910,6 +922,69 @@ void collectJsonFieldSummaries(
   }
 }
 
+void collectJsonLeafStatPaths(
+    const std::string &json,
+    std::string_view prefix,
+    std::vector<std::string> &out,
+    int maxDepth) {
+  if (maxDepth < 0) {
+    return;
+  }
+
+  size_t offset = 0;
+  skipJsonWhitespace(json, offset);
+  if (offset >= json.size() || json[offset] != '{') {
+    return;
+  }
+  ++offset;
+  skipJsonWhitespace(json, offset);
+
+  while (offset < json.size()) {
+    if (json[offset] == '}') {
+      return;
+    }
+
+    auto key = parseJsonString(json, offset);
+    if (!key) {
+      return;
+    }
+    skipJsonWhitespace(json, offset);
+    if (offset >= json.size() || json[offset] != ':') {
+      return;
+    }
+    ++offset;
+    skipJsonWhitespace(json, offset);
+
+    const std::string label =
+        prefix.empty() ? *key : std::format("{}.{}", prefix, *key);
+    const size_t valueStart = offset;
+    if (offset < json.size() && json[offset] == '{') {
+      size_t end = offset;
+      if (!skipJsonValue(json, end)) {
+        return;
+      }
+      collectJsonLeafStatPaths(json.substr(valueStart, end - valueStart), label, out, maxDepth - 1);
+      offset = end;
+    } else {
+      out.push_back(label);
+      if (!skipJsonValue(json, offset)) {
+        return;
+      }
+    }
+
+    skipJsonWhitespace(json, offset);
+    if (offset < json.size() && json[offset] == ',') {
+      ++offset;
+      skipJsonWhitespace(json, offset);
+      continue;
+    }
+    if (offset < json.size() && json[offset] == '}') {
+      return;
+    }
+    return;
+  }
+}
+
 std::string escapeJsonString(std::string_view value) {
   std::string escaped;
   escaped.reserve(value.size() + 8);
@@ -1216,6 +1291,65 @@ bool jsonPlayerIdMatchesIndex(const std::string &playerIdJson, uint32_t playerIn
   }
   const auto parsedIndex = parseJsonNumberValue(*splitScreenValue);
   return parsedIndex && static_cast<uint32_t>(*parsedIndex) == playerIndex;
+}
+
+std::string graphStatLabel(const GraphStatId &stat) {
+  return std::format("{}.{}", stat.module, stat.path);
+}
+
+std::vector<UiStatDefinitionCandidate> graphStatDefinitionsFromStatsJson(
+    const std::string &statsJson) {
+  std::vector<UiStatDefinitionCandidate> definitions;
+  const auto frame = parseJsonObjectProperty(statsJson, "frame");
+  if (!frame) {
+    return definitions;
+  }
+  const auto modules = parseJsonObjectProperty(*frame, "modules");
+  if (!modules) {
+    return definitions;
+  }
+
+  std::unordered_set<std::string> seenIds;
+  for (const std::string &moduleName : parseJsonObjectKeys(*modules)) {
+    const auto module = parseJsonObjectProperty(*modules, moduleName);
+    if (!module) {
+      continue;
+    }
+
+    auto appendStatsObject = [&](const std::string &statsObject, const char *scope) {
+      std::vector<std::string> paths;
+      collectJsonLeafStatPaths(statsObject, "", paths, 8);
+      for (const std::string &path : paths) {
+        const std::string id = std::format("{}:{}.{}", scope, moduleName, path);
+        if (!seenIds.insert(id).second || normalizeUiStatId(id) != id) {
+          continue;
+        }
+        definitions.push_back(UiStatDefinitionCandidate{
+            id,
+            std::format("{}.{}", moduleName, path),
+            moduleName,
+            std::string_view{scope} == "player",
+            std::string_view{scope} == "team",
+            false,
+        });
+      }
+    };
+
+    const std::vector<std::string> playerStats =
+        parseJsonObjectArrayProperty(*module, "player_stats");
+    if (!playerStats.empty()) {
+      if (const auto stats = parseJsonObjectProperty(playerStats.front(), "stats")) {
+        appendStatsObject(*stats, "player");
+      }
+    }
+    if (const auto team = parseJsonObjectProperty(*module, "team_zero")) {
+      appendStatsObject(*team, "team");
+    } else if (const auto teamOne = parseJsonObjectProperty(*module, "team_one")) {
+      appendStatsObject(*teamOne, "team");
+    }
+  }
+
+  return definitions;
 }
 
 static_assert(sizeof(SaBoostPadEventKind) == 4);
@@ -1824,27 +1958,36 @@ const UiStatDefinition *uiStatDefinition(std::string_view statId) {
   return localUiStatDefinition(normalized);
 }
 
-const char *uiStatLabel(std::string_view statId) {
+std::string uiStatLabel(std::string_view statId) {
   if (const UiStatDefinition *definition = uiStatDefinition(statId)) {
     return definition->label;
   }
-  return "Stat";
+  const auto parsed = parseGraphStatId(statId);
+  return parsed ? graphStatLabel(*parsed) : "Stat";
 }
 
-const char *uiStatScopeLabel(const UiStatDefinition &definition) {
-  if (definition.player && definition.team) {
+const char *uiStatScopeLabel(bool player, bool team, bool event) {
+  if (player && team) {
     return "player/team";
   }
-  if (definition.player) {
+  if (player) {
     return "player";
   }
-  if (definition.team) {
+  if (team) {
     return "team";
   }
-  if (definition.event) {
+  if (event) {
     return "event";
   }
   return "stat";
+}
+
+const char *uiStatScopeLabel(const UiStatDefinition &definition) {
+  return uiStatScopeLabel(definition.player, definition.team, definition.event);
+}
+
+const char *uiStatScopeLabel(const UiStatDefinitionCandidate &definition) {
+  return uiStatScopeLabel(definition.player, definition.team, definition.event);
 }
 
 std::optional<std::string_view> coreStatsPlayerField(std::string_view localStatId) {
@@ -1901,7 +2044,9 @@ std::vector<std::string_view> statSearchTokens(std::string_view query) {
 }
 
 std::optional<double> statDefinitionSearchScore(
-    const UiStatDefinition &definition,
+    std::string_view category,
+    std::string_view label,
+    std::string_view id,
     std::string_view query) {
   const std::vector<std::string_view> tokens = statSearchTokens(query);
   if (tokens.empty()) {
@@ -1910,9 +2055,9 @@ std::optional<double> statDefinitionSearchScore(
 
   const std::string searchText = normalizeStatSearchText(std::format(
       "{} {} {}",
-      definition.category,
-      definition.label,
-      definition.id));
+      category,
+      label,
+      id));
   double total = 0.0;
   for (std::string_view token : tokens) {
     const size_t index = searchText.find(token);
@@ -1922,6 +2067,16 @@ std::optional<double> statDefinitionSearchScore(
     total += static_cast<double>(index);
   }
   return total + static_cast<double>(searchText.size()) / 1000.0;
+}
+
+std::optional<double> statDefinitionSearchScore(
+    const UiStatDefinitionCandidate &definition,
+    std::string_view query) {
+  return statDefinitionSearchScore(
+      definition.category,
+      definition.label,
+      definition.id,
+      query);
 }
 
 ImVec4 toImVec4(LinearColor color) {
@@ -9753,17 +9908,23 @@ bool SubtrActorPlugin::statsWindowSupportsStat(
     std::string_view statId) const {
   const std::string localStatId = normalizeUiStatId(statId);
   const UiStatDefinition *definition = localUiStatDefinition(localStatId);
-  if (!definition) {
+  uint8_t definitionScopes = 0;
+  const auto graphStat = parseGraphStatId(localStatId);
+  const bool playerScoped =
+      definition ? definition->player : (graphStat && graphStat->scope == "player");
+  const bool teamScoped =
+      definition ? definition->team : (graphStat && graphStat->scope == "team");
+  const bool eventScoped = definition ? definition->event : false;
+  if (!definition && !graphStat) {
     return false;
   }
-  uint8_t definitionScopes = 0;
-  if (definition->player) {
+  if (playerScoped) {
     definitionScopes |= UI_STAT_SCOPE_PLAYER;
   }
-  if (definition->team) {
+  if (teamScoped) {
     definitionScopes |= UI_STAT_SCOPE_TEAM;
   }
-  if (definition->event) {
+  if (eventScoped) {
     definitionScopes |= UI_STAT_SCOPE_EVENT;
   }
   return (statsWindowKindStatScopes(window.kind) & definitionScopes) != 0;
@@ -9791,8 +9952,12 @@ bool SubtrActorPlugin::statsWindowTargetsEqual(
   if (lhsTargetId == rhsTargetId) {
     return true;
   }
-  const UiStatDefinition *definition = localUiStatDefinition(normalizeUiStatId(statId));
-  if (!definition || !definition->player) {
+  const std::string localStatId = normalizeUiStatId(statId);
+  const UiStatDefinition *definition = localUiStatDefinition(localStatId);
+  const auto graphStat = parseGraphStatId(localStatId);
+  const bool playerScoped =
+      definition ? definition->player : (graphStat && graphStat->scope == "player");
+  if (!playerScoped) {
     return false;
   }
   const std::optional<uint32_t> lhsPlayerIndex = playerIndexForTargetId(lhsTargetId);
@@ -10022,13 +10187,15 @@ std::string SubtrActorPlugin::teamStatValue(uint8_t isTeam0, std::string_view st
 std::string SubtrActorPlugin::defaultAdHocTargetId(std::string_view statId) const {
   const std::string localStatId = normalizeUiStatId(statId);
   const UiStatDefinition *definition = localUiStatDefinition(localStatId);
-  if (!definition) {
-    return "";
-  }
-  if (definition->player) {
+  const auto graphStat = parseGraphStatId(localStatId);
+  const bool playerScoped =
+      definition ? definition->player : (graphStat && graphStat->scope == "player");
+  const bool teamScoped =
+      definition ? definition->team : (graphStat && graphStat->scope == "team");
+  if (playerScoped) {
     return sampledPlayers.empty() ? "" : webPlayerIdForIndex(sampledPlayers.front().player_index);
   }
-  if (definition->team) {
+  if (teamScoped) {
     return "blue";
   }
   return "";
@@ -10039,10 +10206,15 @@ std::string SubtrActorPlugin::adHocStatValue(
     std::string_view targetId) const {
   const std::string localStatId = normalizeUiStatId(statId);
   const UiStatDefinition *definition = localUiStatDefinition(localStatId);
-  if (!definition) {
+  const auto graphStat = parseGraphStatId(localStatId);
+  const bool playerScoped =
+      definition ? definition->player : (graphStat && graphStat->scope == "player");
+  const bool teamScoped =
+      definition ? definition->team : (graphStat && graphStat->scope == "team");
+  if (!definition && !graphStat) {
     return "--";
   }
-  if (definition->player) {
+  if (playerScoped) {
     uint32_t playerIndex = sampledPlayers.empty() ? 0 : sampledPlayers.front().player_index;
     if (const std::optional<uint32_t> resolvedPlayerIndex =
             playerIndexForTargetId(targetId)) {
@@ -10051,7 +10223,7 @@ std::string SubtrActorPlugin::adHocStatValue(
     const SaPlayerFrame *player = sampledPlayerByIndex(playerIndex);
     return player ? playerStatValue(*player, localStatId) : "--";
   }
-  if (definition->team) {
+  if (teamScoped) {
     return teamStatValue(targetId == "orange" ? 0 : 1, localStatId);
   }
   return std::format("{}", recentEventCountForType(localStatId));
@@ -10063,12 +10235,17 @@ void SubtrActorPlugin::renderAdHocTargetSelector(
     std::string_view statId,
     size_t index) {
   const UiStatDefinition *definition = uiStatDefinition(statId);
-  if (!definition || (!definition->player && !definition->team)) {
+  const auto graphStat = parseGraphStatId(normalizeUiStatId(statId));
+  const bool playerScoped =
+      definition ? definition->player : (graphStat && graphStat->scope == "player");
+  const bool teamScoped =
+      definition ? definition->team : (graphStat && graphStat->scope == "team");
+  if (!playerScoped && !teamScoped) {
     ImGui::TextDisabled("-");
     return;
   }
 
-  if (definition->player) {
+  if (playerScoped) {
     const SaPlayerFrame *selected = nullptr;
     if (const std::optional<uint32_t> selectedPlayerIndex =
             playerIndexForTargetId(entry.target_id)) {
@@ -10314,9 +10491,30 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
     }
   }
 
-  std::vector<UiStatDefinitionMatch> matches;
+  std::vector<UiStatDefinitionCandidate> definitions;
+  std::unordered_set<std::string> definitionIds;
   for (size_t index = 0; index < UI_STAT_DEFINITIONS.size(); index += 1) {
     const UiStatDefinition &definition = UI_STAT_DEFINITIONS[index];
+    definitions.push_back(UiStatDefinitionCandidate{
+        definition.id,
+        definition.label,
+        definition.category,
+        definition.player,
+        definition.team,
+        definition.event,
+    });
+    definitionIds.insert(definition.id);
+  }
+  for (UiStatDefinitionCandidate &definition :
+       graphStatDefinitionsFromStatsJson(currentStatsJson())) {
+    if (definitionIds.insert(definition.id).second) {
+      definitions.push_back(std::move(definition));
+    }
+  }
+
+  std::vector<UiStatDefinitionMatch> matches;
+  for (size_t index = 0; index < definitions.size(); index += 1) {
+    const UiStatDefinitionCandidate &definition = definitions[index];
     if (!statsWindowSupportsStat(window, definition.id)) {
       continue;
     }
@@ -10324,20 +10522,20 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
     if (!score) {
       continue;
     }
-    matches.push_back(UiStatDefinitionMatch{&definition, *score, index});
+    matches.push_back(UiStatDefinitionMatch{definition, *score, index});
   }
   std::sort(matches.begin(), matches.end(), [](const auto &left, const auto &right) {
     return left.score == right.score ? left.index < right.index : left.score < right.score;
   });
 
-  std::vector<std::pair<std::string_view, int>> categoryCounts;
+  std::vector<std::pair<std::string, int>> categoryCounts;
   for (const UiStatDefinitionMatch &match : matches) {
     auto found = std::find_if(
         categoryCounts.begin(),
         categoryCounts.end(),
-        [&](const auto &entry) { return entry.first == match.definition->category; });
+        [&](const auto &entry) { return entry.first == match.definition.category; });
     if (found == categoryCounts.end()) {
-      categoryCounts.emplace_back(match.definition->category, 1);
+      categoryCounts.emplace_back(match.definition.category, 1);
     } else {
       found->second += 1;
     }
@@ -10351,14 +10549,14 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
         std::format("Add all {} ({})##{}-{}", category, count, window.id, category);
     if (ImGui::SmallButton(label.c_str())) {
       for (const UiStatDefinitionMatch &match : matches) {
-        if (category != match.definition->category) {
+        if (category != match.definition.category) {
           continue;
         }
         const std::string targetId =
-            window.kind == UiStatsWindowKind::AdHoc ? defaultAdHocTargetId(match.definition->id)
+            window.kind == UiStatsWindowKind::AdHoc ? defaultAdHocTargetId(match.definition.id)
                                                     : "";
-        if (!statsWindowHasStat(window, match.definition->id, targetId)) {
-          window.entries.push_back(UiStatsWindow::Entry{match.definition->id, targetId});
+        if (!statsWindowHasStat(window, match.definition.id, targetId)) {
+          window.entries.push_back(UiStatsWindow::Entry{match.definition.id, targetId});
         }
       }
     }
@@ -10372,7 +10570,7 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   }
 
   for (const UiStatDefinitionMatch &match : matches) {
-    const UiStatDefinition &definition = *match.definition;
+    const UiStatDefinitionCandidate &definition = match.definition;
     const bool alreadySelected = statsWindowHasStat(window, definition.id);
     const std::string itemLabel = std::format(
         "{}  [{}]##{}-{}",
@@ -10381,7 +10579,10 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
         window.id,
         definition.id);
     if (alreadySelected && window.kind != UiStatsWindowKind::AdHoc) {
-      ImGui::TextDisabled("%s  [%s selected]", definition.label, uiStatScopeLabel(definition));
+      ImGui::TextDisabled(
+          "%s  [%s selected]",
+          definition.label.c_str(),
+          uiStatScopeLabel(definition));
       continue;
     }
     if (ImGui::Selectable(itemLabel.c_str(), alreadySelected)) {
@@ -10456,7 +10657,8 @@ void SubtrActorPlugin::renderPlayerStatsTable(
       ++i;
       continue;
     }
-    ImGui::Text("%s", uiStatLabel(statId));
+    const std::string statLabel = uiStatLabel(statId);
+    ImGui::Text("%s", statLabel.c_str());
     ImGui::NextColumn();
     ImGui::Text("%s", playerStatValue(player, statId).c_str());
     ImGui::NextColumn();
@@ -10485,7 +10687,8 @@ void SubtrActorPlugin::renderTeamStatsTable(UiStatsWindow &window, uint8_t isTea
       ++i;
       continue;
     }
-    ImGui::Text("%s", uiStatLabel(statId));
+    const std::string statLabel = uiStatLabel(statId);
+    ImGui::Text("%s", statLabel.c_str());
     ImGui::NextColumn();
     ImGui::Text("%s", teamStatValue(isTeam0, statId).c_str());
     ImGui::NextColumn();
@@ -10541,7 +10744,8 @@ void SubtrActorPlugin::renderAllPlayersStatsTable(UiStatsWindow &window) {
             ++i;
             continue;
           }
-          ImGui::Text("%s", uiStatLabel(statId));
+          const std::string statLabel = uiStatLabel(statId);
+          ImGui::Text("%s", statLabel.c_str());
           ImGui::NextColumn();
           ImGui::Text("%s", playerStatValue(player, statId).c_str());
           ImGui::NextColumn();
@@ -10586,7 +10790,8 @@ void SubtrActorPlugin::renderAllTeamsStatsTable(UiStatsWindow &window) {
         ++i;
         continue;
       }
-      ImGui::Text("%s", uiStatLabel(statId));
+      const std::string statLabel = uiStatLabel(statId);
+      ImGui::Text("%s", statLabel.c_str());
       ImGui::NextColumn();
       ImGui::Text("%s", teamStatValue(isTeam0, statId).c_str());
       ImGui::NextColumn();
@@ -10696,7 +10901,8 @@ void SubtrActorPlugin::renderAdHocStatsWindow(UiStatsWindow &window) {
       ++i;
       continue;
     }
-    ImGui::Text("%s", uiStatLabel(statId));
+    const std::string statLabel = uiStatLabel(statId);
+    ImGui::Text("%s", statLabel.c_str());
     ImGui::NextColumn();
     renderAdHocTargetSelector(window, entry, statId, i);
     ImGui::NextColumn();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -2637,18 +2637,15 @@ void SubtrActorPlugin::applyUiConfigJson(
     out.z_index = static_cast<int>(parseJsonNumberProperty(object, "zIndex").value_or(out.z_index));
     nextUiWindowZIndex = std::max(nextUiWindowZIndex, out.z_index + 1);
   };
-  auto loadPlacement = [&loadPlacementObject](
-                           const std::string &parent,
-                           const char *name,
-                           UiWindowPlacement &out,
-                           bool *visible = nullptr) {
-    const auto object = parseJsonObjectProperty(parent, name);
-    if (!object) {
-      return;
-    }
-    loadPlacementObject(*object, out, visible);
-  };
-
+  auto applyDefaultPlacementSize =
+      [](const std::string &object, UiWindowPlacement &out, float width, float height) {
+        if (!parseJsonNumberProperty(object, "width") || out.width <= 0.0f) {
+          out.width = width;
+        }
+        if (!parseJsonNumberProperty(object, "height") || out.height <= 0.0f) {
+          out.height = height;
+        }
+      };
   for (const SingletonWindowControl &window : singletonWindowControls()) {
     *window.open =
         parseJsonBoolProperty(json, window.legacy_open_key).value_or(*window.open);
@@ -3035,7 +3032,12 @@ void SubtrActorPlugin::applyUiConfigJson(
 
   if (const auto placements = parseJsonObjectProperty(json, "placements")) {
     for (const SingletonWindowControl &window : singletonWindowControls()) {
-      loadPlacement(*placements, window.legacy_placement_key, *window.placement, window.open);
+      const auto object = parseJsonObjectProperty(*placements, window.legacy_placement_key);
+      if (!object) {
+        continue;
+      }
+      loadPlacementObject(*object, *window.placement, window.open);
+      applyDefaultPlacementSize(*object, *window.placement, window.width, window.height);
     }
   }
   auto loadWindowArray = [&](const char *propertyName, bool webConfig) {
@@ -3050,6 +3052,7 @@ void SubtrActorPlugin::applyUiConfigJson(
           continue;
         }
         loadPlacementObject(*placement, *window.placement, window.open);
+        applyDefaultPlacementSize(*placement, *window.placement, window.width, window.height);
         break;
       }
     }
@@ -3183,6 +3186,13 @@ void SubtrActorPlugin::applyUiConfigJson(
         parseJsonNumberProperty(object, "viewport_height").value_or(window.viewport_height));
     window.z_index =
         static_cast<int>(parseJsonNumberProperty(object, "zIndex").value_or(window.z_index));
+    const auto [defaultWidth, defaultHeight] = defaultStatsWindowSize(window.kind);
+    if (window.width <= 0.0f) {
+      window.width = defaultWidth;
+    }
+    if (window.height <= 0.0f) {
+      window.height = defaultHeight;
+    }
     nextUiWindowZIndex = std::max(nextUiWindowZIndex, window.z_index + 1);
     uiStatsWindows.push_back(std::move(window));
   }
@@ -6510,9 +6520,10 @@ void SubtrActorPlugin::applyStatsWindowPlacement(UiStatsWindow &window) {
   if (window.has_placement) {
     const ImGuiCond condition =
         window.pending_apply_placement ? ImGuiCond_Always : ImGuiCond_FirstUseEver;
+    const auto [defaultWidth, defaultHeight] = defaultStatsWindowSize(window.kind);
     const ImVec2 size{
-        std::max(180.0f, window.width),
-        std::max(120.0f, window.height),
+        std::max(180.0f, window.width > 0.0f ? window.width : defaultWidth),
+        std::max(120.0f, window.height > 0.0f ? window.height : defaultHeight),
     };
     const ImVec2 position = mapWindowPositionToViewport(
         window.x,
@@ -6531,8 +6542,7 @@ void SubtrActorPlugin::applyStatsWindowPlacement(UiStatsWindow &window) {
     return;
   }
   const float offset = static_cast<float>((window.id - 1) * 24);
-  const float width = window.kind == UiStatsWindowKind::StatsModule ? 680.0f : 540.0f;
-  const float height = window.kind == UiStatsWindowKind::StatsModule ? 460.0f : 330.0f;
+  const auto [width, height] = defaultStatsWindowSize(window.kind);
   ImGui::SetNextWindowPos(
       mapWindowPositionToViewport(96.0f + offset, 96.0f + offset, width, height, 0.0f, 0.0f),
       ImGuiCond_FirstUseEver);
@@ -9297,15 +9307,22 @@ void SubtrActorPlugin::createStatsModuleWindow(std::string moduleName, int modul
   uiStatsWindows.push_back(std::move(window));
 }
 
+std::pair<float, float> SubtrActorPlugin::defaultStatsWindowSize(UiStatsWindowKind kind) const {
+  if (kind == UiStatsWindowKind::StatsModule) {
+    return {680.0f, 460.0f};
+  }
+  return {540.0f, 330.0f};
+}
+
 void SubtrActorPlugin::initializeStatsWindowPlacement(UiStatsWindow &window) {
   resetStatsWindowPlacement(window, uiStatsWindows.size());
 }
 
 void SubtrActorPlugin::resetStatsWindowPlacement(UiStatsWindow &window, size_t stackIndex) {
   const float offset = static_cast<float>(stackIndex * 18);
-  const bool isModuleWindow = window.kind == UiStatsWindowKind::StatsModule;
-  window.width = isModuleWindow ? 680.0f : 540.0f;
-  window.height = isModuleWindow ? 460.0f : 330.0f;
+  const auto [width, height] = defaultStatsWindowSize(window.kind);
+  window.width = width;
+  window.height = height;
   const ImVec2 position = mapWindowPositionToViewport(
       96.0f + offset,
       96.0f + offset,

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7411,6 +7411,32 @@ void SubtrActorPlugin::renderLauncherWorkspaceControls() {
   }
 }
 
+void SubtrActorPlugin::renderLauncherStatsWindowControls() {
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STATS WINDOWS");
+  for (const StatsWindowKindControl &kind : statsWindowKindControls()) {
+    if (!kind.web_config) {
+      continue;
+    }
+    if (ImGui::Button(kind.create_label, ImVec2{170.0f, 0.0f})) {
+      createStatsWindow(kind.kind);
+      uiLauncherOpen = false;
+    }
+  }
+  if (uiStatsWindows.empty()) {
+    return;
+  }
+
+  const size_t visibleStatsWindows = static_cast<size_t>(std::count_if(
+      uiStatsWindows.begin(),
+      uiStatsWindows.end(),
+      [](const UiStatsWindow &window) { return window.open; }));
+  ImGui::Text(
+      "%zu visible / %zu stats windows",
+      visibleStatsWindows,
+      uiStatsWindows.size());
+  renderStatsWindowManager();
+}
+
 void SubtrActorPlugin::renderLauncherWindow() {
   if (!uiLauncherOpen) {
     return;
@@ -7462,34 +7488,12 @@ void SubtrActorPlugin::renderLauncherWindow() {
     }
     ImGui::PopID();
   };
-  auto renderStatsWindowCreateButton = [&](const char *label, UiStatsWindowKind kind) {
-    if (ImGui::Button(label, ImVec2{170.0f, 0.0f})) {
-      createStatsWindow(kind);
-      uiLauncherOpen = false;
-    }
-  };
-
   for (const SingletonWindowControl &window : webSingletonWindowControls()) {
     renderLauncherWindowToggle(window);
   }
-  for (const StatsWindowKindControl &kind : statsWindowKindControls()) {
-    if (kind.web_config) {
-      renderStatsWindowCreateButton(kind.create_label, kind.kind);
-    }
-  }
-  if (!uiStatsWindows.empty()) {
-    const size_t visibleStatsWindows = static_cast<size_t>(std::count_if(
-        uiStatsWindows.begin(),
-        uiStatsWindows.end(),
-        [](const UiStatsWindow &window) { return window.open; }));
-    ImGui::Separator();
-    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STATS WINDOWS");
-    ImGui::Text(
-        "%zu visible / %zu stats windows",
-        visibleStatsWindows,
-        uiStatsWindows.size());
-    renderStatsWindowManager();
-  }
+
+  ImGui::Separator();
+  renderLauncherStatsWindowControls();
 
   ImGui::Separator();
   renderLauncherWorkspaceControls();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3675,11 +3675,13 @@ void SubtrActorPlugin::applyUiConfigJson(
 
   uiStatsWindows.clear();
   nextUiStatsWindowId = 1;
-  std::vector<std::string> statsWindowObjects =
-      parseJsonObjectArrayProperty(json, "stats_windows");
-  if (statsWindowObjects.empty()) {
-    statsWindowObjects = parseJsonObjectArrayProperty(json, "statsWindows");
-  }
+  const bool hasLegacyStatsWindows = jsonPropertyExists(json, "stats_windows");
+  const bool hasWebStatsWindows = jsonPropertyExists(json, "statsWindows");
+  const std::vector<std::string> statsWindowObjects =
+      hasLegacyStatsWindows
+          ? parseJsonObjectArrayProperty(json, "stats_windows")
+          : hasWebStatsWindows ? parseJsonObjectArrayProperty(json, "statsWindows")
+                               : std::vector<std::string>{};
   for (const std::string &object : statsWindowObjects) {
     const auto kind = parseJsonStringProperty(object, "kind");
     if (!kind) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7380,9 +7380,10 @@ void SubtrActorPlugin::renderCvarModuleSummaryToggle(
     const char *label,
     const char *name,
     bool defaultValue,
-    const char *idSuffix) {
+    const char *idSuffix,
+    float width) {
   const bool active = cvarBool(name, defaultValue);
-  if (renderModuleSummaryToggle(label, active, idSuffix)) {
+  if (renderModuleSummaryToggle(label, active, idSuffix, width)) {
     setCvarBool(name, !active);
   }
 }
@@ -7390,8 +7391,9 @@ void SubtrActorPlugin::renderCvarModuleSummaryToggle(
 void SubtrActorPlugin::renderBoolModuleSummaryToggle(
     const char *label,
     bool &active,
-    const char *idSuffix) {
-  if (renderModuleSummaryToggle(label, active, idSuffix)) {
+    const char *idSuffix,
+    float width) {
+  if (renderModuleSummaryToggle(label, active, idSuffix, width)) {
     active = !active;
     scheduleUiConfigAutosave();
   }
@@ -7400,13 +7402,14 @@ void SubtrActorPlugin::renderBoolModuleSummaryToggle(
 void SubtrActorPlugin::renderEventFilterModuleSummaryToggle(
     const char *label,
     const char *token,
-    const char *idSuffix) {
+    const char *idSuffix,
+    float width) {
   std::vector<std::string> selected =
       selectedEventSourceTokens(cvarString("subtr_actor_overlay_event_types", "all"));
   const bool active =
       eventPlaylistMechanicsEnabled &&
       (containsString(selected, "mechanics") || containsString(selected, token));
-  if (!renderModuleSummaryToggle(label, active, idSuffix)) {
+  if (!renderModuleSummaryToggle(label, active, idSuffix, width)) {
     return;
   }
 
@@ -7432,44 +7435,59 @@ void SubtrActorPlugin::renderEventFilterModuleSummaryToggle(
   setCvarString("subtr_actor_overlay_event_types", eventFilterFromSelectedSources(selected));
 }
 
-void SubtrActorPlugin::renderModuleSummaryControls(const char *idSuffix, bool collapsibleGroups) {
+void SubtrActorPlugin::renderModuleSummaryControls(
+    const char *idSuffix,
+    bool collapsibleGroups,
+    float toggleWidth) {
   auto renderTimelineControls = [&]() {
-    renderEventFilterModuleSummaryToggle("Touch", "touch", idSuffix);
-    renderEventFilterModuleSummaryToggle("Dodge refresh", "dodge_reset", idSuffix);
-    renderEventFilterModuleSummaryToggle("Backboard", "backboard", idSuffix);
-    renderEventFilterModuleSummaryToggle("Speed flip", "speed_flip", idSuffix);
-    renderEventFilterModuleSummaryToggle("Half flip", "half_flip", idSuffix);
-    renderEventFilterModuleSummaryToggle("Powerslide", "powerslide", idSuffix);
-    renderEventFilterModuleSummaryToggle("Wavedash", "wavedash", idSuffix);
-    renderEventFilterModuleSummaryToggle("Ball carry", "ball_carry", idSuffix);
-    renderEventFilterModuleSummaryToggle("Ceiling shot", "ceiling_shot", idSuffix);
-    renderEventFilterModuleSummaryToggle("Flip reset", "flip_reset", idSuffix);
-    renderEventFilterModuleSummaryToggle("Double tap", "double_tap", idSuffix);
-    renderEventFilterModuleSummaryToggle("50/50", "fifty_fifty", idSuffix);
-    renderEventFilterModuleSummaryToggle("Musty flick", "musty_flick", idSuffix);
-    renderEventFilterModuleSummaryToggle("Whiff", "whiff", idSuffix);
-    renderEventFilterModuleSummaryToggle("Bump", "bump", idSuffix);
-    renderEventFilterModuleSummaryToggle("Demo", "demo", idSuffix);
-    renderBoolModuleSummaryToggle("Team event playlist", eventPlaylistTeamEventsEnabled, idSuffix);
+    renderEventFilterModuleSummaryToggle("Touch", "touch", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Dodge refresh", "dodge_reset", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Backboard", "backboard", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Speed flip", "speed_flip", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Half flip", "half_flip", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Powerslide", "powerslide", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Wavedash", "wavedash", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Ball carry", "ball_carry", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Ceiling shot", "ceiling_shot", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Flip reset", "flip_reset", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Double tap", "double_tap", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("50/50", "fifty_fifty", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Musty flick", "musty_flick", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Whiff", "whiff", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Bump", "bump", idSuffix, toggleWidth);
+    renderEventFilterModuleSummaryToggle("Demo", "demo", idSuffix, toggleWidth);
+    renderBoolModuleSummaryToggle(
+        "Team event playlist",
+        eventPlaylistTeamEventsEnabled,
+        idSuffix,
+        toggleWidth);
     renderBoolModuleSummaryToggle(
         "Goal context playlist",
         eventPlaylistGoalContextEnabled,
-        idSuffix);
-    renderBoolModuleSummaryToggle("Boost pickup timeline", timelineRangeBoostEnabled, idSuffix);
+        idSuffix,
+        toggleWidth);
+    renderBoolModuleSummaryToggle(
+        "Boost pickup timeline",
+        timelineRangeBoostEnabled,
+        idSuffix,
+        toggleWidth);
     renderBoolModuleSummaryToggle(
         "Possession timeline",
         timelineRangePossessionEnabled,
-        idSuffix);
+        idSuffix,
+        toggleWidth);
     renderBoolModuleSummaryToggle(
         "Half control timeline",
         timelineRangePressureEnabled,
-        idSuffix);
-    renderBoolModuleSummaryToggle("Rush timeline", timelineRangeRushEnabled, idSuffix);
+        idSuffix,
+        toggleWidth);
+    renderBoolModuleSummaryToggle("Rush timeline", timelineRangeRushEnabled, idSuffix, toggleWidth);
     renderBoolModuleSummaryToggle(
         "Position zones timeline",
         timelineRangeAbsolutePositioningEnabled,
-        idSuffix);
-    renderBoolModuleSummaryToggle("Playlist follow", eventPlaylistAutoFollow, idSuffix);
+        idSuffix,
+        toggleWidth);
+    renderBoolModuleSummaryToggle("Playlist follow", eventPlaylistAutoFollow, idSuffix, toggleWidth);
   };
 
   auto renderInGameControls = [&]() {
@@ -7477,39 +7495,61 @@ void SubtrActorPlugin::renderModuleSummaryControls(const char *idSuffix, bool co
         "Canvas status line",
         "subtr_actor_status_overlay_enabled",
         true,
-        idSuffix);
+        idSuffix,
+        toggleWidth);
     renderCvarModuleSummaryToggle(
         "HUD mechanics",
         "subtr_actor_overlay_mechanics_enabled",
         true,
-        idSuffix);
+        idSuffix,
+        toggleWidth);
     renderCvarModuleSummaryToggle(
         "HUD team events",
         "subtr_actor_overlay_team_events_enabled",
         true,
-        idSuffix);
+        idSuffix,
+        toggleWidth);
     renderCvarModuleSummaryToggle(
         "HUD goal context",
         "subtr_actor_overlay_goal_context_enabled",
         true,
-        idSuffix);
-    renderBoolModuleSummaryToggle("Ceiling shot labels", renderEffectCeilingShotEnabled, idSuffix);
-    renderBoolModuleSummaryToggle("50/50 labels", renderEffectFiftyFiftyEnabled, idSuffix);
-    renderBoolModuleSummaryToggle("Half control", renderEffectPressureEnabled, idSuffix);
-    renderBoolModuleSummaryToggle("Player roles", renderEffectRelativePositioningEnabled, idSuffix);
+        idSuffix,
+        toggleWidth);
+    renderBoolModuleSummaryToggle(
+        "Ceiling shot labels",
+        renderEffectCeilingShotEnabled,
+        idSuffix,
+        toggleWidth);
+    renderBoolModuleSummaryToggle(
+        "50/50 labels",
+        renderEffectFiftyFiftyEnabled,
+        idSuffix,
+        toggleWidth);
+    renderBoolModuleSummaryToggle("Half control", renderEffectPressureEnabled, idSuffix, toggleWidth);
+    renderBoolModuleSummaryToggle(
+        "Player roles",
+        renderEffectRelativePositioningEnabled,
+        idSuffix,
+        toggleWidth);
     renderBoolModuleSummaryToggle(
         "Position zones",
         renderEffectAbsolutePositioningEnabled,
-        idSuffix);
-    renderBoolModuleSummaryToggle("Speed flip labels", renderEffectSpeedFlipEnabled, idSuffix);
-    renderBoolModuleSummaryToggle("Touch labels", renderEffectTouchEnabled, idSuffix);
+        idSuffix,
+        toggleWidth);
+    renderBoolModuleSummaryToggle(
+        "Speed flip labels",
+        renderEffectSpeedFlipEnabled,
+        idSuffix,
+        toggleWidth);
+    renderBoolModuleSummaryToggle("Touch labels", renderEffectTouchEnabled, idSuffix, toggleWidth);
     renderBoolModuleSummaryToggle(
         "Boost pickup animation",
         boostPickupAnimationEnabled,
-        idSuffix);
+        idSuffix,
+        toggleWidth);
     const bool boostPadsEnabled =
         boostPickupPadBig || boostPickupPadSmall || boostPickupPadAmbiguous;
-    if (renderModuleSummaryToggle("Boost pad locations", boostPadsEnabled, idSuffix)) {
+    if (renderModuleSummaryToggle("Boost pad locations", boostPadsEnabled, idSuffix, toggleWidth)) {
       const bool next = !boostPadsEnabled;
       boostPickupPadBig = next;
       boostPickupPadSmall = next;
@@ -7839,7 +7879,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);
 
   ImGui::Separator();
-  renderModuleSummaryControls("launcher-module-summary", false);
+  renderModuleSummaryControls("launcher-module-summary", false, 0.0f);
 
   ImGui::Separator();
   renderModuleSettingsControls("launcher-module-settings", false, true);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9511,9 +9511,15 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
       const std::string playerId = webPlayerIdForIndex(player.player_index);
       bool selected =
           !boostPickupPlayerFilterEnabled || containsString(boostPickupPlayerIds, playerId);
+      const auto playerName = playerNamesByIndex.find(player.player_index);
+      const std::string displayName =
+          playerName != playerNamesByIndex.end() && !playerName->second.empty()
+              ? playerName->second
+              : std::format("Player {}", player.player_index + 1);
       const std::string label = std::format(
-          "{}##boost-pickup-player-{}",
-          playerLabel(player.player_index, player.is_team_0),
+          "{} ({})##boost-pickup-player-{}",
+          displayName,
+          teamLabel(player.is_team_0),
           player.player_index);
       if (ImGui::Checkbox(label.c_str(), &selected)) {
         if (!boostPickupPlayerFilterEnabled) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9050,7 +9050,11 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
       current == nullptr ? 0.0f : std::max(0.0f, current->time - mechanicsReviewClipLeadSeconds);
   const float clipEnd = current == nullptr ? 0.0f : current->time + mechanicsReviewClipTrailSeconds;
   ImGui::Text("%d / %zu", current == nullptr ? 0 : mechanicsReviewIndex + 1, candidates.size());
-  ImGui::TextWrapped("%s", current == nullptr ? "No candidate selected" : current->label.c_str());
+  const std::string currentTitle =
+      current == nullptr ? "No candidate selected"
+      : current->label.empty() ? eventTypeDisplayLabel(current->type)
+                               : current->label;
+  ImGui::TextWrapped("%s", currentTitle.c_str());
   const std::string statusReadout =
       mechanicsReviewClipActive
           ? std::format(
@@ -9173,7 +9177,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     const UiEventRecord &event = recentUiEvents[candidates[i]];
     ImGui::PushID(static_cast<int>(i));
     const bool active = i == static_cast<size_t>(mechanicsReviewIndex);
-    const std::string title = event.label.empty() ? event.type : event.label;
+    const std::string title = event.label.empty() ? eventTypeDisplayLabel(event.type) : event.label;
     const std::string label = std::format(
         "{}  {}##mechanics-review-item",
         formatEventPlaylistTime(event.time),

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7693,19 +7693,23 @@ void SubtrActorPlugin::renderLauncherWorkspaceControls() {
 
 void SubtrActorPlugin::renderWebWindowToggleControls(
     const char *idSuffix,
-    bool closeLauncherOnToggle) {
+    bool closeLauncherOnToggle,
+    bool includeState,
+    bool fullWidth) {
   ImGui::PushID(idSuffix);
   for (const SingletonWindowControl &window : webSingletonWindowControls()) {
     ImGui::PushID(window.label);
     const bool isOpen = window.open != nullptr && *window.open;
-    if (isOpen) {
+    if (includeState && isOpen) {
       ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.16f, 0.35f, 0.28f, 1.0f});
       ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
       ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.25f, 0.55f, 0.43f, 1.0f});
     }
-    const std::string buttonLabel =
-        std::format("{}   {}", window.label, isOpen ? "Hide" : "Show");
-    if (ImGui::Button(buttonLabel.c_str(), ImVec2{210.0f, 0.0f})) {
+    const std::string buttonLabel = includeState
+                                        ? std::format("{}   {}", window.label, isOpen ? "Hide" : "Show")
+                                        : std::string{window.label};
+    const float buttonWidth = fullWidth ? ImGui::GetContentRegionAvail().x : 210.0f;
+    if (ImGui::Button(buttonLabel.c_str(), ImVec2{buttonWidth, 0.0f})) {
       if (*window.open) {
         hideSingletonWindow(*window.open);
       } else {
@@ -7715,7 +7719,7 @@ void SubtrActorPlugin::renderWebWindowToggleControls(
         hideLauncherWindow();
       }
     }
-    if (isOpen) {
+    if (includeState && isOpen) {
       ImGui::PopStyleColor(3);
     }
     ImGui::PopID();
@@ -7727,7 +7731,8 @@ void SubtrActorPlugin::renderStatsWindowCreationControls(
     const char *idSuffix,
     bool closeLauncherOnCreate,
     bool includeHeading,
-    bool includeManager) {
+    bool includeManager,
+    bool fullWidth) {
   ImGui::PushID(idSuffix);
   if (includeHeading) {
     ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STATS WINDOWS");
@@ -7736,7 +7741,8 @@ void SubtrActorPlugin::renderStatsWindowCreationControls(
     if (!kind.web_config) {
       continue;
     }
-    if (ImGui::Button(kind.create_label, ImVec2{170.0f, 0.0f})) {
+    const float buttonWidth = fullWidth ? ImGui::GetContentRegionAvail().x : 170.0f;
+    if (ImGui::Button(kind.create_label, ImVec2{buttonWidth, 0.0f})) {
       createStatsWindow(kind.kind);
       if (closeLauncherOnCreate) {
         hideLauncherWindow();
@@ -7799,8 +7805,8 @@ void SubtrActorPlugin::renderLauncherWindow() {
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
-  renderWebWindowToggleControls("launcher-web-windows", true);
-  renderStatsWindowCreationControls("launcher-stats-windows", false, false, false);
+  renderWebWindowToggleControls("launcher-web-windows", true, false, true);
+  renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);
 
   ImGui::Separator();
   renderLauncherWorkspaceControls();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -6718,30 +6718,62 @@ void SubtrActorPlugin::Render() {
   }
 
   renderEmptyStateWindow();
-  renderSingletonWindows();
-  renderStatsWindows();
+  renderFloatingWindowLayer();
   maybeAutosaveUiConfig();
 }
 
-void SubtrActorPlugin::renderSingletonWindows() {
-  std::vector<SingletonWindowControl> renderOrder;
+void SubtrActorPlugin::renderFloatingWindowLayer() {
+  enum class RenderEntryKind {
+    Singleton,
+    Stats,
+  };
+  struct RenderEntry {
+    RenderEntryKind kind;
+    std::string_view singleton_id;
+    size_t stats_index = 0;
+    int z_index = 0;
+    int fallback_order = 0;
+  };
+
+  std::vector<RenderEntry> renderOrder;
   for (const SingletonWindowControl &window : singletonWindowControls()) {
     if (*window.open) {
-      renderOrder.push_back(window);
+      renderOrder.push_back(RenderEntry{
+          RenderEntryKind::Singleton,
+          std::string_view{window.config_id},
+          0,
+          window.placement->z_index,
+          window.launcher_order});
+    }
+  }
+  for (size_t index = 0; index < uiStatsWindows.size(); index += 1) {
+    const UiStatsWindow &window = uiStatsWindows[index];
+    if (window.open) {
+      renderOrder.push_back(RenderEntry{
+          RenderEntryKind::Stats,
+          {},
+          index,
+          window.z_index,
+          static_cast<int>(1000 + index)});
     }
   }
   std::stable_sort(
       renderOrder.begin(),
       renderOrder.end(),
-      [](const SingletonWindowControl &left, const SingletonWindowControl &right) {
-        if (left.placement->z_index != right.placement->z_index) {
-          return left.placement->z_index < right.placement->z_index;
+      [](const RenderEntry &left, const RenderEntry &right) {
+        if (left.z_index != right.z_index) {
+          return left.z_index < right.z_index;
         }
-        return left.launcher_order < right.launcher_order;
+        return left.fallback_order < right.fallback_order;
       });
 
-  for (const SingletonWindowControl &window : renderOrder) {
-    const std::string_view id{window.config_id};
+  for (const RenderEntry &entry : renderOrder) {
+    if (entry.kind == RenderEntryKind::Stats) {
+      renderStatsWindow(uiStatsWindows[entry.stats_index], entry.stats_index);
+      continue;
+    }
+
+    const std::string_view id = entry.singleton_id;
     if (id == "scoreboard") {
       renderScoreboardWindow();
     } else if (id == "mechanics") {
@@ -10181,24 +10213,6 @@ void SubtrActorPlugin::resetStatsWindowPlacement(UiStatsWindow &window, size_t s
   window.pending_apply_placement = true;
   window.pending_focus = window.open;
   window.z_index = nextUiWindowZIndex++;
-}
-
-void SubtrActorPlugin::renderStatsWindows() {
-  std::vector<size_t> renderOrder;
-  renderOrder.reserve(uiStatsWindows.size());
-  for (size_t index = 0; index < uiStatsWindows.size(); index += 1) {
-    renderOrder.push_back(index);
-  }
-  std::stable_sort(renderOrder.begin(), renderOrder.end(), [&](size_t left, size_t right) {
-    return uiStatsWindows[left].z_index < uiStatsWindows[right].z_index;
-  });
-
-  for (const size_t index : renderOrder) {
-    UiStatsWindow &window = uiStatsWindows[index];
-    if (window.open) {
-      renderStatsWindow(window, index);
-    }
-  }
 }
 
 std::array<SubtrActorPlugin::StatsWindowKindControl, 7>

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7968,14 +7968,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
     tickReplayAnnotations();
     hideLauncherWindow();
   }
-  const bool liveAnalysis = liveProcessingEnabled();
-  if (renderModuleSummaryToggle(
-          "Live analysis graph",
-          liveAnalysis,
-          "launcher-actions",
-          actionButtonWidth)) {
-    setCvarBool("subtr_actor_enabled", !liveAnalysis);
-  }
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
@@ -7990,6 +7982,14 @@ void SubtrActorPlugin::renderLauncherWindow() {
 
   if (ImGui::TreeNode("Plugin tools##launcher-plugin-tools")) {
     const float pluginToolButtonWidth = ImGui::GetContentRegionAvail().x;
+    const bool liveAnalysis = liveProcessingEnabled();
+    if (renderModuleSummaryToggle(
+            "Live analysis graph",
+            liveAnalysis,
+            "launcher-plugin-tools",
+            pluginToolButtonWidth)) {
+      setCvarBool("subtr_actor_enabled", !liveAnalysis);
+    }
     if (ImGui::Button("Verify graph", ImVec2{pluginToolButtonWidth, 0.0f})) {
       showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
       verifyGraphRuntime({"subtr_actor_verify_graph"});

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -6858,10 +6858,22 @@ void SubtrActorPlugin::renderLauncherWindow() {
     }
   };
 
+  std::vector<SingletonWindowControl> launcherWindows;
   for (const SingletonWindowControl &window : singletonWindowControls()) {
     if (window.web_config) {
-      renderLauncherWindowToggle(window);
+      launcherWindows.push_back(window);
     }
+  }
+  std::sort(
+      launcherWindows.begin(),
+      launcherWindows.end(),
+      [](const SingletonWindowControl &left, const SingletonWindowControl &right) {
+        return left.launcher_order == right.launcher_order
+                   ? std::string_view{left.config_id} < std::string_view{right.config_id}
+                   : left.launcher_order < right.launcher_order;
+      });
+  for (const SingletonWindowControl &window : launcherWindows) {
+    renderLauncherWindowToggle(window);
   }
   for (const StatsWindowKindControl &kind : statsWindowKindControls()) {
     if (kind.web_config) {
@@ -8842,6 +8854,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "scoreboard_open",
        "scoreboard",
        true,
+       1,
        &uiScoreboardOpen,
        &scoreboardPlacement,
        0.0f,
@@ -8853,6 +8866,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "events_open",
        "events",
        true,
+       4,
        &uiEventsOpen,
        &eventsPlacement,
        16.0f,
@@ -8864,6 +8878,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "event_playlist_open",
        "event_playlist",
        true,
+       5,
        &uiEventPlaylistOpen,
        &eventPlaylistPlacement,
        eventPlaylistX,
@@ -8875,6 +8890,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "status_open",
        "status",
        false,
+       100,
        &uiStatusOpen,
        &statusPlacement,
        statusX,
@@ -8886,6 +8902,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "camera_open",
        "camera",
        true,
+       0,
        &uiCameraOpen,
        &cameraPlacement,
        16.0f,
@@ -8897,6 +8914,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "playback_controls_open",
        "playback_controls",
        true,
+       2,
        &uiPlaybackControlsOpen,
        &playbackControlsPlacement,
        playbackX,
@@ -8908,6 +8926,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "recording_open",
        "recording",
        true,
+       3,
        &uiRecordingOpen,
        &recordingPlacement,
        recordingX,
@@ -8919,6 +8938,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "graph_inspector_open",
        "graph_inspector",
        false,
+       101,
        &uiGraphInspectorOpen,
        &graphInspectorPlacement,
        360.0f,
@@ -8930,6 +8950,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "mechanics_review_open",
        "mechanics_review",
        true,
+       6,
        &uiMechanicsReviewOpen,
        &mechanicsReviewPlacement,
        mechanicsReviewX,
@@ -8941,6 +8962,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "replay_loading_open",
        "replay_loading",
        true,
+       7,
        &uiReplayLoadingOpen,
        &replayLoadingPlacement,
        replayLoadingX,
@@ -8952,6 +8974,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "module_controls_open",
        "module_controls",
        false,
+       102,
        &uiModuleControlsOpen,
        &moduleControlsPlacement,
        moduleControlsX,
@@ -8963,6 +8986,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "touch_controls_open",
        "touch_controls",
        true,
+       9,
        &uiTouchControlsOpen,
        &touchControlsPlacement,
        touchControlsX,
@@ -8974,6 +8998,7 @@ SubtrActorPlugin::singletonWindowControls() {
        "boost_pickup_controls_open",
        "boost_pickup_controls",
        true,
+       8,
        &uiBoostPickupControlsOpen,
        &boostPickupControlsPlacement,
        16.0f,

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7432,10 +7432,8 @@ void SubtrActorPlugin::renderEventFilterModuleSummaryToggle(
   setCvarString("subtr_actor_overlay_event_types", eventFilterFromSelectedSources(selected));
 }
 
-void SubtrActorPlugin::renderModuleSummaryControls(const char *idSuffix) {
-  if (ImGui::TreeNodeEx(
-          std::format("Timeline visualizations##{}-timeline", idSuffix).c_str(),
-          ImGuiTreeNodeFlags_DefaultOpen)) {
+void SubtrActorPlugin::renderModuleSummaryControls(const char *idSuffix, bool collapsibleGroups) {
+  auto renderTimelineControls = [&]() {
     renderEventFilterModuleSummaryToggle("Touch", "touch", idSuffix);
     renderEventFilterModuleSummaryToggle("Dodge refresh", "dodge_reset", idSuffix);
     renderEventFilterModuleSummaryToggle("Backboard", "backboard", idSuffix);
@@ -7472,12 +7470,9 @@ void SubtrActorPlugin::renderModuleSummaryControls(const char *idSuffix) {
         timelineRangeAbsolutePositioningEnabled,
         idSuffix);
     renderBoolModuleSummaryToggle("Playlist follow", eventPlaylistAutoFollow, idSuffix);
-    ImGui::TreePop();
-  }
+  };
 
-  if (ImGui::TreeNodeEx(
-          std::format("In-game visualizations##{}-ingame", idSuffix).c_str(),
-          ImGuiTreeNodeFlags_DefaultOpen)) {
+  auto renderInGameControls = [&]() {
     renderCvarModuleSummaryToggle(
         "Canvas status line",
         "subtr_actor_status_overlay_enabled",
@@ -7521,8 +7516,30 @@ void SubtrActorPlugin::renderModuleSummaryControls(const char *idSuffix) {
       boostPickupPadAmbiguous = next;
       scheduleUiConfigAutosave();
     }
-    ImGui::TreePop();
+  };
+
+  if (collapsibleGroups) {
+    if (ImGui::TreeNodeEx(
+            std::format("Timeline visualizations##{}-timeline", idSuffix).c_str(),
+            ImGuiTreeNodeFlags_DefaultOpen)) {
+      renderTimelineControls();
+      ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNodeEx(
+            std::format("In-game visualizations##{}-ingame", idSuffix).c_str(),
+            ImGuiTreeNodeFlags_DefaultOpen)) {
+      renderInGameControls();
+      ImGui::TreePop();
+    }
+    return;
   }
+
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "TIMELINE VISUALIZATIONS");
+  renderTimelineControls();
+  ImGui::Spacing();
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "IN-GAME VISUALIZATIONS");
+  renderInGameControls();
 }
 
 void SubtrActorPlugin::renderModuleSettingsControls(
@@ -7815,7 +7832,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);
 
   ImGui::Separator();
-  renderModuleSummaryControls("launcher-module-summary");
+  renderModuleSummaryControls("launcher-module-summary", false);
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "MODULE SETTINGS");

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7592,7 +7592,8 @@ void SubtrActorPlugin::renderEventFilterModuleSummaryToggle(
 void SubtrActorPlugin::renderModuleSummaryControls(
     const char *idSuffix,
     bool collapsibleGroups,
-    float toggleWidth) {
+    float toggleWidth,
+    bool includePluginControls) {
   auto renderTimelineControls = [&]() {
     renderEventFilterModuleSummaryToggle("Touch", "touch", idSuffix, toggleWidth);
     renderEventFilterModuleSummaryToggle("Dodge refresh", "dodge_reset", idSuffix, toggleWidth);
@@ -7610,16 +7611,18 @@ void SubtrActorPlugin::renderModuleSummaryControls(
     renderEventFilterModuleSummaryToggle("Whiff", "whiff", idSuffix, toggleWidth);
     renderEventFilterModuleSummaryToggle("Bump", "bump", idSuffix, toggleWidth);
     renderEventFilterModuleSummaryToggle("Demo", "demo", idSuffix, toggleWidth);
-    renderBoolModuleSummaryToggle(
-        "Team event playlist",
-        eventPlaylistTeamEventsEnabled,
-        idSuffix,
-        toggleWidth);
-    renderBoolModuleSummaryToggle(
-        "Goal context playlist",
-        eventPlaylistGoalContextEnabled,
-        idSuffix,
-        toggleWidth);
+    if (includePluginControls) {
+      renderBoolModuleSummaryToggle(
+          "Team event playlist",
+          eventPlaylistTeamEventsEnabled,
+          idSuffix,
+          toggleWidth);
+      renderBoolModuleSummaryToggle(
+          "Goal context playlist",
+          eventPlaylistGoalContextEnabled,
+          idSuffix,
+          toggleWidth);
+    }
     renderBoolModuleSummaryToggle(
         "Boost pickup timeline",
         timelineRangeBoostEnabled,
@@ -7641,34 +7644,42 @@ void SubtrActorPlugin::renderModuleSummaryControls(
         timelineRangeAbsolutePositioningEnabled,
         idSuffix,
         toggleWidth);
-    renderBoolModuleSummaryToggle("Playlist follow", eventPlaylistAutoFollow, idSuffix, toggleWidth);
+    if (includePluginControls) {
+      renderBoolModuleSummaryToggle(
+          "Playlist follow",
+          eventPlaylistAutoFollow,
+          idSuffix,
+          toggleWidth);
+    }
   };
 
   auto renderInGameControls = [&]() {
-    renderCvarModuleSummaryToggle(
-        "Canvas status line",
-        "subtr_actor_status_overlay_enabled",
-        true,
-        idSuffix,
-        toggleWidth);
-    renderCvarModuleSummaryToggle(
-        "HUD mechanics",
-        "subtr_actor_overlay_mechanics_enabled",
-        true,
-        idSuffix,
-        toggleWidth);
-    renderCvarModuleSummaryToggle(
-        "HUD team events",
-        "subtr_actor_overlay_team_events_enabled",
-        true,
-        idSuffix,
-        toggleWidth);
-    renderCvarModuleSummaryToggle(
-        "HUD goal context",
-        "subtr_actor_overlay_goal_context_enabled",
-        true,
-        idSuffix,
-        toggleWidth);
+    if (includePluginControls) {
+      renderCvarModuleSummaryToggle(
+          "Canvas status line",
+          "subtr_actor_status_overlay_enabled",
+          true,
+          idSuffix,
+          toggleWidth);
+      renderCvarModuleSummaryToggle(
+          "HUD mechanics",
+          "subtr_actor_overlay_mechanics_enabled",
+          true,
+          idSuffix,
+          toggleWidth);
+      renderCvarModuleSummaryToggle(
+          "HUD team events",
+          "subtr_actor_overlay_team_events_enabled",
+          true,
+          idSuffix,
+          toggleWidth);
+      renderCvarModuleSummaryToggle(
+          "HUD goal context",
+          "subtr_actor_overlay_goal_context_enabled",
+          true,
+          idSuffix,
+          toggleWidth);
+    }
     renderBoolModuleSummaryToggle(
         "Ceiling shot labels",
         renderEffectCeilingShotEnabled,
@@ -8028,7 +8039,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   renderStatsWindowCreationControls("launcher-stats-windows", true, false, false, true);
 
   ImGui::Separator();
-  renderModuleSummaryControls("launcher-module-summary", false, 0.0f);
+  renderModuleSummaryControls("launcher-module-summary", false, 0.0f, false);
 
   ImGui::Separator();
   renderModuleSettingsControls("launcher-module-settings", false, true);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9982,14 +9982,14 @@ void SubtrActorPlugin::renderGraphInspectorWindow() {
 
 std::array<SubtrActorPlugin::SingletonWindowControl, 13>
 SubtrActorPlugin::singletonWindowControls() {
-  const float eventPlaylistX = rightAnchoredUiX(430.0f);
+  const float eventPlaylistX = rightAnchoredUiX(432.0f);
   const float statusX = rightAnchoredUiX(330.0f);
   const float playbackX = rightAnchoredUiX(336.0f, 32.0f);
   const float recordingX = rightAnchoredUiX(416.0f, 32.0f);
-  const float mechanicsReviewX = rightAnchoredUiX(500.0f);
-  const float replayLoadingX = rightAnchoredUiX(520.0f);
+  const float mechanicsReviewX = rightAnchoredUiX(480.0f);
+  const float replayLoadingX = rightAnchoredUiX(512.0f);
   const float moduleControlsX = rightAnchoredUiX(430.0f);
-  const float touchControlsX = rightAnchoredUiX(410.0f);
+  const float touchControlsX = rightAnchoredUiX(384.0f);
 
   return {{
       {"Scoreboard",
@@ -10026,7 +10026,7 @@ SubtrActorPlugin::singletonWindowControls() {
        &eventPlaylistPlacement,
        eventPlaylistX,
        256.0f,
-       430.0f,
+       432.0f,
        430.0f},
       {"Status",
        "status",
@@ -10098,7 +10098,7 @@ SubtrActorPlugin::singletonWindowControls() {
        &mechanicsReviewPlacement,
        mechanicsReviewX,
        256.0f,
-       500.0f,
+       480.0f,
        560.0f},
       {"Replay loading",
        "replay-loading",
@@ -10110,7 +10110,7 @@ SubtrActorPlugin::singletonWindowControls() {
        &replayLoadingPlacement,
        replayLoadingX,
        68.0f,
-       520.0f,
+       512.0f,
        360.0f},
       {"Module controls",
        "module-controls",
@@ -10134,7 +10134,7 @@ SubtrActorPlugin::singletonWindowControls() {
        &touchControlsPlacement,
        touchControlsX,
        256.0f,
-       410.0f,
+       384.0f,
        380.0f},
       {"Boost pickup filters",
        "boost-pickups",

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11925,7 +11925,6 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
 }
 
 void SubtrActorPlugin::renderAdHocStatsWindow(UiStatsWindow &window) {
-  ImGui::Columns(4, "ad-hoc-stat-rows", false);
   for (size_t i = 0; i < window.entries.size();) {
     UiStatsWindow::Entry &entry = window.entries[i];
     const std::string &statId = entry.stat_id;
@@ -11934,45 +11933,33 @@ void SubtrActorPlugin::renderAdHocStatsWindow(UiStatsWindow &window) {
       continue;
     }
     const std::string statLabel = uiStatLabel(statId);
+    const std::string statValue = adHocStatValue(statId, entry.target_id);
+    const float removeWidth = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+    const float valueWidth = std::max(48.0f, ImGui::CalcTextSize(statValue.c_str()).x + 18.0f);
+    const float removeX =
+        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - removeWidth);
+    const float valueX = std::max(
+        ImGui::GetCursorPosX(),
+        removeX - valueWidth - 12.0f);
+    const float targetX = std::max(ImGui::GetCursorPosX(), valueX - 148.0f);
+
     ImGui::Text("%s", statLabel.c_str());
-    ImGui::NextColumn();
+    ImGui::SameLine(targetX);
+    ImGui::SetNextItemWidth(132.0f);
     renderAdHocTargetSelector(window, entry, statId, i);
-    ImGui::NextColumn();
-    ImGui::Text("%s", adHocStatValue(statId, entry.target_id).c_str());
-    ImGui::NextColumn();
+    ImGui::SameLine(valueX);
+    ImGui::Text("%s", statValue.c_str());
+    ImGui::SameLine(removeX);
     if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
       window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
       scheduleUiConfigAutosave();
-      ImGui::Columns(1);
       return;
     }
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip("Remove stat");
     }
-    ImGui::NextColumn();
     ++i;
   }
-  ImGui::Columns(1);
-  ImGui::Separator();
-  ImGui::BeginChild("ad-hoc-events", ImVec2{0.0f, 0.0f}, true);
-  for (const UiEventRecord &event : recentUiEvents) {
-    const bool selected = std::any_of(
-        window.entries.begin(),
-        window.entries.end(),
-        [&](const UiStatsWindow::Entry &entry) {
-          if (entry.stat_id == "recent_events") {
-            return true;
-          }
-          return eventFilterAllows(entry.stat_id, event.category, event.type);
-        });
-    if (!selected) {
-      continue;
-    }
-    ImGui::TextColored(toImVec4(event.color), "%.2fs %s", event.time, event.actor.c_str());
-    ImGui::SameLine();
-    ImGui::TextWrapped("%s", event.label.c_str());
-  }
-  ImGui::EndChild();
 }
 
 void SubtrActorPlugin::renderJsonSummary(const std::string &json) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3328,7 +3328,7 @@ void SubtrActorPlugin::applyUiConfigJson(
 
     const std::vector<std::string> renderEffects =
         parseJsonStringArrayProperty(*overlays, "renderEffects");
-    if (overlays->find("\"renderEffects\"") != std::string::npos) {
+    if (jsonPropertyExists(*overlays, "renderEffects")) {
       const bool anyRenderEffect = !renderEffects.empty();
       renderEffectCeilingShotEnabled = containsString(renderEffects, "ceiling-shot");
       renderEffectFiftyFiftyEnabled = containsString(renderEffects, "fifty-fifty");

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1079,7 +1079,7 @@ std::optional<std::string> urlDecode(std::string_view value) {
   return decoded;
 }
 
-std::optional<std::string> statsPlayerCfgJsonFromClipboard(std::string_view clipboardText) {
+std::optional<std::string> statsPlayerCfgValueFromClipboard(std::string_view clipboardText) {
   const size_t firstByte = clipboardText.find_first_not_of(" \t\r\n");
   if (firstByte == std::string_view::npos) {
     return std::nullopt;
@@ -1103,7 +1103,7 @@ std::optional<std::string> statsPlayerCfgJsonFromClipboard(std::string_view clip
     return std::nullopt;
   }
   const size_t decodedFirstByte = decoded->find_first_not_of(" \t\r\n");
-  if (decodedFirstByte == std::string::npos || (*decoded)[decodedFirstByte] != '{') {
+  if (decodedFirstByte == std::string::npos) {
     return std::nullopt;
   }
   return decoded->substr(decodedFirstByte);
@@ -2381,6 +2381,50 @@ SaPlayerFrame syntheticPlayer(
 
 } // namespace
 
+std::optional<std::string> SubtrActorPlugin::statsPlayerCfgJsonFromClipboard(
+    std::string_view clipboardText) {
+  const std::optional<std::string> value = statsPlayerCfgValueFromClipboard(clipboardText);
+  if (!value) {
+    return std::nullopt;
+  }
+
+  const size_t firstByte = value->find_first_not_of(" \t\r\n");
+  if (firstByte == std::string::npos) {
+    return std::nullopt;
+  }
+  if ((*value)[firstByte] == '{') {
+    return value->substr(firstByte);
+  }
+
+  if (!decodedStatsPlayerConfigJsonLen || !writeDecodedStatsPlayerConfigJson) {
+    return std::nullopt;
+  }
+
+  const std::string encoded = value->substr(firstByte);
+  if (encoded.find('\0') != std::string::npos) {
+    return std::nullopt;
+  }
+  const size_t byteCount = decodedStatsPlayerConfigJsonLen(encoded.c_str());
+  if (byteCount == 0) {
+    return std::nullopt;
+  }
+
+  std::string json(byteCount, '\0');
+  const size_t written = writeDecodedStatsPlayerConfigJson(
+      encoded.c_str(),
+      reinterpret_cast<uint8_t *>(json.data()),
+      json.size());
+  if (written == 0 || written > json.size()) {
+    return std::nullopt;
+  }
+  json.resize(written);
+  const size_t jsonFirstByte = json.find_first_not_of(" \t\r\n");
+  if (jsonFirstByte == std::string::npos || json[jsonFirstByte] != '{') {
+    return std::nullopt;
+  }
+  return json.substr(jsonFirstByte);
+}
+
 std::string SubtrActorPlugin::webUiStatIdForWindow(
     const UiStatsWindow &window,
     const UiStatsWindow::Entry &entry) const {
@@ -2917,6 +2961,10 @@ bool SubtrActorPlugin::loadRustLibrary() {
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_graph_info_json_len"));
   writeGraphInfoJson = reinterpret_cast<WriteGraphInfoJson>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_graph_info_json"));
+  decodedStatsPlayerConfigJsonLen = reinterpret_cast<DecodedStatsPlayerConfigJsonLen>(
+      GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_decoded_stats_player_config_json_len"));
+  writeDecodedStatsPlayerConfigJson = reinterpret_cast<WriteDecodedStatsPlayerConfigJson>(
+      GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_decoded_stats_player_config_json"));
   drainEvents = reinterpret_cast<DrainEvents>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_drain_events"));
   drainTeamEvents = reinterpret_cast<DrainTeamEvents>(
@@ -2944,6 +2992,7 @@ bool SubtrActorPlugin::loadRustLibrary() {
       !writeStatsModuleConfigJson || !graphOutputJsonLen || !writeGraphOutputJson ||
       !analysisNodeJsonLen || !writeAnalysisNodeJson || !analysisNodeNamesJsonLen ||
       !writeAnalysisNodeNamesJson || !graphInfoJsonLen || !writeGraphInfoJson ||
+      !decodedStatsPlayerConfigJsonLen || !writeDecodedStatsPlayerConfigJson ||
       !drainEvents || !drainTeamEvents || !drainGoalContextEvents ||
       !replayAnnotationsCreate || !replayAnnotationsDestroy || !replayAnnotationCount ||
       !replayAnnotationPlayerCount || !writeReplayAnnotationPlayers ||
@@ -2997,6 +3046,8 @@ void SubtrActorPlugin::unloadRustLibrary() {
   writeAnalysisNodeNamesJson = nullptr;
   graphInfoJsonLen = nullptr;
   writeGraphInfoJson = nullptr;
+  decodedStatsPlayerConfigJsonLen = nullptr;
+  writeDecodedStatsPlayerConfigJson = nullptr;
   drainEvents = nullptr;
   drainTeamEvents = nullptr;
   drainGoalContextEvents = nullptr;
@@ -7478,7 +7529,7 @@ void SubtrActorPlugin::renderLauncherWorkspaceControls() {
       applyUiConfigJson(*configJson, "clipboard");
     } else {
       cvarManager->log(
-          "subtr-actor: clipboard does not contain raw UI config JSON or a raw JSON cfg value");
+          "subtr-actor: clipboard does not contain UI config JSON or a stats-player cfg value");
     }
   }
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -4204,12 +4204,7 @@ std::string SubtrActorPlugin::uiConfigJson() {
     } else {
       file << "null";
     }
-    file << ",\"team\":";
-    if (window.kind == UiStatsWindowKind::Team) {
-      file << "\"" << (window.selected_team_is_team_0 != 0 ? "blue" : "orange") << "\"";
-    } else {
-      file << "null";
-    }
+    file << ",\"team\":\"" << (window.selected_team_is_team_0 != 0 ? "blue" : "orange") << "\"";
     file << ",\"entries\":[";
     for (size_t j = 0; j < window.entries.size(); j += 1) {
       if (j != 0) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3167,6 +3167,8 @@ bool SubtrActorPlugin::loadRustLibrary() {
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_replay_annotation_player_count"));
   writeReplayAnnotationPlayers = reinterpret_cast<WriteReplayAnnotationPlayers>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_replay_annotation_players"));
+  writeReplayAnnotationFramePlayers = reinterpret_cast<WriteReplayAnnotationFramePlayers>(
+      GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_write_replay_annotation_frame_players"));
   replayAnnotationScoreAtTime = reinterpret_cast<ReplayAnnotationScoreAtTime>(
       GetProcAddress(rustLibrary, "subtr_actor_bakkesmod_replay_annotation_score_at_time"));
   pollReplayAnnotations = reinterpret_cast<PollReplayAnnotations>(
@@ -3185,7 +3187,8 @@ bool SubtrActorPlugin::loadRustLibrary() {
       !drainEvents || !drainTeamEvents || !drainGoalContextEvents ||
       !replayAnnotationsCreate || !replayAnnotationsDestroy || !replayAnnotationCount ||
       !replayAnnotationPlayerCount || !writeReplayAnnotationPlayers ||
-      !replayAnnotationScoreAtTime || !pollReplayAnnotations) {
+      !writeReplayAnnotationFramePlayers || !replayAnnotationScoreAtTime ||
+      !pollReplayAnnotations) {
     unloadRustLibrary();
     return false;
   }
@@ -3247,6 +3250,7 @@ void SubtrActorPlugin::unloadRustLibrary() {
   replayAnnotationCount = nullptr;
   replayAnnotationPlayerCount = nullptr;
   writeReplayAnnotationPlayers = nullptr;
+  writeReplayAnnotationFramePlayers = nullptr;
   replayAnnotationScoreAtTime = nullptr;
   pollReplayAnnotations = nullptr;
 }
@@ -4689,9 +4693,13 @@ void SubtrActorPlugin::resetReplayAnnotations() {
   replayAnnotations = nullptr;
   replayAnnotationPath.clear();
   replayAnnotationLoadFailed = false;
+  if (gameWrapper && gameWrapper->IsInReplay()) {
+    sampledPlayers.clear();
+    sampledPlayerNames.clear();
+  }
 }
 
-void SubtrActorPlugin::importReplayAnnotationPlayers() {
+void SubtrActorPlugin::importReplayAnnotationPlayers(float replayTime) {
   if (!replayAnnotations || !replayAnnotationPlayerCount || !writeReplayAnnotationPlayers) {
     return;
   }
@@ -4701,15 +4709,42 @@ void SubtrActorPlugin::importReplayAnnotationPlayers() {
     return;
   }
 
+  if (writeReplayAnnotationFramePlayers) {
+    std::vector<SaPlayerFrame> framePlayers(playerCount);
+    const size_t copiedFramePlayers = writeReplayAnnotationFramePlayers(
+        replayAnnotations,
+        replayTime,
+        framePlayers.data(),
+        framePlayers.size());
+    if (copiedFramePlayers > 0) {
+      sampledPlayers.assign(framePlayers.begin(), framePlayers.begin() + copiedFramePlayers);
+      sampledPlayerNames.clear();
+      for (const SaPlayerFrame &player : sampledPlayers) {
+        if (player.player_name != nullptr && player.player_name[0] != '\0') {
+          playerNamesByIndex[player.player_index] = player.player_name;
+        }
+        playerTeamsByIndex[player.player_index] = player.is_team_0;
+      }
+      return;
+    }
+  }
+
   std::vector<SaReplayPlayerInfo> players(playerCount);
   const size_t copied =
       writeReplayAnnotationPlayers(replayAnnotations, players.data(), players.size());
+  sampledPlayers.clear();
+  sampledPlayerNames.clear();
   for (size_t i = 0; i < copied; i += 1) {
     const SaReplayPlayerInfo &player = players[i];
     if (player.name != nullptr && player.name[0] != '\0') {
       playerNamesByIndex[player.player_index] = player.name;
     }
     playerTeamsByIndex[player.player_index] = player.is_team_0;
+    SaPlayerFrame frame{};
+    frame.player_index = player.player_index;
+    frame.player_name = player.name;
+    frame.is_team_0 = player.is_team_0;
+    sampledPlayers.push_back(frame);
   }
 }
 
@@ -4795,13 +4830,14 @@ void SubtrActorPlugin::tickReplayAnnotations() {
     replayAnnotationLoadFailed = false;
     const size_t annotationCount =
         replayAnnotationCount ? replayAnnotationCount(replayAnnotations) : 0;
-    importReplayAnnotationPlayers();
+    importReplayAnnotationPlayers(replayServer.GetReplayTimeElapsed());
     cvarManager->log(std::format(
         "subtr-actor: loaded {} replay annotations from normal replay processor for {}",
         annotationCount,
         *replayPath));
   }
 
+  importReplayAnnotationPlayers(replayServer.GetReplayTimeElapsed());
   std::array<SaMechanicEvent, 64> replayEvents{};
   const size_t eventCount = pollReplayAnnotations(
       replayAnnotations,

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9593,7 +9593,7 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
       touchMarkerDecaySeconds);
   ImGui::TextDisabled("Keep each marker visible after the touch");
   if (ImGui::SliderFloat(
-          "Marker decay seconds", &touchMarkerDecaySeconds, 1.0f, 10.0f, "%.1fs")) {
+          "##touch-marker-decay-seconds", &touchMarkerDecaySeconds, 1.0f, 10.0f, "%.1fs")) {
     scheduleUiConfigAutosave();
   }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9098,6 +9098,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
       : candidates.empty()             ? "Load a review playlist."
                                        : "Loaded review playlist.";
   ImGui::TextWrapped("%s", statusReadout.c_str());
+  ImGui::Separator();
   ImGui::Text("%d / %zu", current == nullptr ? 0 : mechanicsReviewIndex + 1, candidates.size());
   const std::string currentTitle =
       current == nullptr ? "No candidate selected"

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9026,12 +9026,28 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     ImGui::TextWrapped("%s", status.c_str());
   }
 
-  if (ImGui::Button("Prev") && current != nullptr && mechanicsReviewIndex > 0) {
+  auto mechanicsReviewButton = [](const char *label, bool disabled) {
+    if (disabled) {
+      ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.45f);
+    }
+    const bool clicked = ImGui::Button(label);
+    if (disabled) {
+      ImGui::PopStyleVar();
+    }
+    return clicked && !disabled;
+  };
+  const bool prevDisabled = current == nullptr || mechanicsReviewIndex <= 0;
+  const bool replayDisabled = current == nullptr;
+  const bool nextDisabled =
+      current == nullptr || mechanicsReviewIndex >= static_cast<int>(candidates.size()) - 1;
+  const bool decisionDisabled = current == nullptr;
+
+  if (mechanicsReviewButton("Prev", prevDisabled)) {
     mechanicsReviewIndex -= 1;
     scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
-  if (ImGui::Button("Replay clip") && current != nullptr) {
+  if (mechanicsReviewButton("Replay clip", replayDisabled)) {
     playbackCurrentTime = clipStart;
     playbackPlaying = true;
     playbackSkipPostGoalTransitions = false;
@@ -9055,21 +9071,20 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
-  if (ImGui::Button("Next") &&
-      current != nullptr && mechanicsReviewIndex < static_cast<int>(candidates.size()) - 1) {
+  if (mechanicsReviewButton("Next", nextDisabled)) {
     mechanicsReviewIndex += 1;
     scheduleUiConfigAutosave();
   }
 
-  if (ImGui::Button("Confirm") && current != nullptr) {
+  if (mechanicsReviewButton("Confirm", decisionDisabled)) {
     mechanicsReviewDecisions[currentKey] = 1;
   }
   ImGui::SameLine();
-  if (ImGui::Button("Reject") && current != nullptr) {
+  if (mechanicsReviewButton("Reject", decisionDisabled)) {
     mechanicsReviewDecisions[currentKey] = 2;
   }
   ImGui::SameLine();
-  if (ImGui::Button("Uncertain") && current != nullptr) {
+  if (mechanicsReviewButton("Uncertain", decisionDisabled)) {
     mechanicsReviewDecisions[currentKey] = 3;
   }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -75,6 +75,18 @@ std::string formatEventPlaylistTime(float seconds) {
   return std::format("{}:{:04.1f}", minutes, remainingSeconds);
 }
 
+std::string replaySourceDisplayLabel(std::string_view path) {
+  constexpr std::string_view prefix = "path:";
+  if (path.starts_with(prefix)) {
+    path.remove_prefix(prefix.size());
+  }
+  const size_t lastSeparator = path.find_last_of("/\\");
+  if (lastSeparator != std::string_view::npos) {
+    path.remove_prefix(lastSeparator + 1);
+  }
+  return path.empty() ? "review replay" : std::string{path};
+}
+
 std::string joinStrings(const std::vector<std::string> &parts, std::string_view separator) {
   std::string joined;
   for (const std::string &part : parts) {
@@ -9292,16 +9304,17 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
   if (!hasReplaySource) {
     ImGui::TextDisabled("No replay sources.");
   } else {
-    const std::string title = replayPath ? *replayPath
-                              : !rawReplayPath.empty() ? rawReplayPath
-                                                       : replayAnnotationPath;
+    const std::string titlePath = replayPath ? *replayPath
+                                  : !rawReplayPath.empty() ? rawReplayPath
+                                                           : replayAnnotationPath;
+    const std::string title = replaySourceDisplayLabel(titlePath);
     const float replayLoadProgress = replayAnnotations ? 1.0f : 0.0f;
     ImGui::TextWrapped("%s", title.c_str());
     std::vector<std::string> replayMeta;
     if (!rawReplayPath.empty()) {
       replayMeta.push_back(std::format("raw: {}", rawReplayPath));
     }
-    if (!replayAnnotationPath.empty() && replayAnnotationPath != title) {
+    if (!replayAnnotationPath.empty() && replayAnnotationPath != titlePath) {
       replayMeta.push_back(std::format("processed: {}", replayAnnotationPath));
     }
     if (annotationCount > 0) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8910,10 +8910,12 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
                            : replayAnnotations ? "Loaded"
                            : replayAnnotationLoadFailed ? "Failed"
                                                         : "Scanning";
+  const std::string replaySummary = replayPath ? "1 replay" : "0 replays";
 
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REPLAY LOADING");
-  ImGui::Text("Summary: %s", replayPath ? "1 replay candidate" : "0 replay candidates");
-  ImGui::Text("Active: %s", status);
+  ImGui::Text("%s", replaySummary.c_str());
+  ImGui::SameLine();
+  ImGui::Text("%s", status);
   ImGui::Text("In replay: %s", inReplay ? "yes" : "no");
   if (hasReplayServer) {
     ImGui::Text("Replay time: %.2fs", replayServer.GetReplayTimeElapsed());

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7823,7 +7823,7 @@ void SubtrActorPlugin::captureWindowPlacement(UiWindowPlacement &placement) {
   placement.viewport_width = displaySize.x;
   placement.viewport_height = displaySize.y;
   if (ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows) &&
-      ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+      ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !ImGui::IsAnyItemActive()) {
     placement.z_index = nextUiWindowZIndex++;
   }
   if (!hadPlacement || previousX != placement.x || previousY != placement.y ||
@@ -7948,7 +7948,7 @@ void SubtrActorPlugin::captureStatsWindowPlacement(UiStatsWindow &window) {
   window.viewport_width = displaySize.x;
   window.viewport_height = displaySize.y;
   if (ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows) &&
-      ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+      ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !ImGui::IsAnyItemActive()) {
     window.z_index = nextUiWindowZIndex++;
   }
   if (!hadPlacement || previousX != window.x || previousY != window.y ||

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8692,30 +8692,10 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
-  if (mechanicsReviewClipActive && ImGui::Button("Stop clip")) {
-    mechanicsReviewClipActive = false;
-    playbackPlaying = false;
-    mechanicsReviewStatus = "Clip stopped";
-    ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
-    if (!replayServer.IsNull()) {
-      ReplayWrapper replay = replayServer.GetReplay();
-      if (!replay.IsNull()) {
-        replay.StopPlayback();
-      }
-    }
-    scheduleUiConfigAutosave();
-  }
-  if (mechanicsReviewClipActive) {
-    ImGui::SameLine();
-  }
   if (ImGui::Button("Next") &&
       mechanicsReviewIndex < static_cast<int>(candidates.size()) - 1) {
     mechanicsReviewIndex += 1;
     scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Show playlist")) {
-    showSingletonWindow(uiEventPlaylistOpen, eventPlaylistPlacement);
   }
 
   if (ImGui::Button("Confirm")) {
@@ -8728,10 +8708,6 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   ImGui::SameLine();
   if (ImGui::Button("Uncertain")) {
     mechanicsReviewDecisions[currentKey] = 3;
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Clear decision")) {
-    mechanicsReviewDecisions.erase(currentKey);
   }
 
   ImGui::Separator();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9580,61 +9580,7 @@ void SubtrActorPlugin::renderCameraWindow() {
   };
   cameraViewMode = std::clamp(cameraViewMode, 0, static_cast<int>(viewModes.size()) - 1);
 
-  const std::string selectedLabel =
-      targetPlayer == nullptr
-          ? "Free camera"
-          : playerLabel(targetPlayer->player_index, targetPlayer->is_team_0);
-  ImGui::TextDisabled("Camera profile");
-  ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-  if (ImGui::BeginCombo("##attached-player", selectedLabel.c_str())) {
-    if (ImGui::Selectable("Free camera", cameraViewMode != 1)) {
-      cameraViewMode = 0;
-      cameraFreePreset = -1;
-      scheduleUiConfigAutosave();
-    }
-    for (const SaPlayerFrame &player : sampledPlayers) {
-      const std::string label = std::format(
-          "{}##camera-player-{}",
-          playerLabel(player.player_index, player.is_team_0),
-          player.player_index);
-      if (ImGui::Selectable(
-              label.c_str(), targetPlayer != nullptr &&
-                                 targetPlayer->player_index == player.player_index)) {
-        cameraSelectedPlayerIndex = player.player_index;
-        cameraSelectedPlayerId = webPlayerIdForIndex(cameraSelectedPlayerIndex);
-        cameraViewMode = 1;
-        cameraFreePreset = -1;
-        scheduleUiConfigAutosave();
-      }
-    }
-    ImGui::EndCombo();
-  }
-
-  if (ImGui::RadioButton("Free##camera-view", &cameraViewMode, 0)) {
-    cameraFreePreset = -1;
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::RadioButton("Follow##camera-view", &cameraViewMode, 1)) {
-    cameraFreePreset = -1;
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::RadioButton("Overhead##camera-view", &cameraViewMode, 2)) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::RadioButton("Diagonal##camera-view", &cameraViewMode, 3)) {
-    scheduleUiConfigAutosave();
-  }
-
-  if (cameraViewMode == 2) {
-    cameraFreePreset = 0;
-  } else if (cameraViewMode == 3) {
-    cameraFreePreset = 1;
-  }
-
-  const bool hasAttachedCamera = targetPlayer != nullptr;
+  const bool hasCameraContext = !sampledPlayers.empty();
   auto pushCameraDisabledStyle = [](bool disabled) {
     if (disabled) {
       ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.45f);
@@ -9646,6 +9592,82 @@ void SubtrActorPlugin::renderCameraWindow() {
     }
   };
 
+  const std::string selectedLabel =
+      targetPlayer == nullptr
+          ? "Free camera"
+          : playerLabel(targetPlayer->player_index, targetPlayer->is_team_0);
+  ImGui::TextDisabled("Camera profile");
+  ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+  const bool profileDisabled = !hasCameraContext;
+  pushCameraDisabledStyle(profileDisabled);
+  const bool profileOpen = ImGui::BeginCombo("##attached-player", selectedLabel.c_str());
+  popCameraDisabledStyle(profileDisabled);
+  if (profileOpen) {
+    if (profileDisabled) {
+      ImGui::CloseCurrentPopup();
+      ImGui::EndCombo();
+    } else {
+      if (ImGui::Selectable("Free camera", cameraViewMode != 1)) {
+        cameraViewMode = 0;
+        cameraFreePreset = -1;
+        scheduleUiConfigAutosave();
+      }
+      for (const SaPlayerFrame &player : sampledPlayers) {
+        const std::string label = std::format(
+            "{}##camera-player-{}",
+            playerLabel(player.player_index, player.is_team_0),
+            player.player_index);
+        if (ImGui::Selectable(
+                label.c_str(), targetPlayer != nullptr &&
+                                   targetPlayer->player_index == player.player_index)) {
+          cameraSelectedPlayerIndex = player.player_index;
+          cameraSelectedPlayerId = webPlayerIdForIndex(cameraSelectedPlayerIndex);
+          cameraViewMode = 1;
+          cameraFreePreset = -1;
+          scheduleUiConfigAutosave();
+        }
+      }
+      ImGui::EndCombo();
+    }
+  }
+
+  auto cameraViewButton = [&](const char *label, int mode, bool disabled) {
+    int nextMode = cameraViewMode;
+    pushCameraDisabledStyle(disabled);
+    const bool clicked = ImGui::RadioButton(label, &nextMode, mode);
+    popCameraDisabledStyle(disabled);
+    return clicked && !disabled;
+  };
+
+  if (cameraViewButton("Free##camera-view", 0, !hasCameraContext)) {
+    cameraViewMode = 0;
+    cameraFreePreset = -1;
+    scheduleUiConfigAutosave();
+  }
+  ImGui::SameLine();
+  if (cameraViewButton("Follow##camera-view", 1, !hasCameraContext || selectedPlayer == nullptr)) {
+    cameraViewMode = 1;
+    cameraFreePreset = -1;
+    scheduleUiConfigAutosave();
+  }
+  ImGui::SameLine();
+  if (cameraViewButton("Overhead##camera-view", 2, !hasCameraContext)) {
+    cameraViewMode = 2;
+    scheduleUiConfigAutosave();
+  }
+  ImGui::SameLine();
+  if (cameraViewButton("Diagonal##camera-view", 3, !hasCameraContext)) {
+    cameraViewMode = 3;
+    scheduleUiConfigAutosave();
+  }
+
+  if (cameraViewMode == 2) {
+    cameraFreePreset = 0;
+  } else if (cameraViewMode == 3) {
+    cameraFreePreset = 1;
+  }
+
+  const bool hasAttachedCamera = targetPlayer != nullptr;
   float nextDistanceScale = cameraDistanceScale;
   pushCameraDisabledStyle(!hasAttachedCamera);
   const bool distanceScaleChanged =

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11638,6 +11638,44 @@ void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
   }
 }
 
+bool SubtrActorPlugin::renderStatsWindowValueRow(
+    UiStatsWindow &window,
+    size_t entryIndex,
+    std::string_view label,
+    std::string_view value,
+    std::string_view idSuffix) {
+  const std::string valueString{value};
+  const float removeWidth = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+  const float valueWidth =
+      std::max(48.0f, ImGui::CalcTextSize(valueString.c_str()).x + 18.0f);
+  const float removeX =
+      std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - removeWidth);
+  const float valueX = std::max(
+      ImGui::GetCursorPosX(),
+      removeX - valueWidth - 12.0f);
+  const std::string labelString{label};
+  ImGui::Text("%s", labelString.c_str());
+  ImGui::SameLine(valueX);
+  ImGui::Text("%s", valueString.c_str());
+  ImGui::SameLine(removeX);
+  const std::string removeLabel = idSuffix.empty()
+                                      ? std::format("x##remove-stat-{}-{}", window.id, entryIndex)
+                                      : std::format(
+                                            "x##remove-stat-{}-{}-{}",
+                                            window.id,
+                                            entryIndex,
+                                            idSuffix);
+  if (ImGui::SmallButton(removeLabel.c_str())) {
+    window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(entryIndex));
+    scheduleUiConfigAutosave();
+    return true;
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Remove stat");
+  }
+  return false;
+}
+
 void SubtrActorPlugin::renderMissingStatsRows(UiStatsWindow &window) {
   for (size_t i = 0; i < window.entries.size();) {
     const std::string &statId = window.entries[i].stat_id;
@@ -11646,25 +11684,8 @@ void SubtrActorPlugin::renderMissingStatsRows(UiStatsWindow &window) {
       continue;
     }
 
-    const float removeWidth = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
-    const float valueWidth = std::max(48.0f, ImGui::CalcTextSize("--").x + 18.0f);
-    const float valueX = std::max(
-        ImGui::GetCursorPosX(),
-        ImGui::GetWindowContentRegionMax().x - valueWidth - removeWidth - 12.0f);
-    const float removeX =
-        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - removeWidth);
-
-    ImGui::Text("%s", uiStatLabel(statId).c_str());
-    ImGui::SameLine(valueX);
-    ImGui::Text("--");
-    ImGui::SameLine(removeX);
-    if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
-      window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
-      scheduleUiConfigAutosave();
+    if (renderStatsWindowValueRow(window, i, uiStatLabel(statId), "--")) {
       return;
-    }
-    if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip("Remove stat");
     }
     ++i;
   }
@@ -11681,24 +11702,8 @@ void SubtrActorPlugin::renderPlayerStatsTable(
     }
     const std::string statLabel = uiStatLabel(statId);
     const std::string statValue = playerStatValue(player, statId);
-    const float removeWidth = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
-    const float valueWidth = std::max(48.0f, ImGui::CalcTextSize(statValue.c_str()).x + 18.0f);
-    const float valueX = std::max(
-        ImGui::GetCursorPosX(),
-        ImGui::GetWindowContentRegionMax().x - valueWidth - removeWidth - 12.0f);
-    const float removeX =
-        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - removeWidth);
-    ImGui::Text("%s", statLabel.c_str());
-    ImGui::SameLine(valueX);
-    ImGui::Text("%s", statValue.c_str());
-    ImGui::SameLine(removeX);
-    if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
-      window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
-      scheduleUiConfigAutosave();
+    if (renderStatsWindowValueRow(window, i, statLabel, statValue)) {
       return;
-    }
-    if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip("Remove stat");
     }
     ++i;
   }
@@ -11713,24 +11718,8 @@ void SubtrActorPlugin::renderTeamStatsTable(UiStatsWindow &window, uint8_t isTea
     }
     const std::string statLabel = uiStatLabel(statId);
     const std::string statValue = teamStatValue(isTeam0, statId);
-    const float removeWidth = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
-    const float valueWidth = std::max(48.0f, ImGui::CalcTextSize(statValue.c_str()).x + 18.0f);
-    const float valueX = std::max(
-        ImGui::GetCursorPosX(),
-        ImGui::GetWindowContentRegionMax().x - valueWidth - removeWidth - 12.0f);
-    const float removeX =
-        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - removeWidth);
-    ImGui::Text("%s", statLabel.c_str());
-    ImGui::SameLine(valueX);
-    ImGui::Text("%s", statValue.c_str());
-    ImGui::SameLine(removeX);
-    if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
-      window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
-      scheduleUiConfigAutosave();
+    if (renderStatsWindowValueRow(window, i, statLabel, statValue)) {
       return;
-    }
-    if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip("Remove stat");
     }
     ++i;
   }
@@ -11763,39 +11752,23 @@ void SubtrActorPlugin::renderAllPlayersStatsTable(UiStatsWindow &window) {
 
       ImGui::PushID(static_cast<int>(player.player_index));
       const std::string playerName = playerLabel(player.player_index, player.is_team_0);
-      if (ImGui::TreeNodeEx(playerName.c_str(), ImGuiTreeNodeFlags_DefaultOpen)) {
-        ImGui::Columns(
-            3,
-            std::format("all-player-stat-rows-{}", player.player_index).c_str(),
-            false);
-        for (size_t i = 0; i < window.entries.size();) {
-          const std::string &statId = window.entries[i].stat_id;
-          if (!statsWindowSupportsStat(window, statId)) {
-            ++i;
-            continue;
-          }
-          const std::string statLabel = uiStatLabel(statId);
-          ImGui::Text("%s", statLabel.c_str());
-          ImGui::NextColumn();
-          ImGui::Text("%s", playerStatValue(player, statId).c_str());
-          ImGui::NextColumn();
-          if (ImGui::SmallButton(std::format("x##remove-stat-{}-{}", window.id, i).c_str())) {
-            window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
-            scheduleUiConfigAutosave();
-            ImGui::Columns(1);
-            ImGui::TreePop();
-            ImGui::PopID();
-            return true;
-          }
-          if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("Remove stat");
-          }
-          ImGui::NextColumn();
+      ImGui::TextColored(toImVec4(color), "%s", playerName.c_str());
+      for (size_t i = 0; i < window.entries.size();) {
+        const std::string &statId = window.entries[i].stat_id;
+        if (!statsWindowSupportsStat(window, statId)) {
           ++i;
+          continue;
         }
-        ImGui::Columns(1);
-        ImGui::TreePop();
+        const std::string statLabel = uiStatLabel(statId);
+        const std::string statValue = playerStatValue(player, statId);
+        if (renderStatsWindowValueRow(
+                window, i, statLabel, statValue, std::format("player-{}", player.player_index))) {
+          ImGui::PopID();
+          return true;
+        }
+        ++i;
       }
+      ImGui::Spacing();
       ImGui::PopID();
     }
     return false;
@@ -11814,7 +11787,6 @@ void SubtrActorPlugin::renderAllTeamsStatsTable(UiStatsWindow &window) {
     const LinearColor color =
         isTeam0 != 0 ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255};
     ImGui::TextColored(toImVec4(color), "%s", teamLabel(isTeam0).c_str());
-    ImGui::Columns(3, std::format("all-team-stat-rows-{}", isTeam0).c_str(), false);
     for (size_t i = 0; i < window.entries.size();) {
       const std::string &statId = window.entries[i].stat_id;
       if (!statsWindowSupportsStat(window, statId)) {
@@ -11822,25 +11794,14 @@ void SubtrActorPlugin::renderAllTeamsStatsTable(UiStatsWindow &window) {
         continue;
       }
       const std::string statLabel = uiStatLabel(statId);
-      ImGui::Text("%s", statLabel.c_str());
-      ImGui::NextColumn();
-      ImGui::Text("%s", teamStatValue(isTeam0, statId).c_str());
-      ImGui::NextColumn();
-      if (ImGui::SmallButton(
-              std::format("x##remove-stat-{}-{}-{}", window.id, isTeam0, i).c_str())) {
-        window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(i));
-        scheduleUiConfigAutosave();
-        ImGui::Columns(1);
+      const std::string statValue = teamStatValue(isTeam0, statId);
+      if (renderStatsWindowValueRow(
+              window, i, statLabel, statValue, std::format("team-{}", isTeam0))) {
         return;
       }
-      if (ImGui::IsItemHovered()) {
-        ImGui::SetTooltip("Remove stat");
-      }
-      ImGui::NextColumn();
       ++i;
     }
-    ImGui::Columns(1);
-    ImGui::Separator();
+    ImGui::Spacing();
   }
 }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7595,7 +7595,7 @@ void SubtrActorPlugin::renderLauncherToggleChrome() {
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.28f, 0.57f, 0.72f, 1.0f});
   }
 
-  if (ImGui::Button("Menu##subtr-actor-launcher-toggle", ImVec2{44.0f, 28.0f})) {
+  if (ImGui::Button("Menu##subtr-actor-launcher-toggle", ImVec2{42.0f, 42.0f})) {
     uiWindowOpen = true;
     if (uiLauncherOpen) {
       hideLauncherWindow();
@@ -7614,9 +7614,9 @@ void SubtrActorPlugin::renderLauncherToggleChrome() {
 
 void SubtrActorPlugin::applyLauncherMenuPlacement() {
   const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
-  const float width = 340.0f;
-  const float height = std::max(320.0f, displaySize.y > 0.0f ? displaySize.y - 68.0f : 650.0f);
-  ImGui::SetNextWindowPos(ImVec2{12.0f, 50.0f}, ImGuiCond_Always);
+  const float width = 352.0f;
+  const float height = std::max(320.0f, displaySize.y > 0.0f ? displaySize.y - 120.0f : 650.0f);
+  ImGui::SetNextWindowPos(ImVec2{12.0f, 64.0f}, ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2{width, height}, ImGuiCond_Always);
   ImGui::SetNextWindowBgAlpha(0.92f);
   if (launcherPlacement.pending_focus) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8126,9 +8126,7 @@ void SubtrActorPlugin::renderWebWindowToggleControls(
       ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
       ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.25f, 0.55f, 0.43f, 1.0f});
     }
-    const std::string buttonLabel = includeState
-                                        ? std::format("{}   {}", window.label, isOpen ? "Hide" : "Show")
-                                        : std::string{window.label};
+    const std::string buttonLabel{window.label};
     const float buttonWidth = fullWidth ? ImGui::GetContentRegionAvail().x : 210.0f;
     if (ImGui::Button(buttonLabel.c_str(), ImVec2{buttonWidth, 0.0f})) {
       if (*window.open) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1019,6 +1019,26 @@ std::string escapeJsonString(std::string_view value) {
   return escaped;
 }
 
+std::string urlEncode(std::string_view value) {
+  constexpr char HEX[] = "0123456789ABCDEF";
+  std::string encoded;
+  encoded.reserve(value.size());
+  for (const unsigned char byte : value) {
+    const bool unreserved =
+        (byte >= 'A' && byte <= 'Z') || (byte >= 'a' && byte <= 'z') ||
+        (byte >= '0' && byte <= '9') || byte == '-' || byte == '_' ||
+        byte == '.' || byte == '~';
+    if (unreserved) {
+      encoded.push_back(static_cast<char>(byte));
+      continue;
+    }
+    encoded.push_back('%');
+    encoded.push_back(HEX[byte >> 4]);
+    encoded.push_back(HEX[byte & 0x0F]);
+  }
+  return encoded;
+}
+
 std::string clippedDisplayText(std::string value, size_t maxBytes = 24000) {
   if (value.size() <= maxBytes) {
     return value;
@@ -7384,6 +7404,14 @@ void SubtrActorPlugin::renderLauncherWindow() {
       const std::string json = uiConfigJson();
       ImGui::SetClipboardText(json.c_str());
       cvarManager->log(std::format("subtr-actor: copied {} UI config bytes", json.size()));
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Copy layout cfg")) {
+      const std::string json = uiConfigJson();
+      const std::string cfg = std::format("#cfg={}", urlEncode(json));
+      ImGui::SetClipboardText(cfg.c_str());
+      cvarManager->log(
+          std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
     }
     ImGui::SameLine();
     if (ImGui::Button("Paste layout JSON")) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3655,9 +3655,12 @@ void SubtrActorPlugin::applyUiConfigJson(
   auto loadWindowArray = [&](const char *propertyName, bool webConfig) {
     for (const std::string &object : parseJsonObjectArrayProperty(json, propertyName)) {
       const std::string id = parseJsonStringProperty(object, "id").value_or("");
-      const auto placement = parseJsonObjectProperty(object, "placement");
+      std::optional<std::string> placement = parseJsonObjectProperty(object, "placement");
       if (!placement) {
-        continue;
+        if (!webConfig) {
+          continue;
+        }
+        placement = R"({"x":8,"y":8,"viewport":{"width":1,"height":1},"visible":true})";
       }
       for (const SingletonWindowControl &window : singletonWindowControls()) {
         if (window.web_config != webConfig || id != window.config_id) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9672,6 +9672,14 @@ void SubtrActorPlugin::renderStatsWindowManager() {
     }
   }
   ImGui::SameLine();
+  if (ImGui::SmallButton("Focus visible##stats-windows")) {
+    for (UiStatsWindow &window : uiStatsWindows) {
+      if (window.open) {
+        focusStatsWindow(window);
+      }
+    }
+  }
+  ImGui::SameLine();
   if (ImGui::SmallButton("Reset positions##stats-windows")) {
     for (size_t index = 0; index < uiStatsWindows.size(); index += 1) {
       resetStatsWindowPlacement(uiStatsWindows[index], index);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10089,9 +10089,10 @@ void SubtrActorPlugin::resetStatsWindowPlacement(UiStatsWindow &window, size_t s
 }
 
 void SubtrActorPlugin::renderStatsWindows() {
-  for (UiStatsWindow &window : uiStatsWindows) {
+  for (size_t index = 0; index < uiStatsWindows.size(); index += 1) {
+    UiStatsWindow &window = uiStatsWindows[index];
     if (window.open) {
-      renderStatsWindow(window);
+      renderStatsWindow(window, index);
     }
   }
 }
@@ -10704,7 +10705,7 @@ void SubtrActorPlugin::renderAdHocTargetSelector(
   }
 }
 
-void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window) {
+void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t stackIndex) {
   applyStatsWindowPlacement(window);
   if (window.pending_focus) {
     ImGui::SetNextWindowFocus();
@@ -10726,13 +10727,21 @@ void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window) {
         statsWindowKindLabel(window.kind));
     ImGui::SameLine();
   }
+  const std::string resetLabel = std::format("Reset##stats-window-reset-{}", window.id);
   const std::string hideLabel = std::format("Hide##stats-window-hide-{}", window.id);
+  const float buttonPadding = ImGui::GetStyle().FramePadding.x * 2.0f;
+  const float resetWidth = ImGui::CalcTextSize("Reset").x + buttonPadding;
   const float hideWidth =
-      ImGui::CalcTextSize("Hide").x + ImGui::GetStyle().FramePadding.x * 2.0f;
-  const float rightAlignedX = ImGui::GetWindowContentRegionMax().x - hideWidth;
+      ImGui::CalcTextSize("Hide").x + buttonPadding;
+  const float controlsWidth = resetWidth + ImGui::GetStyle().ItemSpacing.x + hideWidth;
+  const float rightAlignedX = ImGui::GetWindowContentRegionMax().x - controlsWidth;
   if (rightAlignedX > ImGui::GetCursorPosX()) {
     ImGui::SetCursorPosX(rightAlignedX);
   }
+  if (ImGui::SmallButton(resetLabel.c_str())) {
+    resetStatsWindowPlacement(window, stackIndex);
+  }
+  ImGui::SameLine();
   if (ImGui::SmallButton(hideLabel.c_str())) {
     window.open = false;
     ImGui::End();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8198,17 +8198,22 @@ void SubtrActorPlugin::renderEventSourceControls() {
     return;
   }
 
-  if (renderModuleSummaryToggle(
-          "All events",
-          allSelected,
-          "event-sources-actions")) {
+  auto renderEventSourceAction = [](const std::string &label) {
+    const bool clicked = ImGui::Button(label.c_str());
+    const float itemRight = ImGui::GetItemRectMax().x;
+    const float contentRight = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
+    if (contentRight - itemRight > 112.0f) {
+      ImGui::SameLine();
+    }
+    return clicked;
+  };
+
+  if (renderEventSourceAction(
+          std::format("All events   {}##event-sources-actions-all", displaySources.size()))) {
     selected = selectedEventSourceTokens("all");
     applySelection();
   }
-  if (renderModuleSummaryToggle(
-          "No events",
-          selected.empty(),
-          "event-sources-actions")) {
+  if (renderEventSourceAction("No events   Off##event-sources-actions-none")) {
     selected.clear();
     applySelection();
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -98,6 +98,15 @@ std::string joinStrings(const std::vector<std::string> &parts, std::string_view 
   return joined;
 }
 
+std::string uppercaseHeaderLabel(std::string_view value) {
+  std::string label;
+  label.reserve(value.size());
+  for (char ch : value) {
+    label.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));
+  }
+  return label;
+}
+
 void pushWebFloatingWindowStyle() {
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{14.0f, 12.0f});
   ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f);
@@ -7858,7 +7867,8 @@ void SubtrActorPlugin::captureWindowPlacement(UiWindowPlacement &placement) {
 }
 
 bool SubtrActorPlugin::renderSingletonWindowHeader(const char *label, bool &open) {
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", label);
+  const std::string headerLabel = uppercaseHeaderLabel(label);
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", headerLabel.c_str());
   ImGui::SameLine();
   const std::string hideLabel = std::format("Hide##singleton-window-hide-{}", label);
   const float hideWidth =
@@ -7867,7 +7877,10 @@ bool SubtrActorPlugin::renderSingletonWindowHeader(const char *label, bool &open
   if (rightAlignedX > ImGui::GetCursorPosX()) {
     ImGui::SetCursorPosX(rightAlignedX);
   }
-  if (ImGui::SmallButton(hideLabel.c_str())) {
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
+  const bool hideClicked = ImGui::Button(hideLabel.c_str());
+  ImGui::PopStyleVar();
+  if (hideClicked) {
     hideSingletonWindow(open);
     return true;
   }
@@ -11839,10 +11852,11 @@ void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t /*stackIn
 
   const bool scopeHeaderOnly = statsWindowKindHasScopeSelector(window.kind);
   if (!scopeHeaderOnly) {
+    const std::string headerLabel = uppercaseHeaderLabel(statsWindowKindLabel(window.kind));
     ImGui::TextColored(
         ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
         "%s",
-        statsWindowKindLabel(window.kind));
+        headerLabel.c_str());
     ImGui::SameLine();
   }
   const std::string hideLabel = std::format("Hide##stats-window-hide-{}", window.id);
@@ -11853,7 +11867,10 @@ void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t /*stackIn
   if (rightAlignedX > ImGui::GetCursorPosX()) {
     ImGui::SetCursorPosX(rightAlignedX);
   }
-  if (ImGui::SmallButton(hideLabel.c_str())) {
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
+  const bool hideClicked = ImGui::Button(hideLabel.c_str());
+  ImGui::PopStyleVar();
+  if (hideClicked) {
     hideStatsWindow(window);
     ImGui::End();
     return;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3379,8 +3379,10 @@ void SubtrActorPlugin::applyUiConfigJson(
 
     const std::vector<std::string> renderEffects =
         parseJsonStringArrayProperty(*overlays, "renderEffects");
-    if (jsonPropertyExists(*overlays, "renderEffects")) {
-      const bool anyRenderEffect = !renderEffects.empty();
+    const bool hasRenderEffects = jsonPropertyExists(*overlays, "renderEffects");
+    bool anyRenderEffect = false;
+    if (hasRenderEffects) {
+      anyRenderEffect = !renderEffects.empty();
       renderEffectCeilingShotEnabled = containsString(renderEffects, "ceiling-shot");
       renderEffectFiftyFiftyEnabled = containsString(renderEffects, "fifty-fifty");
       renderEffectPressureEnabled = containsString(renderEffects, "pressure");
@@ -3390,18 +3392,23 @@ void SubtrActorPlugin::applyUiConfigJson(
           containsString(renderEffects, "absolute-positioning");
       renderEffectSpeedFlipEnabled = containsString(renderEffects, "speed-flip");
       renderEffectTouchEnabled = containsString(renderEffects, "touch");
-      setCvarBool("subtr_actor_overlay_enabled", anyRenderEffect);
     }
     const bool hasPluginRenderEffects = jsonPropertyExists(*overlays, "pluginRenderEffects");
     std::vector<std::string> pluginRenderEffects =
         parseJsonStringArrayProperty(*overlays, "pluginRenderEffects");
-    const bool hasRenderEffects = jsonPropertyExists(*overlays, "renderEffects");
     if (!hasPluginRenderEffects && hasRenderEffects) {
       for (const char *id : {"mechanics", "team", "goal_context"}) {
         if (containsString(renderEffects, id)) {
           pluginRenderEffects.emplace_back(id);
         }
       }
+    }
+    if (const auto pluginHudOverlay = parseJsonBoolProperty(*overlays, "pluginHudOverlay")) {
+      setCvarBool("subtr_actor_overlay_enabled", *pluginHudOverlay);
+    } else if (hasPluginRenderEffects) {
+      setCvarBool("subtr_actor_overlay_enabled", anyRenderEffect || !pluginRenderEffects.empty());
+    } else if (hasRenderEffects) {
+      setCvarBool("subtr_actor_overlay_enabled", anyRenderEffect);
     }
     if (hasPluginRenderEffects || hasRenderEffects) {
       setCvarBool(
@@ -4096,6 +4103,7 @@ std::string SubtrActorPlugin::uiConfigJson() {
   writeOverlayId("team", cvarBool("subtr_actor_overlay_team_events_enabled", true));
   writeOverlayId("goal_context", cvarBool("subtr_actor_overlay_goal_context_enabled", true));
   file << "],\n";
+  file << "    \"pluginHudOverlay\": " << (hudOverlayEnabled ? "true" : "false") << ",\n";
   file << "    \"followedPlayerHud\": false,\n";
   file << "    \"boostPads\": "
        << (boostPickupPadBig || boostPickupPadSmall || boostPickupPadAmbiguous ? "true" : "false")

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -12125,7 +12125,12 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
            event.type == "air_dribble_goal" || event.type == "flip_reset_goal" ||
            event.type == "half_volley_goal";
   };
-  auto goalTagText = [](const UiEventRecord &event) {
+  struct GoalTagChip {
+    std::string label;
+    float confidence = 1.0f;
+    std::string text;
+  };
+  auto goalTagChip = [](const UiEventRecord &event) {
     std::string label = event.label;
     if (!event.actor.empty()) {
       const std::string actorPrefix = event.actor + " ";
@@ -12135,6 +12140,7 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
     }
 
     std::string confidence = "100%";
+    float confidenceValue = 1.0f;
     const size_t parenthesizedConfidence = label.rfind(" (");
     if (parenthesizedConfidence != std::string::npos && !label.empty() &&
         label.back() == ')' &&
@@ -12148,11 +12154,16 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
       const size_t start = event.details.rfind(' ', percent);
       confidence = event.details.substr(start == std::string::npos ? 0 : start + 1, percent + 1);
     }
+    try {
+      confidenceValue = std::clamp(std::stof(confidence) / 100.0f, 0.0f, 1.0f);
+    } catch (const std::exception &) {
+      confidenceValue = 1.0f;
+    }
 
-    return std::format("{} {}", label, confidence);
+    return GoalTagChip{label, confidenceValue, std::format("{} {}", label, confidence)};
   };
   auto goalTagsForEvent = [&](const UiEventRecord &goalEvent) {
-    std::vector<std::string> tags;
+    std::vector<GoalTagChip> tags;
     for (const UiEventRecord &candidate : recentUiEvents) {
       if (!isGoalTagEvent(candidate)) {
         continue;
@@ -12162,12 +12173,22 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
       const bool sameFrame = candidate.frame_number == goalEvent.frame_number;
       const bool nearbyTime = std::fabs(candidate.time - goalEvent.time) <= 0.25f;
       if (samePlayer && (sameFrame || nearbyTime)) {
-        tags.push_back(goalTagText(candidate));
+        tags.push_back(goalTagChip(candidate));
       }
     }
-    std::sort(tags.begin(), tags.end());
-    tags.erase(std::unique(tags.begin(), tags.end()), tags.end());
-    return tags;
+    std::sort(tags.begin(), tags.end(), [](const GoalTagChip &left, const GoalTagChip &right) {
+      if (left.label == right.label) {
+        return left.confidence > right.confidence;
+      }
+      return left.label < right.label;
+    });
+    std::vector<std::string> tagTexts;
+    for (const GoalTagChip &tag : tags) {
+      if (!containsString(tagTexts, tag.text)) {
+        tagTexts.push_back(tag.text);
+      }
+    }
+    return tagTexts;
   };
 
   std::vector<size_t> goalEventIndexes;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7783,7 +7783,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   renderSingletonWindowManager();
 
   ImGui::Separator();
-  renderStatsWindowCreationControls("launcher-stats-windows", true);
+  renderStatsWindowCreationControls("launcher-stats-windows", false);
 
   ImGui::Separator();
   renderLauncherWorkspaceControls();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8671,6 +8671,14 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
   }
   const std::string activeEventKey =
       activeEventIndex ? mechanicsReviewKey(recentUiEvents[*activeEventIndex]) : "";
+  auto sourceLabelForEvent = [&](const UiEventRecord &event) -> std::string {
+    for (const PlaylistSource &source : playlistSources) {
+      if (source.enabled && eventFilterAllows(source.option->value, event.category, event.type)) {
+        return source.option->label;
+      }
+    }
+    return event.type;
+  };
 
   ImGui::BeginChild("event-playlist-list", ImVec2{0.0f, 0.0f}, true);
   for (const size_t index : playlistEventIndexes) {
@@ -8704,8 +8712,9 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     if (event.frame_number != 0) {
       metaParts.push_back(std::format("frame {}", event.frame_number));
     }
-    if (!event.type.empty()) {
-      metaParts.push_back(event.type);
+    const std::string sourceLabel = sourceLabelForEvent(event);
+    if (!sourceLabel.empty()) {
+      metaParts.push_back(sourceLabel);
     }
     if (!metaParts.empty()) {
       ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -2649,28 +2649,10 @@ void SubtrActorPlugin::applyUiConfigJson(
     loadPlacementObject(*object, out, visible);
   };
 
-  uiScoreboardOpen = parseJsonBoolProperty(json, "scoreboard_open").value_or(uiScoreboardOpen);
-  uiEventsOpen = parseJsonBoolProperty(json, "events_open").value_or(uiEventsOpen);
-  uiStatusOpen = parseJsonBoolProperty(json, "status_open").value_or(uiStatusOpen);
-  uiCameraOpen = parseJsonBoolProperty(json, "camera_open").value_or(uiCameraOpen);
-  uiPlaybackControlsOpen =
-      parseJsonBoolProperty(json, "playback_controls_open").value_or(uiPlaybackControlsOpen);
-  uiRecordingOpen =
-      parseJsonBoolProperty(json, "recording_open").value_or(uiRecordingOpen);
-  uiGraphInspectorOpen =
-      parseJsonBoolProperty(json, "graph_inspector_open").value_or(uiGraphInspectorOpen);
-  uiEventPlaylistOpen =
-      parseJsonBoolProperty(json, "event_playlist_open").value_or(uiEventPlaylistOpen);
-  uiMechanicsReviewOpen =
-      parseJsonBoolProperty(json, "mechanics_review_open").value_or(uiMechanicsReviewOpen);
-  uiReplayLoadingOpen =
-      parseJsonBoolProperty(json, "replay_loading_open").value_or(uiReplayLoadingOpen);
-  uiModuleControlsOpen =
-      parseJsonBoolProperty(json, "module_controls_open").value_or(uiModuleControlsOpen);
-  uiTouchControlsOpen =
-      parseJsonBoolProperty(json, "touch_controls_open").value_or(uiTouchControlsOpen);
-  uiBoostPickupControlsOpen =
-      parseJsonBoolProperty(json, "boost_pickup_controls_open").value_or(uiBoostPickupControlsOpen);
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    *window.open =
+        parseJsonBoolProperty(json, window.legacy_open_key).value_or(*window.open);
+  }
   eventPlaylistMechanicsEnabled = parseJsonBoolProperty(json, "event_playlist_mechanics_enabled")
                                       .value_or(eventPlaylistMechanicsEnabled);
   eventPlaylistTeamEventsEnabled = parseJsonBoolProperty(json, "event_playlist_team_enabled")
@@ -3052,31 +3034,9 @@ void SubtrActorPlugin::applyUiConfigJson(
       parseJsonStringProperty(json, "graph_inspector_node_query").value_or("");
 
   if (const auto placements = parseJsonObjectProperty(json, "placements")) {
-    loadPlacement(*placements, "scoreboard", scoreboardPlacement, &uiScoreboardOpen);
-    loadPlacement(*placements, "events", eventsPlacement, &uiEventsOpen);
-    loadPlacement(*placements, "status", statusPlacement, &uiStatusOpen);
-    loadPlacement(*placements, "camera", cameraPlacement, &uiCameraOpen);
-    loadPlacement(
-        *placements,
-        "playback_controls",
-        playbackControlsPlacement,
-        &uiPlaybackControlsOpen);
-    loadPlacement(*placements, "recording", recordingPlacement, &uiRecordingOpen);
-    loadPlacement(*placements, "graph_inspector", graphInspectorPlacement, &uiGraphInspectorOpen);
-    loadPlacement(*placements, "event_playlist", eventPlaylistPlacement, &uiEventPlaylistOpen);
-    loadPlacement(
-        *placements,
-        "mechanics_review",
-        mechanicsReviewPlacement,
-        &uiMechanicsReviewOpen);
-    loadPlacement(*placements, "replay_loading", replayLoadingPlacement, &uiReplayLoadingOpen);
-    loadPlacement(*placements, "module_controls", moduleControlsPlacement, &uiModuleControlsOpen);
-    loadPlacement(*placements, "touch_controls", touchControlsPlacement, &uiTouchControlsOpen);
-    loadPlacement(
-        *placements,
-        "boost_pickup_controls",
-        boostPickupControlsPlacement,
-        &uiBoostPickupControlsOpen);
+    for (const SingletonWindowControl &window : singletonWindowControls()) {
+      loadPlacement(*placements, window.legacy_placement_key, *window.placement, window.open);
+    }
   }
   auto loadWindowArray = [&](const char *propertyName, bool webConfig) {
     for (const std::string &object : parseJsonObjectArrayProperty(json, propertyName)) {
@@ -3273,27 +3233,11 @@ std::string SubtrActorPlugin::uiConfigJson() {
   std::ostringstream file;
   file << "{\n";
   file << "  \"version\": 1,\n";
-  file << "  \"scoreboard_open\": " << (uiScoreboardOpen ? "true" : "false") << ",\n";
-  file << "  \"events_open\": " << (uiEventsOpen ? "true" : "false") << ",\n";
-  file << "  \"status_open\": " << (uiStatusOpen ? "true" : "false") << ",\n";
-  file << "  \"camera_open\": " << (uiCameraOpen ? "true" : "false") << ",\n";
-  file << "  \"playback_controls_open\": "
-       << (uiPlaybackControlsOpen ? "true" : "false") << ",\n";
-  file << "  \"recording_open\": " << (uiRecordingOpen ? "true" : "false") << ",\n";
-  file << "  \"graph_inspector_open\": " << (uiGraphInspectorOpen ? "true" : "false")
-       << ",\n";
-  file << "  \"event_playlist_open\": " << (uiEventPlaylistOpen ? "true" : "false")
-       << ",\n";
-  file << "  \"mechanics_review_open\": " << (uiMechanicsReviewOpen ? "true" : "false")
-       << ",\n";
-  file << "  \"replay_loading_open\": " << (uiReplayLoadingOpen ? "true" : "false")
-       << ",\n";
-  file << "  \"module_controls_open\": " << (uiModuleControlsOpen ? "true" : "false")
-       << ",\n";
-  file << "  \"touch_controls_open\": " << (uiTouchControlsOpen ? "true" : "false")
-       << ",\n";
-  file << "  \"boost_pickup_controls_open\": "
-       << (uiBoostPickupControlsOpen ? "true" : "false") << ",\n";
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    const bool visible = window.open != nullptr && *window.open;
+    file << "  \"" << window.legacy_open_key << "\": "
+         << (visible ? "true" : "false") << ",\n";
+  }
   file << "  \"event_playlist_mechanics_enabled\": "
        << (eventPlaylistMechanicsEnabled ? "true" : "false") << ",\n";
   file << "  \"event_playlist_team_enabled\": "
@@ -3550,33 +3494,18 @@ std::string SubtrActorPlugin::uiConfigJson() {
   file << "  \"graph_inspector_node_query\": \""
        << escapeJsonString(graphInspectorNodeQuery) << "\",\n";
   file << "  \"placements\": {\n";
-  file << "    \"scoreboard\": ";
-  writePlacement(file, scoreboardPlacement, uiScoreboardOpen);
-  file << ",\n    \"events\": ";
-  writePlacement(file, eventsPlacement, uiEventsOpen);
-  file << ",\n    \"status\": ";
-  writePlacement(file, statusPlacement, uiStatusOpen);
-  file << ",\n    \"camera\": ";
-  writePlacement(file, cameraPlacement, uiCameraOpen);
-  file << ",\n    \"playback_controls\": ";
-  writePlacement(file, playbackControlsPlacement, uiPlaybackControlsOpen);
-  file << ",\n    \"recording\": ";
-  writePlacement(file, recordingPlacement, uiRecordingOpen);
-  file << ",\n    \"graph_inspector\": ";
-  writePlacement(file, graphInspectorPlacement, uiGraphInspectorOpen);
-  file << ",\n    \"event_playlist\": ";
-  writePlacement(file, eventPlaylistPlacement, uiEventPlaylistOpen);
-  file << ",\n    \"mechanics_review\": ";
-  writePlacement(file, mechanicsReviewPlacement, uiMechanicsReviewOpen);
-  file << ",\n    \"replay_loading\": ";
-  writePlacement(file, replayLoadingPlacement, uiReplayLoadingOpen);
-  file << ",\n    \"module_controls\": ";
-  writePlacement(file, moduleControlsPlacement, uiModuleControlsOpen);
-  file << ",\n    \"touch_controls\": ";
-  writePlacement(file, touchControlsPlacement, uiTouchControlsOpen);
-  file << ",\n    \"boost_pickup_controls\": ";
-  writePlacement(file, boostPickupControlsPlacement, uiBoostPickupControlsOpen);
-  file << "\n  },\n";
+  const std::array<SingletonWindowControl, 13> singletonWindows = singletonWindowControls();
+  for (size_t index = 0; index < singletonWindows.size(); index += 1) {
+    const SingletonWindowControl &window = singletonWindows[index];
+    const bool visible = window.open != nullptr && *window.open;
+    file << "    \"" << window.legacy_placement_key << "\": ";
+    writePlacement(file, *window.placement, visible);
+    if (index + 1 != singletonWindows.size()) {
+      file << ",";
+    }
+    file << "\n";
+  }
+  file << "  },\n";
   file << "  \"singletonWindows\": [\n";
   auto writeWindowConfig = [&](const SingletonWindowControl &window, bool last) {
     const bool visible = window.open != nullptr && *window.open;
@@ -8900,6 +8829,8 @@ SubtrActorPlugin::singletonWindowControls() {
   return {{
       {"Scoreboard",
        "scoreboard",
+       "scoreboard_open",
+       "scoreboard",
        true,
        &uiScoreboardOpen,
        &scoreboardPlacement,
@@ -8907,9 +8838,21 @@ SubtrActorPlugin::singletonWindowControls() {
        11.0f,
        88.0f,
        34.0f},
-      {"Events", "mechanics", true, &uiEventsOpen, &eventsPlacement, 16.0f, 256.0f, 520.0f, 360.0f},
+      {"Events",
+       "mechanics",
+       "events_open",
+       "events",
+       true,
+       &uiEventsOpen,
+       &eventsPlacement,
+       16.0f,
+       256.0f,
+       520.0f,
+       360.0f},
       {"Event playlist",
        "event-playlist",
+       "event_playlist_open",
+       "event_playlist",
        true,
        &uiEventPlaylistOpen,
        &eventPlaylistPlacement,
@@ -8917,10 +8860,32 @@ SubtrActorPlugin::singletonWindowControls() {
        256.0f,
        430.0f,
        430.0f},
-      {"Status", "status", false, &uiStatusOpen, &statusPlacement, statusX, 68.0f, 330.0f, 220.0f},
-      {"Camera", "camera", true, &uiCameraOpen, &cameraPlacement, 16.0f, 68.0f, 416.0f, 500.0f},
+      {"Status",
+       "status",
+       "status_open",
+       "status",
+       false,
+       &uiStatusOpen,
+       &statusPlacement,
+       statusX,
+       68.0f,
+       330.0f,
+       220.0f},
+      {"Camera",
+       "camera",
+       "camera_open",
+       "camera",
+       true,
+       &uiCameraOpen,
+       &cameraPlacement,
+       16.0f,
+       68.0f,
+       416.0f,
+       500.0f},
       {"Playback",
        "playback",
+       "playback_controls_open",
+       "playback_controls",
        true,
        &uiPlaybackControlsOpen,
        &playbackControlsPlacement,
@@ -8929,6 +8894,8 @@ SubtrActorPlugin::singletonWindowControls() {
        336.0f,
        430.0f},
       {"Recording",
+       "recording",
+       "recording_open",
        "recording",
        true,
        &uiRecordingOpen,
@@ -8939,6 +8906,8 @@ SubtrActorPlugin::singletonWindowControls() {
        380.0f},
       {"Graph inspector",
        "graph-inspector",
+       "graph_inspector_open",
+       "graph_inspector",
        false,
        &uiGraphInspectorOpen,
        &graphInspectorPlacement,
@@ -8948,6 +8917,8 @@ SubtrActorPlugin::singletonWindowControls() {
        520.0f},
       {"Mechanics review",
        "mechanics-review",
+       "mechanics_review_open",
+       "mechanics_review",
        true,
        &uiMechanicsReviewOpen,
        &mechanicsReviewPlacement,
@@ -8957,6 +8928,8 @@ SubtrActorPlugin::singletonWindowControls() {
        560.0f},
       {"Replay loading",
        "replay-loading",
+       "replay_loading_open",
+       "replay_loading",
        true,
        &uiReplayLoadingOpen,
        &replayLoadingPlacement,
@@ -8966,6 +8939,8 @@ SubtrActorPlugin::singletonWindowControls() {
        360.0f},
       {"Module controls",
        "module-controls",
+       "module_controls_open",
+       "module_controls",
        false,
        &uiModuleControlsOpen,
        &moduleControlsPlacement,
@@ -8975,6 +8950,8 @@ SubtrActorPlugin::singletonWindowControls() {
        520.0f},
       {"Touch controls",
        "touch-controls",
+       "touch_controls_open",
+       "touch_controls",
        true,
        &uiTouchControlsOpen,
        &touchControlsPlacement,
@@ -8984,6 +8961,8 @@ SubtrActorPlugin::singletonWindowControls() {
        380.0f},
       {"Boost pickup filters",
        "boost-pickups",
+       "boost_pickup_controls_open",
+       "boost_pickup_controls",
        true,
        &uiBoostPickupControlsOpen,
        &boostPickupControlsPlacement,

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10852,7 +10852,13 @@ void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {
     return;
   }
 
-  if (window.entries.empty()) {
+  const bool hasSupportedEntries = std::any_of(
+      window.entries.begin(),
+      window.entries.end(),
+      [&](const UiStatsWindow::Entry &entry) {
+        return statsWindowSupportsStat(window, entry.stat_id);
+      });
+  if (!hasSupportedEntries) {
     ImGui::Text("No stats added.");
     return;
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10008,10 +10008,24 @@ void SubtrActorPlugin::renderCameraWindow() {
     }
   }
 
+  const float cameraPresetGap = ImGui::GetStyle().ItemSpacing.x;
+  const float cameraPresetWidth =
+      std::max(96.0f, (ImGui::GetContentRegionAvail().x - cameraPresetGap) * 0.5f);
   auto cameraViewButton = [&](const char *label, int mode, bool disabled) {
-    int nextMode = cameraViewMode;
+    const bool active = cameraViewMode == mode;
     pushCameraDisabledStyle(disabled);
-    const bool clicked = ImGui::RadioButton(label, &nextMode, mode);
+    if (active) {
+      ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
+      ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{0.56f, 0.77f, 1.0f, 0.42f});
+      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.13f, 0.28f, 0.42f, 0.96f});
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.16f, 0.34f, 0.52f, 0.98f});
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.18f, 0.38f, 0.58f, 1.0f});
+    }
+    const bool clicked = ImGui::Button(label, ImVec2{cameraPresetWidth, 0.0f});
+    if (active) {
+      ImGui::PopStyleColor(4);
+      ImGui::PopStyleVar();
+    }
     popCameraDisabledStyle(disabled);
     return clicked && !disabled;
   };
@@ -10021,18 +10035,17 @@ void SubtrActorPlugin::renderCameraWindow() {
     cameraFreePreset = -1;
     scheduleUiConfigAutosave();
   }
-  ImGui::SameLine();
+  ImGui::SameLine(0.0f, cameraPresetGap);
   if (cameraViewButton("Follow##camera-view", 1, !hasCameraContext || selectedPlayer == nullptr)) {
     cameraViewMode = 1;
     cameraFreePreset = -1;
     scheduleUiConfigAutosave();
   }
-  ImGui::SameLine();
   if (cameraViewButton("Overhead##camera-view", 2, !hasCameraContext)) {
     cameraViewMode = 2;
     scheduleUiConfigAutosave();
   }
-  ImGui::SameLine();
+  ImGui::SameLine(0.0f, cameraPresetGap);
   if (cameraViewButton("Diagonal##camera-view", 3, !hasCameraContext)) {
     cameraViewMode = 3;
     scheduleUiConfigAutosave();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1651,6 +1651,8 @@ std::string replayStatsModuleFrameJson(
   bool firstPlayer = true;
   for (const std::string &player : parseJsonObjectArrayProperty(frameJson, "players")) {
     const auto playerId = parseJsonPropertyValue(player, "player_id");
+    const auto playerName = parseJsonPropertyValue(player, "name");
+    const auto isTeam0 = parseJsonPropertyValue(player, "is_team_0");
     const auto stats = parseJsonObjectProperty(player, moduleName);
     if (!playerId || !stats) {
       continue;
@@ -1661,6 +1663,14 @@ std::string replayStatsModuleFrameJson(
     firstPlayer = false;
     json += "{\"player_id\":";
     json += *playerId;
+    if (playerName) {
+      json += ",\"name\":";
+      json += *playerName;
+    }
+    if (isTeam0) {
+      json += ",\"is_team_0\":";
+      json += *isTeam0;
+    }
     json += ",\"stats\":";
     json += *stats;
     json += "}";
@@ -12110,18 +12120,76 @@ void SubtrActorPlugin::renderAdHocStatsWindow(UiStatsWindow &window) {
   }
 }
 
-void SubtrActorPlugin::renderJsonSummary(const std::string &json) {
-  auto renderFields = [](const char *tableId, const std::vector<JsonFieldSummary> &fields) {
-    ImGui::Columns(2, tableId, false);
-    for (const JsonFieldSummary &field : fields) {
-      ImGui::TextWrapped("%s", field.label.c_str());
-      ImGui::NextColumn();
-      ImGui::TextWrapped("%s", field.value.c_str());
-      ImGui::NextColumn();
+void renderJsonFieldTable(const char *tableId, const std::vector<JsonFieldSummary> &fields) {
+  ImGui::Columns(2, tableId, false);
+  for (const JsonFieldSummary &field : fields) {
+    ImGui::TextWrapped("%s", field.label.c_str());
+    ImGui::NextColumn();
+    ImGui::TextWrapped("%s", field.value.c_str());
+    ImGui::NextColumn();
+  }
+  ImGui::Columns(1);
+}
+
+void renderStatsModuleFrameOverview(const std::string &json, const std::string &id) {
+  bool renderedAny = false;
+  auto renderSnapshot = [&](const char *heading,
+                            const char *propertyName,
+                            const ImVec4 &color,
+                            size_t maxFields) {
+    const auto object = parseJsonObjectProperty(json, propertyName);
+    if (!object) {
+      return;
     }
-    ImGui::Columns(1);
+    std::vector<JsonFieldSummary> fields;
+    collectJsonFieldSummaries(*object, "", fields, maxFields, 2);
+    if (fields.empty()) {
+      return;
+    }
+    renderedAny = true;
+    ImGui::TextColored(color, "%s", heading);
+    renderJsonFieldTable(std::format("{}-{}-fields", id, propertyName).c_str(), fields);
+    ImGui::Spacing();
   };
 
+  renderSnapshot("Blue team", "team_zero", ImVec4{0.31f, 0.74f, 1.0f, 1.0f}, 14);
+  renderSnapshot("Orange team", "team_one", ImVec4{1.0f, 0.69f, 0.31f, 1.0f}, 14);
+
+  const std::vector<std::string> playerStats = parseJsonObjectArrayProperty(json, "player_stats");
+  if (!playerStats.empty()) {
+    renderedAny = true;
+    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Players");
+    for (size_t index = 0; index < playerStats.size(); index += 1) {
+      const std::string &player = playerStats[index];
+      const auto stats = parseJsonObjectProperty(player, "stats");
+      if (!stats) {
+        continue;
+      }
+      std::vector<JsonFieldSummary> fields;
+      collectJsonFieldSummaries(*stats, "", fields, 12, 2);
+      if (fields.empty()) {
+        continue;
+      }
+
+      std::string label =
+          parseJsonStringProperty(player, "name").value_or(std::format("Player {}", index + 1));
+      const std::optional<bool> isTeam0 = parseJsonBoolProperty(player, "is_team_0");
+      const ImVec4 color = isTeam0.value_or(true) ? ImVec4{0.31f, 0.74f, 1.0f, 1.0f}
+                                                  : ImVec4{1.0f, 0.69f, 0.31f, 1.0f};
+      ImGui::PushID(static_cast<int>(index));
+      ImGui::TextColored(color, "%s", label.c_str());
+      renderJsonFieldTable("player-module-fields", fields);
+      ImGui::Spacing();
+      ImGui::PopID();
+    }
+  }
+
+  if (!renderedAny) {
+    ImGui::TextWrapped("No team or player module frame fields are available.");
+  }
+}
+
+void SubtrActorPlugin::renderJsonSummary(const std::string &json) {
   bool renderedAny = false;
   auto renderObjectSection = [&](const char *label, const char *propertyName, size_t maxFields) {
     const auto object = parseJsonObjectProperty(json, propertyName);
@@ -12135,7 +12203,7 @@ void SubtrActorPlugin::renderJsonSummary(const std::string &json) {
       if (fields.empty()) {
         ImGui::Text("No scalar fields.");
       } else {
-        renderFields(std::format("{}-fields", propertyName).c_str(), fields);
+        renderJsonFieldTable(std::format("{}-fields", propertyName).c_str(), fields);
       }
       ImGui::TreePop();
     }
@@ -12160,7 +12228,7 @@ void SubtrActorPlugin::renderJsonSummary(const std::string &json) {
   if (!counts.empty()) {
     renderedAny = true;
     if (ImGui::TreeNode("Event collections")) {
-      renderFields("module-event-counts", counts);
+      renderJsonFieldTable("module-event-counts", counts);
       ImGui::TreePop();
     }
   }
@@ -12183,7 +12251,7 @@ void SubtrActorPlugin::renderJsonSummary(const std::string &json) {
           if (stats) {
             std::vector<JsonFieldSummary> fields;
             collectJsonFieldSummaries(*stats, "", fields, 18, 2);
-            renderFields("player-stats-fields", fields);
+            renderJsonFieldTable("player-stats-fields", fields);
           } else {
             ImGui::Text("No stats object.");
           }
@@ -12201,7 +12269,7 @@ void SubtrActorPlugin::renderJsonSummary(const std::string &json) {
     if (fields.empty()) {
       ImGui::TextWrapped("No structured summary is available for this JSON shape.");
     } else {
-      renderFields("module-top-level-fields", fields);
+      renderJsonFieldTable("module-top-level-fields", fields);
     }
   }
 }
@@ -12295,6 +12363,10 @@ void SubtrActorPlugin::renderStatsModuleWindow(UiStatsWindow &window) {
     ImGui::SetClipboardText(json.c_str());
   }
 
+  if (window.module_view == 0) {
+    renderStatsModuleFrameOverview(json, std::format("module-frame-{}", window.id));
+    ImGui::Separator();
+  }
   renderJsonSummary(json);
   ImGui::Separator();
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3670,8 +3670,6 @@ void SubtrActorPlugin::applyUiConfigJson(
           .value_or(mechanicsReviewClipTrailSeconds),
       0.0,
       10.0));
-  mechanicsReviewStatus =
-      parseJsonStringProperty(json, "mechanics_review_status").value_or(mechanicsReviewStatus);
   selectedGraphOutput = parseJsonStringProperty(json, "selected_graph_output").value_or("");
   selectedAnalysisNode = parseJsonStringProperty(json, "selected_analysis_node").value_or("");
   graphInspectorNodeQuery =
@@ -4220,8 +4218,6 @@ std::string SubtrActorPlugin::uiConfigJson() {
   file << "  \"mechanics_review_index\": " << mechanicsReviewIndex << ",\n";
   file << "  \"mechanics_review_clip_lead_seconds\": " << mechanicsReviewClipLeadSeconds << ",\n";
   file << "  \"mechanics_review_clip_trail_seconds\": " << mechanicsReviewClipTrailSeconds << ",\n";
-  file << "  \"mechanics_review_status\": \"" << escapeJsonString(mechanicsReviewStatus)
-       << "\",\n";
   file << "  \"selected_graph_output\": \"" << escapeJsonString(selectedGraphOutput)
        << "\",\n";
   file << "  \"selected_analysis_node\": \"" << escapeJsonString(selectedAnalysisNode)

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11987,8 +11987,10 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
 }
 
 void renderStatsWindowEmpty(std::string_view message) {
-  ImGui::Spacing();
-  ImGui::TextDisabled("%s", std::string{message}.c_str());
+  const std::string messageString{message};
+  ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{0.62f, 0.71f, 0.78f, 1.0f});
+  ImGui::TextWrapped("%s", messageString.c_str());
+  ImGui::PopStyleColor();
 }
 
 void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3362,6 +3362,9 @@ void SubtrActorPlugin::applyUiConfigJson(
           .value_or(eventPlaylistGoalContextEnabled);
   eventPlaylistAutoFollow =
       parseJsonBoolProperty(json, "event_playlist_auto_follow").value_or(eventPlaylistAutoFollow);
+  eventPlaylistSourceFilter =
+      parseJsonStringProperty(json, "event_playlist_source_filter")
+          .value_or(eventPlaylistSourceFilter);
   if (const auto overlays = parseJsonObjectProperty(json, "overlays")) {
     const std::vector<std::string> timelineEvents =
         parseJsonStringArrayProperty(*overlays, "timelineEvents");
@@ -4058,6 +4061,8 @@ std::string SubtrActorPlugin::uiConfigJson() {
        << (eventPlaylistGoalContextEnabled ? "true" : "false") << ",\n";
   file << "  \"event_playlist_auto_follow\": "
        << (eventPlaylistAutoFollow ? "true" : "false") << ",\n";
+  file << "  \"event_playlist_source_filter\": \""
+       << escapeJsonString(eventPlaylistSourceFilter) << "\",\n";
   file << "  \"overlays\": {\n";
   const std::string currentEventFilter = cvarString("subtr_actor_overlay_event_types", "all");
   const std::vector<std::string> currentEventFilterTokens =
@@ -8355,16 +8360,7 @@ void SubtrActorPlugin::renderEventSourceControls() {
 }
 
 bool SubtrActorPlugin::eventPlaylistSourceEnabled(const UiEventRecord &event) const {
-  if (event.category == "mechanics") {
-    return eventPlaylistMechanicsEnabled;
-  }
-  if (event.category == "team") {
-    return eventPlaylistTeamEventsEnabled;
-  }
-  if (event.category == "goal_context" || event.type == "goal") {
-    return eventPlaylistGoalContextEnabled;
-  }
-  return true;
+  return eventFilterAllows(eventPlaylistSourceFilter, event.category, event.type);
 }
 
 std::string SubtrActorPlugin::mechanicsReviewKey(const UiEventRecord &event) const {
@@ -8412,7 +8408,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     return;
   }
 
-  const std::string currentFilter = cvarString("subtr_actor_overlay_event_types", "all");
+  const std::string currentFilter = eventPlaylistSourceFilter;
   const bool allEventSourcesEnabled = allEventSourcesSelected(currentFilter);
   std::vector<std::string> selectedSources = selectedEventSourceTokens(currentFilter);
 
@@ -8424,20 +8420,6 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
       }
     }
     return false;
-  };
-  auto enableMatchingPlaylistGroups = [&](std::string_view source) {
-    for (const UiEventRecord &event : recentUiEvents) {
-      if (!eventFilterAllows(source, event.category, event.type)) {
-        continue;
-      }
-      if (event.category == "mechanics") {
-        eventPlaylistMechanicsEnabled = true;
-      } else if (event.category == "team") {
-        eventPlaylistTeamEventsEnabled = true;
-      } else if (event.category == "goal_context" || event.type == "goal") {
-        eventPlaylistGoalContextEnabled = true;
-      }
-    }
   };
 
   struct PlaylistSource {
@@ -8475,7 +8457,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
   playlistEventIndexes.reserve(recentUiEvents.size());
   for (size_t index = 0; index < recentUiEvents.size(); index += 1) {
     const UiEventRecord &event = recentUiEvents[index];
-    if (eventPlaylistSourceEnabled(event) && uiEventVisible(event)) {
+    if (eventPlaylistSourceEnabled(event)) {
       playlistEventIndexes.push_back(index);
     }
   }
@@ -8514,17 +8496,13 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
 
   if (filtersOpen) {
     if (ImGui::Button("All##event-playlist-sources-all")) {
-      eventPlaylistMechanicsEnabled = true;
-      eventPlaylistTeamEventsEnabled = true;
-      eventPlaylistGoalContextEnabled = true;
-      setCvarString("subtr_actor_overlay_event_types", "all");
+      eventPlaylistSourceFilter = "all";
+      scheduleUiConfigAutosave();
     }
     ImGui::SameLine();
     if (ImGui::Button("None##event-playlist-sources-none")) {
-      eventPlaylistMechanicsEnabled = false;
-      eventPlaylistTeamEventsEnabled = false;
-      eventPlaylistGoalContextEnabled = false;
-      setCvarString("subtr_actor_overlay_event_types", "none");
+      eventPlaylistSourceFilter = "none";
+      scheduleUiConfigAutosave();
     }
 
     ImGui::BeginChild("event-playlist-source-list", ImVec2{0.0f, 170.0f}, true);
@@ -8550,11 +8528,9 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
               selectedSources.end());
         } else {
           appendUniqueFilterToken(selectedSources, option.value);
-          enableMatchingPlaylistGroups(option.value);
         }
-        setCvarString(
-            "subtr_actor_overlay_event_types",
-            eventFilterFromSelectedSources(selectedSources));
+        eventPlaylistSourceFilter = eventFilterFromSelectedSources(selectedSources);
+        scheduleUiConfigAutosave();
       }
       ImGui::PopID();
     }
@@ -10416,6 +10392,7 @@ void SubtrActorPlugin::applyReplayReviewUiWorkspace() {
   eventPlaylistTeamEventsEnabled = true;
   eventPlaylistGoalContextEnabled = true;
   eventPlaylistAutoFollow = true;
+  eventPlaylistSourceFilter = "all";
   resetWindowPlacements();
   mechanicsReviewPlacement.pending_focus = true;
   replayLoadingPlacement.pending_focus = true;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10055,9 +10055,9 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
       ImGui::PopStyleVar();
     }
   };
-  auto playbackButton = [&](const char *label, bool disabled) {
+  auto playbackButton = [&](const char *label, bool disabled, float width) {
     pushPlaybackDisabledStyle(disabled);
-    const bool clicked = ImGui::Button(label);
+    const bool clicked = ImGui::Button(label, ImVec2{width, 0.0f});
     popPlaybackDisabledStyle(disabled);
     return clicked && !disabled;
   };
@@ -10086,10 +10086,17 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
 
   playbackCurrentTime = std::max(0.0f, playbackCurrentTime);
 
-  if (playbackButton(playbackPlaying ? "Pause" : "Play", !transportEnabled)) {
+  const float playbackTransportWidth = ImGui::GetContentRegionAvail().x;
+  const float playbackTransportGap = ImGui::GetStyle().ItemSpacing.x;
+  const float playbackTransportItemWidth =
+      std::max(72.0f, (playbackTransportWidth - playbackTransportGap) * 0.5f);
+  if (playbackButton(
+          playbackPlaying ? "Pause" : "Play",
+          !transportEnabled,
+          playbackTransportItemWidth)) {
     applyPlaybackState(!playbackPlaying);
   }
-  ImGui::SameLine();
+  ImGui::SameLine(0.0f, playbackTransportGap);
   constexpr std::array<const char *, 5> playbackRateLabels{{"0.25x", "0.5x", "1.0x", "1.5x", "2.0x"}};
   constexpr std::array<float, 5> playbackRateValues{{0.25f, 0.5f, 1.0f, 1.5f, 2.0f}};
   size_t playbackRateIndex = 2;
@@ -10103,7 +10110,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   }
   const bool playbackRateDisabled = !transportEnabled;
   pushPlaybackDisabledStyle(playbackRateDisabled);
-  ImGui::SetNextItemWidth(96.0f);
+  ImGui::SetNextItemWidth(playbackTransportItemWidth);
   const bool playbackRateOpen =
       ImGui::BeginCombo("##playback-rate", playbackRateLabels[playbackRateIndex]);
   popPlaybackDisabledStyle(playbackRateDisabled);
@@ -10235,42 +10242,47 @@ void SubtrActorPlugin::renderRecordingWindow() {
       ImGui::PopStyleVar();
     }
   };
-  auto recordingButton = [](const char *label, bool disabled) {
+  auto recordingButton = [](const char *label, bool disabled, float width) {
     if (disabled) {
       ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.45f);
     }
-    const bool clicked = ImGui::Button(label);
+    const bool clicked = ImGui::Button(label, ImVec2{width, 0.0f});
     if (disabled) {
       ImGui::PopStyleVar();
     }
     return clicked && !disabled;
   };
 
-  ImGui::TextDisabled("FPS");
-  ImGui::SameLine();
+  const float recordingControlGap = ImGui::GetStyle().ItemSpacing.x;
+  const float recordingControlWidth =
+      std::max(96.0f, (ImGui::GetContentRegionAvail().x - recordingControlGap) * 0.5f);
   int nextRecordingFps = recordingFps;
+  ImGui::BeginGroup();
+  ImGui::TextDisabled("FPS");
   pushRecordingDisabledStyle(recordingSettingsLocked);
-  ImGui::SetNextItemWidth(88.0f);
-  const bool fpsChanged = ImGui::InputInt(
-      "##recording-fps",
-      &nextRecordingFps,
-      1,
-      10,
-      recordingSettingsLocked ? ImGuiInputTextFlags_ReadOnly : 0);
+  ImGui::SetNextItemWidth(recordingControlWidth);
+  const bool fpsChanged =
+      ImGui::InputInt(
+          "##recording-fps",
+          &nextRecordingFps,
+          1,
+          10,
+          recordingSettingsLocked ? ImGuiInputTextFlags_ReadOnly : 0);
   popRecordingDisabledStyle(recordingSettingsLocked);
+  ImGui::EndGroup();
   if (!recordingSettingsLocked && fpsChanged) {
     recordingFps = std::clamp(nextRecordingFps, 1, 120);
     scheduleUiConfigAutosave();
   }
-  ImGui::SameLine();
+  ImGui::SameLine(0.0f, recordingControlGap);
+  ImGui::BeginGroup();
   ImGui::TextDisabled("Playback rate");
-  ImGui::SameLine();
   const std::array<const char *, 4> rates{{"0.5x", "1.0x", "1.5x", "2.0x"}};
   recordingPlaybackRateIndex = std::clamp(recordingPlaybackRateIndex, 0, 3);
   int nextRecordingPlaybackRateIndex = recordingPlaybackRateIndex;
   const bool recordingPlaybackRateDisabled = recordingSettingsLocked;
   pushRecordingDisabledStyle(recordingPlaybackRateDisabled);
-  ImGui::SetNextItemWidth(96.0f);
+  ImGui::SetNextItemWidth(recordingControlWidth);
   const bool recordingPlaybackRateOpen = ImGui::BeginCombo(
       "##recording-playback-rate",
       rates[static_cast<size_t>(recordingPlaybackRateIndex)]);
@@ -10297,30 +10309,50 @@ void SubtrActorPlugin::renderRecordingWindow() {
     recordingPlaybackRateIndex = nextRecordingPlaybackRateIndex;
     scheduleUiConfigAutosave();
   }
+  ImGui::EndGroup();
+  ImGui::Spacing();
 
-  if (recordingButton("Start", recordingActive || !loaded || !engine)) {
+  const float recordingPrimaryRowWidth = ImGui::GetContentRegionAvail().x;
+  const float recordingPrimaryButtonWidth =
+      std::max(68.0f, (recordingPrimaryRowWidth - recordingControlGap * 2.0f) / 3.0f);
+  if (recordingButton(
+          "Start",
+          recordingActive || !loaded || !engine,
+          recordingPrimaryButtonWidth)) {
     recordingActive = true;
     recordingStartedAt = std::chrono::steady_clock::now();
     recordingStatus = "Recording analysis snapshots";
   }
-  ImGui::SameLine();
-  if (recordingButton("Full replay", recordingActive || !loaded || !engine)) {
+  ImGui::SameLine(0.0f, recordingControlGap);
+  if (recordingButton(
+          "Full replay",
+          recordingActive || !loaded || !engine,
+          recordingPrimaryButtonWidth)) {
     recordingActive = false;
     dumpSnapshot(true);
   }
-  ImGui::SameLine();
-  if (recordingButton("Stop", !recordingActive)) {
+  ImGui::SameLine(0.0f, recordingControlGap);
+  if (recordingButton("Stop", !recordingActive, recordingPrimaryButtonWidth)) {
     recordingActive = false;
     dumpSnapshot(false);
   }
-  if (recordingButton("Download", recordingActive || !hasGraphSnapshot)) {
+  const float recordingSecondaryRowWidth = recordingPrimaryRowWidth;
+  const float recordingSecondaryButtonWidth =
+      std::max(88.0f, (recordingSecondaryRowWidth - recordingControlGap) * 0.5f);
+  if (recordingButton(
+          "Download",
+          recordingActive || !hasGraphSnapshot,
+          recordingSecondaryButtonWidth)) {
     cvarManager->log(std::format(
         "subtr-actor: recording snapshots are written to {}",
         outputDirectory.string()));
     recordingStatus = "Snapshot location logged";
   }
-  ImGui::SameLine();
-  if (recordingButton("Clear", recordingActive || !hasGraphSnapshot)) {
+  ImGui::SameLine(0.0f, recordingControlGap);
+  if (recordingButton(
+          "Clear",
+          recordingActive || !hasGraphSnapshot,
+          recordingSecondaryButtonWidth)) {
     recordingActive = false;
     recordingSnapshotCount = 0;
     recordingLastBytes = 0;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9202,9 +9202,11 @@ void SubtrActorPlugin::resetWindowPlacements() {
 void SubtrActorPlugin::resetDefaultStatsWindows() {
   uiStatsWindows.clear();
   nextUiStatsWindowId = 1;
-  createStatsWindow(UiStatsWindowKind::Player, true);
-  createStatsWindow(UiStatsWindowKind::Team, true);
-  createStatsWindow(UiStatsWindowKind::GoalsOverview, true);
+  for (const StatsWindowKindControl &window : statsWindowKindControls()) {
+    if (window.default_window) {
+      createStatsWindow(window.kind, true);
+    }
+  }
 }
 
 void SubtrActorPlugin::applyWorkspaceWindowVisibility(
@@ -9333,28 +9335,32 @@ void SubtrActorPlugin::renderStatsWindows() {
 std::array<SubtrActorPlugin::StatsWindowKindControl, 7>
 SubtrActorPlugin::statsWindowKindControls() const {
   return {{
-      {UiStatsWindowKind::Player, "player", "Player stats", "New player stats", true},
-      {UiStatsWindowKind::Team, "team", "Team stats", "New team stats", true},
+      {UiStatsWindowKind::Player, "player", "Player stats", "New player stats", true, true},
+      {UiStatsWindowKind::Team, "team", "Team stats", "New team stats", true, true},
       {UiStatsWindowKind::AllPlayers,
        "all-players",
        "All players stats",
        "New all players stats",
-       true},
+       true,
+       false},
       {UiStatsWindowKind::AllTeams,
        "all-teams",
        "All teams stats",
        "New all teams stats",
-       true},
+       true,
+       false},
       {UiStatsWindowKind::GoalsOverview,
        "goals-overview",
        "Goal labels",
        "New goal labels",
+       true,
        true},
-      {UiStatsWindowKind::AdHoc, "ad-hoc", "Ad hoc stats", "New ad hoc stats", true},
+      {UiStatsWindowKind::AdHoc, "ad-hoc", "Ad hoc stats", "New ad hoc stats", true, false},
       {UiStatsWindowKind::StatsModule,
        "stats-module",
        "Stats module",
        "New stats module",
+       false,
        false},
   }};
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9869,6 +9869,13 @@ void SubtrActorPlugin::renderCameraWindow() {
                                          : cameraCustomSettingsEnabled
                                                ? std::format("{} custom", activeCameraLabel)
                                                : activeCameraLabel;
+  auto renderAttachedCameraMetric = [&](const char *format, float value) {
+    if (!hasAttachedCamera) {
+      ImGui::Text("--");
+      return;
+    }
+    ImGui::Text(format, value);
+  };
 
   ImGui::Separator();
   ImGui::Columns(2, "camera-detail-grid", false);
@@ -9876,19 +9883,19 @@ void SubtrActorPlugin::renderCameraWindow() {
   ImGui::Text("%s", profileReadout.c_str());
   ImGui::NextColumn();
   ImGui::TextDisabled("FOV");
-  ImGui::Text("%.0f", fov);
+  renderAttachedCameraMetric("%.0f", fov);
   ImGui::NextColumn();
   ImGui::TextDisabled("Height");
-  ImGui::Text("%.0f", height);
+  renderAttachedCameraMetric("%.0f", height);
   ImGui::NextColumn();
   ImGui::TextDisabled("Pitch");
-  ImGui::Text("%.1f", pitch);
+  renderAttachedCameraMetric("%.1f", pitch);
   ImGui::NextColumn();
   ImGui::TextDisabled("Distance");
-  ImGui::Text("%.0f", distance);
+  renderAttachedCameraMetric("%.0f", distance);
   ImGui::NextColumn();
   ImGui::TextDisabled("Stiffness");
-  ImGui::Text("%.2f", stiffness);
+  renderAttachedCameraMetric("%.2f", stiffness);
   ImGui::Columns(1);
 
   ImGui::End();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3296,8 +3296,6 @@ void SubtrActorPlugin::applyUiConfigJson(
           .value_or(eventPlaylistGoalContextEnabled);
   eventPlaylistAutoFollow =
       parseJsonBoolProperty(json, "event_playlist_auto_follow").value_or(eventPlaylistAutoFollow);
-  eventPlaylistStatus =
-      parseJsonStringProperty(json, "event_playlist_status").value_or(eventPlaylistStatus);
   if (const auto overlays = parseJsonObjectProperty(json, "overlays")) {
     const std::vector<std::string> timelineEvents =
         parseJsonStringArrayProperty(*overlays, "timelineEvents");
@@ -3974,7 +3972,6 @@ std::string SubtrActorPlugin::uiConfigJson() {
        << (eventPlaylistGoalContextEnabled ? "true" : "false") << ",\n";
   file << "  \"event_playlist_auto_follow\": "
        << (eventPlaylistAutoFollow ? "true" : "false") << ",\n";
-  file << "  \"event_playlist_status\": \"" << escapeJsonString(eventPlaylistStatus) << "\",\n";
   file << "  \"overlays\": {\n";
   const std::string currentEventFilter = cvarString("subtr_actor_overlay_event_types", "all");
   const std::vector<std::string> currentEventFilterTokens =
@@ -8464,9 +8461,6 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     ImGui::TreePop();
   }
 
-  if (!eventPlaylistStatus.empty()) {
-    ImGui::TextWrapped("Status: %s", eventPlaylistStatus.c_str());
-  }
   ImGui::Separator();
 
   ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
@@ -8514,11 +8508,6 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
       showSingletonWindow(uiPlaybackControlsOpen, playbackControlsPlacement);
       if (hasReplayServer) {
         replayServer.SkipToTime(seekTime);
-        eventPlaylistStatus =
-            std::format("Cued {} at {:.2f}s", event.label, seekTime);
-      } else {
-        eventPlaylistStatus =
-            std::format("Selected {} at {:.2f}s; open a replay to seek", event.label, seekTime);
       }
     }
     std::vector<std::string> metaParts;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8396,23 +8396,15 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
         return left < right;
       });
 
-  const bool allSourcesEnabled = eventPlaylistMechanicsEnabled && eventPlaylistTeamEventsEnabled &&
-                                 eventPlaylistGoalContextEnabled && allEventSourcesEnabled;
-  const bool noSourcesEnabled =
-      (!eventPlaylistMechanicsEnabled && !eventPlaylistTeamEventsEnabled &&
-       !eventPlaylistGoalContextEnabled) ||
-      selectedSources.empty();
   ImGui::Text("Filters %zu/%zu", selectedSourceCount, playlistSources.size());
-  if (renderModuleSummaryToggle(
-          "All",
-          allSourcesEnabled,
-          "event-playlist-sources")) {
+  if (ImGui::Button("All##event-playlist-sources-all")) {
     eventPlaylistMechanicsEnabled = true;
     eventPlaylistTeamEventsEnabled = true;
     eventPlaylistGoalContextEnabled = true;
     setCvarString("subtr_actor_overlay_event_types", "all");
   }
-  if (renderModuleSummaryToggle("None", noSourcesEnabled, "event-playlist-sources")) {
+  ImGui::SameLine();
+  if (ImGui::Button("None##event-playlist-sources-none")) {
     eventPlaylistMechanicsEnabled = false;
     eventPlaylistTeamEventsEnabled = false;
     eventPlaylistGoalContextEnabled = false;
@@ -8442,8 +8434,9 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
 
       ImGui::PushID(option.value);
       const std::string label = std::format("{} ({})", option.label, source.count);
-      if (renderModuleSummaryToggle(label.c_str(), source.enabled, "event-playlist-sources")) {
-        if (source.enabled) {
+      bool enabled = source.enabled;
+      if (ImGui::Checkbox(label.c_str(), &enabled)) {
+        if (!enabled) {
           selectedSources.erase(
               std::remove(selectedSources.begin(), selectedSources.end(), std::string{option.value}),
               selectedSources.end());
@@ -8543,8 +8536,8 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
   }
   if (playlistEventIndexes.empty()) {
     ImGui::TextWrapped(
-        noSourcesEnabled ? "No event types selected."
-                         : "No events match the selected playlist filters.");
+        selectedSourceCount == 0 ? "No event types selected."
+                                 : "No events match the selected playlist filters.");
   }
   ImGui::EndChild();
   ImGui::End();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7244,12 +7244,12 @@ void SubtrActorPlugin::pushEventMessage(const SaMechanicEvent &event) {
                                        event.confidence * 100.0f)
                                  : mechanicLabel(event.kind);
   const std::string label =
-      std::format("{}: {}", playerLabel(event.player_index, event.is_team_0), action);
+      std::format("{} {}", playerLabel(event.player_index, event.is_team_0), action);
   appendUiEvent(UiEventRecord{
       isCorePlayerStat ? "core" : "mechanics",
       mechanicToken(event.kind),
       playerLabel(event.player_index, event.is_team_0),
-      mechanicLabel(event.kind),
+      label,
       isCorePlayerStat
           ? "Shots, saves, assists"
           : event.confidence < 0.999f
@@ -7282,18 +7282,24 @@ void SubtrActorPlugin::pushEventMessage(const SaMechanicEvent &event) {
 
 void SubtrActorPlugin::pushTeamEventMessage(const SaTeamEvent &event) {
   const bool isBlue = event.is_team_0 != 0;
+  const std::string title = event.kind == SaTeamEventKindRush
+                                ? std::format(
+                                      "{} rush {}v{}",
+                                      teamLabel(event.is_team_0),
+                                      event.attackers,
+                                      event.defenders)
+                                : std::format(
+                                      "{} {}",
+                                      teamLabel(event.is_team_0),
+                                      teamEventLabel(event));
   const std::string action = event.confidence < 0.999f
-                                 ? std::format(
-                                       "{} ({:.0f}%)",
-                                       teamEventLabel(event),
-                                       event.confidence * 100.0f)
-                                 : teamEventLabel(event);
-  const std::string label = std::format("{}: {}", teamLabel(event.is_team_0), action);
+                                 ? std::format("{} ({:.0f}%)", title, event.confidence * 100.0f)
+                                 : title;
   appendUiEvent(UiEventRecord{
       "team",
       "rush",
       teamLabel(event.is_team_0),
-      teamEventLabel(event),
+      title,
       std::format("{:.1f}s - {:.1f}s", event.start_time, event.end_time),
       isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
       event.start_frame,
@@ -7305,7 +7311,7 @@ void SubtrActorPlugin::pushTeamEventMessage(const SaTeamEvent &event) {
   }
 
   OverlayMessage message{
-      label,
+      action,
       isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
       std::chrono::steady_clock::now() +
           std::chrono::duration_cast<std::chrono::steady_clock::duration>(
@@ -7327,7 +7333,7 @@ void SubtrActorPlugin::pushGoalContextEventMessage(const SaGoalContextEvent &eve
       "goal_context",
       "goal_context",
       actor,
-      goalContextLabel(event),
+      std::format("{} {}", actor, goalContextLabel(event)),
       teamLabel(event.scoring_team_is_team_0),
       isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
       event.frame_number,

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7815,9 +7815,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
   renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);
 
   ImGui::Separator();
-  renderLauncherWorkspaceControls();
-
-  ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "VISUALIZATIONS");
   renderModuleSummaryControls("launcher-module-summary");
 
@@ -7868,6 +7865,9 @@ void SubtrActorPlugin::renderLauncherWindow() {
     if (ImGui::Button("Close launcher", ImVec2{170.0f, 0.0f})) {
       hideLauncherWindow();
     }
+
+    ImGui::Separator();
+    renderLauncherWorkspaceControls();
 
     ImGui::Separator();
     renderSharedSettingsControls();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9667,6 +9667,11 @@ void SubtrActorPlugin::renderCameraWindow() {
     cameraFreePreset = 1;
   }
 
+  targetPlayer = cameraViewMode == 1 ? sampledPlayerByIndex(cameraSelectedPlayerIndex) : nullptr;
+  const std::string activeCameraLabel =
+      targetPlayer == nullptr
+          ? "Free camera"
+          : playerLabel(targetPlayer->player_index, targetPlayer->is_team_0);
   const bool hasAttachedCamera = targetPlayer != nullptr;
   float nextDistanceScale = cameraDistanceScale;
   pushCameraDisabledStyle(!hasAttachedCamera);
@@ -9731,8 +9736,8 @@ void SubtrActorPlugin::renderCameraWindow() {
   const std::string profileReadout = targetPlayer == nullptr
                                          ? "Free camera"
                                          : cameraCustomSettingsEnabled
-                                               ? std::format("{} custom", selectedLabel)
-                                               : selectedLabel;
+                                               ? std::format("{} custom", activeCameraLabel)
+                                               : activeCameraLabel;
 
   ImGui::Separator();
   ImGui::Columns(2, "camera-detail-grid", false);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8991,8 +8991,9 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     const std::string timeLabel = formatEventPlaylistTime(event.time);
     const std::string sourceLabel = sourceLabelForEvent(event);
     const std::string eventLabel = event.label.empty() ? sourceLabel : event.label;
-    const std::string itemLabel =
-        std::format("{}  {}##event-playlist-item", timeLabel, eventLabel);
+    const std::string itemLabel = std::format("{}##event-playlist-item", eventLabel);
+    ImGui::TextDisabled("%s", timeLabel.c_str());
+    ImGui::SameLine(64.0f);
     ImGui::PushStyleColor(ImGuiCol_Text, color);
     const bool selected = ImGui::Selectable(itemLabel.c_str(), active);
     ImGui::PopStyleColor();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7641,35 +7641,78 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     return;
   }
 
-  size_t selectedCount = 0;
-  size_t mechanicsSourceCount = 0;
-  size_t teamSourceCount = 0;
-  size_t goalContextSourceCount = 0;
-  for (const UiEventRecord &event : recentUiEvents) {
-    if (event.category == "mechanics") {
-      mechanicsSourceCount += 1;
-    } else if (event.category == "team") {
-      teamSourceCount += 1;
-    } else if (event.category == "goal_context" || event.type == "goal") {
-      goalContextSourceCount += 1;
+  const std::string currentFilter = cvarString("subtr_actor_overlay_event_types", "all");
+  const bool allEventSourcesEnabled = allEventSourcesSelected(currentFilter);
+  std::vector<std::string> selectedSources = selectedEventSourceTokens(currentFilter);
+
+  auto sourceHasEnabledPlaylistGroup = [&](std::string_view source) {
+    for (const UiEventRecord &event : recentUiEvents) {
+      if (eventFilterAllows(source, event.category, event.type) &&
+          eventPlaylistSourceEnabled(event)) {
+        return true;
+      }
     }
+    return false;
+  };
+  auto enableMatchingPlaylistGroups = [&](std::string_view source) {
+    for (const UiEventRecord &event : recentUiEvents) {
+      if (!eventFilterAllows(source, event.category, event.type)) {
+        continue;
+      }
+      if (event.category == "mechanics") {
+        eventPlaylistMechanicsEnabled = true;
+      } else if (event.category == "team") {
+        eventPlaylistTeamEventsEnabled = true;
+      } else if (event.category == "goal_context" || event.type == "goal") {
+        eventPlaylistGoalContextEnabled = true;
+      }
+    }
+  };
+
+  struct PlaylistSource {
+    const EventFilterOption *option = nullptr;
+    size_t count = 0;
+    bool enabled = false;
+  };
+
+  std::vector<PlaylistSource> playlistSources;
+  playlistSources.reserve(EVENT_FILTER_OPTIONS.size());
+  for (const EventFilterOption &option : EVENT_FILTER_OPTIONS) {
+    if (std::string_view{option.value} == "all") {
+      continue;
+    }
+    size_t count = 0;
+    for (const UiEventRecord &event : recentUiEvents) {
+      if (eventFilterAllows(option.value, event.category, event.type)) {
+        count += 1;
+      }
+    }
+    const bool selected = containsString(selectedSources, option.value);
+    if (count == 0 && (allEventSourcesEnabled || !selected)) {
+      continue;
+    }
+    playlistSources.push_back(
+        PlaylistSource{&option, count, selected && sourceHasEnabledPlaylistGroup(option.value)});
+  }
+
+  const size_t selectedSourceCount = static_cast<size_t>(std::count_if(
+      playlistSources.begin(),
+      playlistSources.end(),
+      [](const PlaylistSource &source) { return source.enabled; }));
+  size_t selectedCount = 0;
+  for (const UiEventRecord &event : recentUiEvents) {
     if (eventPlaylistSourceEnabled(event) && uiEventVisible(event)) {
       selectedCount += 1;
     }
   }
 
   const bool allSourcesEnabled = eventPlaylistMechanicsEnabled && eventPlaylistTeamEventsEnabled &&
-                                 eventPlaylistGoalContextEnabled &&
-                                 allEventSourcesSelected(
-                                     cvarString("subtr_actor_overlay_event_types", "all"));
+                                 eventPlaylistGoalContextEnabled && allEventSourcesEnabled;
   const bool noSourcesEnabled =
       (!eventPlaylistMechanicsEnabled && !eventPlaylistTeamEventsEnabled &&
        !eventPlaylistGoalContextEnabled) ||
-      selectedEventSourceTokens(cvarString("subtr_actor_overlay_event_types", "all")).empty();
-  const size_t activeSourceGroups = static_cast<size_t>(eventPlaylistMechanicsEnabled) +
-                                    static_cast<size_t>(eventPlaylistTeamEventsEnabled) +
-                                    static_cast<size_t>(eventPlaylistGoalContextEnabled);
-  ImGui::Text("Filters %zu / 3", activeSourceGroups);
+      selectedSources.empty();
+  ImGui::Text("Filters %zu / %zu", selectedSourceCount, playlistSources.size());
   if (renderModuleSummaryToggle(
           std::format("All ({})", recentUiEvents.size()).c_str(),
           allSourcesEnabled,
@@ -7689,20 +7732,41 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "FILTERS");
-  renderBoolModuleSummaryToggle(
-      std::format("Mechanics ({})", mechanicsSourceCount).c_str(),
-      eventPlaylistMechanicsEnabled,
-      "event-playlist-sources");
-  renderBoolModuleSummaryToggle(
-      std::format("Team ({})", teamSourceCount).c_str(),
-      eventPlaylistTeamEventsEnabled,
-      "event-playlist-sources");
-  renderBoolModuleSummaryToggle(
-      std::format("Goal context ({})", goalContextSourceCount).c_str(),
-      eventPlaylistGoalContextEnabled,
-      "event-playlist-sources");
+  if (playlistSources.empty()) {
+    ImGui::TextDisabled("No events loaded.");
+  } else {
+    ImGui::BeginChild("event-playlist-source-list", ImVec2{0.0f, 170.0f}, true);
+    std::string_view currentGroup;
+    for (const PlaylistSource &source : playlistSources) {
+      const EventFilterOption &option = *source.option;
+      const std::string_view optionGroup{option.group};
+      if (currentGroup != optionGroup) {
+        if (!currentGroup.empty()) {
+          ImGui::Separator();
+        }
+        ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", option.group);
+        currentGroup = optionGroup;
+      }
 
-  renderEventFilterCombo("Event filter");
+      ImGui::PushID(option.value);
+      const std::string label = std::format("{} ({})", option.label, source.count);
+      if (renderModuleSummaryToggle(label.c_str(), source.enabled, "event-playlist-sources")) {
+        if (source.enabled) {
+          selectedSources.erase(
+              std::remove(selectedSources.begin(), selectedSources.end(), std::string{option.value}),
+              selectedSources.end());
+        } else {
+          appendUniqueFilterToken(selectedSources, option.value);
+          enableMatchingPlaylistGroups(option.value);
+        }
+        setCvarString(
+            "subtr_actor_overlay_event_types",
+            eventFilterFromSelectedSources(selectedSources));
+      }
+      ImGui::PopID();
+    }
+    ImGui::EndChild();
+  }
 
   ImGui::Text("%zu selected / %zu recent", selectedCount, recentUiEvents.size());
   if (!eventPlaylistStatus.empty()) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -2783,7 +2783,7 @@ void SubtrActorPlugin::onLoad() {
       "subtr_actor_open_ui",
       [this](std::vector<std::string>) {
         uiWindowOpen = true;
-        showSingletonWindow(uiLauncherOpen, launcherPlacement);
+        showLauncherWindow();
       },
       "Opens the subtr-actor in-game launcher window.",
       PERMISSION_ALL);
@@ -2794,7 +2794,7 @@ void SubtrActorPlugin::onLoad() {
         if (uiLauncherOpen) {
           hideLauncherWindow();
         } else {
-          showSingletonWindow(uiLauncherOpen, launcherPlacement);
+          showLauncherWindow();
         }
       },
       "Toggles the subtr-actor in-game launcher window.",
@@ -2841,7 +2841,7 @@ bool SubtrActorPlugin::IsActiveOverlay() {
 
 void SubtrActorPlugin::OnOpen() {
   uiWindowOpen = true;
-  showSingletonWindow(uiLauncherOpen, launcherPlacement);
+  showLauncherWindow();
 }
 
 void SubtrActorPlugin::OnClose() {
@@ -7187,12 +7187,17 @@ void SubtrActorPlugin::hideStatsWindow(UiStatsWindow &window) {
   scheduleUiConfigAutosave();
 }
 
+void SubtrActorPlugin::showLauncherWindow() {
+  uiWindowOpen = true;
+  uiLauncherOpen = true;
+  launcherPlacement.pending_focus = true;
+}
+
 void SubtrActorPlugin::hideLauncherWindow() {
   if (!uiLauncherOpen) {
     return;
   }
   uiLauncherOpen = false;
-  scheduleUiConfigAutosave();
 }
 
 void SubtrActorPlugin::captureWindowPlacement(UiWindowPlacement &placement) {
@@ -7719,7 +7724,7 @@ void SubtrActorPlugin::renderLauncherToggleChrome() {
     if (uiLauncherOpen) {
       hideLauncherWindow();
     } else {
-      showSingletonWindow(uiLauncherOpen, launcherPlacement);
+      showLauncherWindow();
     }
   }
 
@@ -7875,7 +7880,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
     ImGui::End();
     return;
   }
-  captureWindowPlacement(launcherPlacement);
   const bool launcherHovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
 
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ACTIONS");
@@ -7999,7 +8003,7 @@ void SubtrActorPlugin::renderEmptyStateWindow() {
     setCvarBool("subtr_actor_enabled", true);
   }
   if (ImGui::Button("Open menu", ImVec2{150.0f, 0.0f})) {
-    showSingletonWindow(uiLauncherOpen, launcherPlacement);
+    showLauncherWindow();
   }
 
   ImGui::End();
@@ -10507,7 +10511,8 @@ void SubtrActorPlugin::focusTopLoadedWindow() {
 
 void SubtrActorPlugin::resetWindowPlacements() {
   nextUiWindowZIndex = 1;
-  resetSingletonWindowPlacement(launcherPlacement, 16.0f, 68.0f, 340.0f, 430.0f, true);
+  launcherPlacement = {};
+  launcherPlacement.pending_focus = uiLauncherOpen;
   for (const SingletonWindowControl &window : singletonWindowControls()) {
     if (window.placement == &scoreboardPlacement) {
       resetScoreboardWindowPlacement();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -12282,6 +12282,7 @@ void SubtrActorPlugin::renderAllPlayersStatsTable(UiStatsWindow &window) {
   auto renderTeamGroup = [&](uint8_t isTeam0) {
     const LinearColor color =
         isTeam0 != 0 ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255};
+    const ImVec4 teamColor = toImVec4(color);
     const size_t playerCount = static_cast<size_t>(std::count_if(
         sampledPlayers.begin(),
         sampledPlayers.end(),
@@ -12290,9 +12291,19 @@ void SubtrActorPlugin::renderAllPlayersStatsTable(UiStatsWindow &window) {
       return false;
     }
 
-    ImGui::TextColored(toImVec4(color), "%s team", teamLabel(isTeam0).c_str());
-    ImGui::SameLine();
-    ImGui::TextDisabled("%zu player%s", playerCount, playerCount == 1 ? "" : "s");
+    ImGui::Spacing();
+    const std::string teamTitle = std::format("{} team", teamLabel(isTeam0));
+    const std::string teamMeta =
+        std::format("{} player{}", playerCount, playerCount == 1 ? "" : "s");
+    ImGui::TextColored(teamColor, "%s", teamTitle.c_str());
+    const float metaX = std::max(
+        ImGui::GetCursorPosX(),
+        ImGui::GetWindowContentRegionMax().x - ImGui::CalcTextSize(teamMeta.c_str()).x);
+    ImGui::SameLine(metaX);
+    ImGui::TextColored(teamColor, "%s", teamMeta.c_str());
+    ImGui::PushStyleColor(ImGuiCol_Separator, teamColor);
+    ImGui::Separator();
+    ImGui::PopStyleColor();
     for (const SaPlayerFrame &player : sampledPlayers) {
       if (player.is_team_0 != isTeam0) {
         continue;
@@ -12300,7 +12311,14 @@ void SubtrActorPlugin::renderAllPlayersStatsTable(UiStatsWindow &window) {
 
       ImGui::PushID(static_cast<int>(player.player_index));
       const std::string playerName = playerLabel(player.player_index, player.is_team_0);
-      ImGui::TextColored(toImVec4(color), "%s", playerName.c_str());
+      ImDrawList *drawList = ImGui::GetWindowDrawList();
+      const ImVec2 entityStart = ImGui::GetCursorScreenPos();
+      drawList->AddRectFilled(
+          ImVec2{entityStart.x, entityStart.y + 2.0f},
+          ImVec2{entityStart.x + 2.0f, entityStart.y + ImGui::GetTextLineHeight() + 2.0f},
+          ImGui::GetColorU32(teamColor));
+      ImGui::Indent(8.0f);
+      ImGui::TextColored(teamColor, "%s", playerName.c_str());
       for (size_t i = 0; i < window.entries.size();) {
         const std::string &statId = window.entries[i].stat_id;
         if (!statsWindowSupportsStat(window, statId)) {
@@ -12311,11 +12329,13 @@ void SubtrActorPlugin::renderAllPlayersStatsTable(UiStatsWindow &window) {
         const std::string statValue = playerStatValue(player, statId);
         if (renderStatsWindowValueRow(
                 window, i, statLabel, statValue, std::format("player-{}", player.player_index))) {
+          ImGui::Unindent(8.0f);
           ImGui::PopID();
           return true;
         }
         ++i;
       }
+      ImGui::Unindent(8.0f);
       ImGui::Spacing();
       ImGui::PopID();
     }
@@ -12334,7 +12354,15 @@ void SubtrActorPlugin::renderAllTeamsStatsTable(UiStatsWindow &window) {
   for (const uint8_t isTeam0 : {static_cast<uint8_t>(1), static_cast<uint8_t>(0)}) {
     const LinearColor color =
         isTeam0 != 0 ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255};
-    ImGui::TextColored(toImVec4(color), "%s", teamLabel(isTeam0).c_str());
+    const ImVec4 teamColor = toImVec4(color);
+    ImDrawList *drawList = ImGui::GetWindowDrawList();
+    const ImVec2 entityStart = ImGui::GetCursorScreenPos();
+    drawList->AddRectFilled(
+        ImVec2{entityStart.x, entityStart.y + 2.0f},
+        ImVec2{entityStart.x + 2.0f, entityStart.y + ImGui::GetTextLineHeight() + 2.0f},
+        ImGui::GetColorU32(teamColor));
+    ImGui::Indent(8.0f);
+    ImGui::TextColored(teamColor, "%s", teamLabel(isTeam0).c_str());
     for (size_t i = 0; i < window.entries.size();) {
       const std::string &statId = window.entries[i].stat_id;
       if (!statsWindowSupportsStat(window, statId)) {
@@ -12345,10 +12373,12 @@ void SubtrActorPlugin::renderAllTeamsStatsTable(UiStatsWindow &window) {
       const std::string statValue = teamStatValue(isTeam0, statId);
       if (renderStatsWindowValueRow(
               window, i, statLabel, statValue, std::format("team-{}", isTeam0))) {
+        ImGui::Unindent(8.0f);
         return;
       }
       ++i;
     }
+    ImGui::Unindent(8.0f);
     ImGui::Spacing();
   }
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8037,6 +8037,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
     showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
     resetReplayAnnotations();
     tickReplayAnnotations();
+    hideLauncherWindow();
   }
 
   ImGui::Separator();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11719,6 +11719,26 @@ void SubtrActorPlugin::renderAdHocTargetSelector(
     return;
   }
 
+  auto pushAdHocTargetSelectorStyle = [](std::optional<LinearColor> teamColor) {
+    ImGui::SetNextItemWidth(std::min(112.0f, ImGui::GetContentRegionAvail().x));
+    if (!teamColor) {
+      return 0;
+    }
+
+    const ImVec4 accent = toImVec4(*teamColor);
+    ImGui::PushStyleColor(ImGuiCol_Border, accent);
+    ImGui::PushStyleColor(
+        ImGuiCol_FrameBg,
+        ImVec4{accent.x * 0.18f, accent.y * 0.18f, accent.z * 0.18f, 0.58f});
+    ImGui::PushStyleColor(
+        ImGuiCol_FrameBgHovered,
+        ImVec4{accent.x * 0.24f, accent.y * 0.24f, accent.z * 0.24f, 0.74f});
+    ImGui::PushStyleColor(
+        ImGuiCol_FrameBgActive,
+        ImVec4{accent.x * 0.30f, accent.y * 0.30f, accent.z * 0.30f, 0.88f});
+    return 4;
+  };
+
   if (playerScoped) {
     const SaPlayerFrame *selected = nullptr;
     if (const std::optional<uint32_t> selectedPlayerIndex =
@@ -11727,8 +11747,18 @@ void SubtrActorPlugin::renderAdHocTargetSelector(
     }
     const std::string selectedLabel =
         selected ? playerLabel(selected->player_index, selected->is_team_0) : "Select player";
-    if (ImGui::BeginCombo(std::format("##ad-hoc-target-{}-{}", window.id, index).c_str(),
-                          selectedLabel.c_str())) {
+    const std::optional<LinearColor> selectedColor =
+        selected ? std::make_optional(selected->is_team_0 != 0 ? LinearColor{80, 190, 255, 255}
+                                                              : LinearColor{255, 175, 80, 255})
+                 : std::nullopt;
+    const int selectorStyleColors = pushAdHocTargetSelectorStyle(selectedColor);
+    const bool comboOpen = ImGui::BeginCombo(
+        std::format("##ad-hoc-target-{}-{}", window.id, index).c_str(),
+        selectedLabel.c_str());
+    if (selectorStyleColors > 0) {
+      ImGui::PopStyleColor(selectorStyleColors);
+    }
+    if (comboOpen) {
       for (uint8_t isTeam0 : {uint8_t{1}, uint8_t{0}}) {
         const bool hasTeamPlayers = std::any_of(
             sampledPlayers.begin(),
@@ -11765,9 +11795,17 @@ void SubtrActorPlugin::renderAdHocTargetSelector(
   }
 
   const char *selectedTeam = entry.target_id == "orange" ? "Orange" : "Blue";
-  if (ImGui::BeginCombo(
-          std::format("##ad-hoc-target-{}-{}", window.id, index).c_str(),
-          selectedTeam)) {
+  const std::optional<LinearColor> selectedColor =
+      entry.target_id == "orange" ? std::make_optional(LinearColor{255, 175, 80, 255})
+                                  : std::make_optional(LinearColor{80, 190, 255, 255});
+  const int selectorStyleColors = pushAdHocTargetSelectorStyle(selectedColor);
+  const bool comboOpen = ImGui::BeginCombo(
+      std::format("##ad-hoc-target-{}-{}", window.id, index).c_str(),
+      selectedTeam);
+  if (selectorStyleColors > 0) {
+    ImGui::PopStyleColor(selectorStyleColors);
+  }
+  if (comboOpen) {
     for (const auto &[label, targetId, isTeam0] : {
              std::tuple<const char *, const char *, uint8_t>{"Blue", "blue", uint8_t{1}},
              std::tuple<const char *, const char *, uint8_t>{"Orange", "orange", uint8_t{0}},

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -121,6 +121,32 @@ void popWebFloatingWindowStyle() {
   ImGui::PopStyleVar(4);
 }
 
+void pushWebModuleSummaryButtonStyle(bool active) {
+  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2{10.0f, 5.0f});
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 999.0f);
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
+  ImGui::PushStyleColor(
+      ImGuiCol_Button,
+      active ? ImVec4{0.29f, 0.58f, 1.0f, 0.08f} : ImVec4{1.0f, 1.0f, 1.0f, 0.03f});
+  ImGui::PushStyleColor(
+      ImGuiCol_ButtonHovered,
+      active ? ImVec4{0.29f, 0.58f, 1.0f, 0.14f} : ImVec4{1.0f, 1.0f, 1.0f, 0.07f});
+  ImGui::PushStyleColor(
+      ImGuiCol_ButtonActive,
+      active ? ImVec4{0.29f, 0.58f, 1.0f, 0.20f} : ImVec4{1.0f, 1.0f, 1.0f, 0.11f});
+  ImGui::PushStyleColor(
+      ImGuiCol_Border,
+      active ? ImVec4{0.29f, 0.58f, 1.0f, 0.22f} : ImVec4{1.0f, 1.0f, 1.0f, 0.10f});
+  ImGui::PushStyleColor(
+      ImGuiCol_Text,
+      active ? ImVec4{0.86f, 0.92f, 0.98f, 1.0f} : ImVec4{0.63f, 0.70f, 0.76f, 1.0f});
+}
+
+void popWebModuleSummaryButtonStyle() {
+  ImGui::PopStyleColor(5);
+  ImGui::PopStyleVar(3);
+}
+
 void renderWebDetailGridCell(std::string_view label, std::string_view value) {
   const std::string labelString{label};
   const std::string valueString{value};
@@ -8020,14 +8046,9 @@ bool SubtrActorPlugin::renderModuleSummaryToggle(
     float width) {
   const std::string buttonLabel =
       std::format("{}   {}##{}-{}", label, active ? "On" : "Off", idSuffix, label);
-  if (active) {
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.16f, 0.35f, 0.28f, 1.0f});
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
-  }
+  pushWebModuleSummaryButtonStyle(active);
   const bool clicked = ImGui::Button(buttonLabel.c_str(), ImVec2{width, 0.0f});
-  if (active) {
-    ImGui::PopStyleColor(2);
-  }
+  popWebModuleSummaryButtonStyle();
   if (width <= 0.0f) {
     const float itemRight = ImGui::GetItemRectMax().x;
     const float contentRight = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
@@ -8487,9 +8508,7 @@ void SubtrActorPlugin::renderWebWindowToggleControls(
     ImGui::PushID(window.label);
     const bool isOpen = window.open != nullptr && *window.open;
     if (includeState && isOpen) {
-      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.16f, 0.35f, 0.28f, 1.0f});
-      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
-      ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.25f, 0.55f, 0.43f, 1.0f});
+      pushWebModuleSummaryButtonStyle(true);
     }
     const std::string buttonLabel{window.label};
     const float buttonWidth = fullWidth ? ImGui::GetContentRegionAvail().x : 210.0f;
@@ -8504,7 +8523,7 @@ void SubtrActorPlugin::renderWebWindowToggleControls(
       }
     }
     if (includeState && isOpen) {
-      ImGui::PopStyleColor(3);
+      popWebModuleSummaryButtonStyle();
     }
     ImGui::PopID();
   }
@@ -8760,7 +8779,9 @@ void SubtrActorPlugin::renderEventSourceControls() {
   }
 
   auto renderEventSourceAction = [](const std::string &label) {
+    pushWebModuleSummaryButtonStyle(false);
     const bool clicked = ImGui::Button(label.c_str());
+    popWebModuleSummaryButtonStyle();
     const float itemRight = ImGui::GetItemRectMax().x;
     const float contentRight = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
     if (contentRight - itemRight > 112.0f) {
@@ -8769,20 +8790,15 @@ void SubtrActorPlugin::renderEventSourceControls() {
     return clicked;
   };
   auto renderEventSourceRow = [](const EventFilterOption &option, bool enabled, size_t count) {
-    if (enabled) {
-      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.16f, 0.35f, 0.28f, 1.0f});
-      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
-    }
     const std::string label = std::format(
         "{}   {} {}##event-sources-{}",
         option.label,
         enabled ? "On" : "Off",
         count,
         option.value);
+    pushWebModuleSummaryButtonStyle(enabled);
     const bool clicked = ImGui::Button(label.c_str());
-    if (enabled) {
-      ImGui::PopStyleColor(2);
-    }
+    popWebModuleSummaryButtonStyle();
     return clicked;
   };
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8207,6 +8207,23 @@ void SubtrActorPlugin::renderEventSourceControls() {
     }
     return clicked;
   };
+  auto renderEventSourceRow = [](const EventFilterOption &option, bool enabled, size_t count) {
+    if (enabled) {
+      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.16f, 0.35f, 0.28f, 1.0f});
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.20f, 0.45f, 0.36f, 1.0f});
+    }
+    const std::string label = std::format(
+        "{}   {} {}##event-sources-{}",
+        option.label,
+        enabled ? "On" : "Off",
+        count,
+        option.value);
+    const bool clicked = ImGui::Button(label.c_str());
+    if (enabled) {
+      ImGui::PopStyleColor(2);
+    }
+    return clicked;
+  };
 
   if (renderEventSourceAction(
           std::format("All events   {}##event-sources-actions-all", displaySources.size()))) {
@@ -8224,10 +8241,8 @@ void SubtrActorPlugin::renderEventSourceControls() {
   for (const DisplaySource &source : displaySources) {
     const EventFilterOption &option = *source.option;
     ImGui::PushID(option.value);
-    bool enabled = source.enabled;
-    const std::string label = std::format("{} ({})", option.label, source.count);
-    if (renderModuleSummaryToggle(label.c_str(), enabled, "event-sources")) {
-      if (enabled) {
+    if (renderEventSourceRow(option, source.enabled, source.count)) {
+      if (source.enabled) {
         selected.erase(
             std::remove(selected.begin(), selected.end(), std::string{option.value}),
             selected.end());

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3782,19 +3782,26 @@ void SubtrActorPlugin::applyUiConfigJson(
         std::max(0.0, parseJsonNumberProperty(object, "module_view").value_or(0.0)));
     const bool hasEntriesProperty = object.find("\"entries\"") != std::string::npos;
     for (const std::string &statId : parseJsonStringArrayProperty(object, "entries")) {
+      if (statsWindowObjectsFromWeb) {
+        continue;
+      }
       window.entries.push_back(UiStatsWindow::Entry{normalizeUiStatId(statId), ""});
     }
     for (const std::string &entryObject : parseJsonObjectArrayProperty(object, "entries")) {
-      std::string statId = parseJsonStringProperty(entryObject, "stat_id").value_or("");
-      if (statId.empty()) {
+      std::string statId = statsWindowObjectsFromWeb
+                               ? parseJsonStringProperty(entryObject, "statId").value_or("")
+                               : parseJsonStringProperty(entryObject, "stat_id").value_or("");
+      if (!statsWindowObjectsFromWeb && statId.empty()) {
         statId = parseJsonStringProperty(entryObject, "statId").value_or("");
       }
       if (statId.empty()) {
         continue;
       }
       statId = normalizeUiStatId(statId);
-      std::string targetId = parseJsonStringProperty(entryObject, "target_id").value_or("");
-      if (targetId.empty()) {
+      std::string targetId = statsWindowObjectsFromWeb
+                                 ? parseJsonStringProperty(entryObject, "targetId").value_or("")
+                                 : parseJsonStringProperty(entryObject, "target_id").value_or("");
+      if (!statsWindowObjectsFromWeb && targetId.empty()) {
         targetId = parseJsonStringProperty(entryObject, "targetId").value_or("");
       }
       window.entries.push_back(UiStatsWindow::Entry{statId, targetId});

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -6718,21 +6718,58 @@ void SubtrActorPlugin::Render() {
   }
 
   renderEmptyStateWindow();
-  renderScoreboardWindow();
-  renderEventsWindow();
-  renderStatusWindow();
-  renderCameraWindow();
-  renderPlaybackControlsWindow();
-  renderRecordingWindow();
-  renderGraphInspectorWindow();
-  renderEventPlaylistWindow();
-  renderMechanicsReviewWindow();
-  renderReplayLoadingWindow();
-  renderModuleControlsWindow();
-  renderTouchControlsWindow();
-  renderBoostPickupControlsWindow();
+  renderSingletonWindows();
   renderStatsWindows();
   maybeAutosaveUiConfig();
+}
+
+void SubtrActorPlugin::renderSingletonWindows() {
+  std::vector<SingletonWindowControl> renderOrder;
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    if (*window.open) {
+      renderOrder.push_back(window);
+    }
+  }
+  std::stable_sort(
+      renderOrder.begin(),
+      renderOrder.end(),
+      [](const SingletonWindowControl &left, const SingletonWindowControl &right) {
+        if (left.placement->z_index != right.placement->z_index) {
+          return left.placement->z_index < right.placement->z_index;
+        }
+        return left.launcher_order < right.launcher_order;
+      });
+
+  for (const SingletonWindowControl &window : renderOrder) {
+    const std::string_view id{window.config_id};
+    if (id == "scoreboard") {
+      renderScoreboardWindow();
+    } else if (id == "mechanics") {
+      renderEventsWindow();
+    } else if (id == "event-playlist") {
+      renderEventPlaylistWindow();
+    } else if (id == "status") {
+      renderStatusWindow();
+    } else if (id == "camera") {
+      renderCameraWindow();
+    } else if (id == "playback") {
+      renderPlaybackControlsWindow();
+    } else if (id == "recording") {
+      renderRecordingWindow();
+    } else if (id == "graph-inspector") {
+      renderGraphInspectorWindow();
+    } else if (id == "mechanics-review") {
+      renderMechanicsReviewWindow();
+    } else if (id == "replay-loading") {
+      renderReplayLoadingWindow();
+    } else if (id == "module-controls") {
+      renderModuleControlsWindow();
+    } else if (id == "touch-controls") {
+      renderTouchControlsWindow();
+    } else if (id == "boost-pickups") {
+      renderBoostPickupControlsWindow();
+    }
+  }
 }
 
 void SubtrActorPlugin::RenderSettings() {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9335,31 +9335,53 @@ void SubtrActorPlugin::renderStatsWindows() {
 std::array<SubtrActorPlugin::StatsWindowKindControl, 7>
 SubtrActorPlugin::statsWindowKindControls() const {
   return {{
-      {UiStatsWindowKind::Player, "player", "Player stats", "New player stats", true, true},
-      {UiStatsWindowKind::Team, "team", "Team stats", "New team stats", true, true},
+      {UiStatsWindowKind::Player,
+       "player",
+       "Player stats",
+       "New player stats",
+       UI_STAT_SCOPE_PLAYER,
+       true,
+       true},
+      {UiStatsWindowKind::Team,
+       "team",
+       "Team stats",
+       "New team stats",
+       UI_STAT_SCOPE_TEAM,
+       true,
+       true},
       {UiStatsWindowKind::AllPlayers,
        "all-players",
        "All players stats",
        "New all players stats",
+       UI_STAT_SCOPE_PLAYER,
        true,
        false},
       {UiStatsWindowKind::AllTeams,
        "all-teams",
        "All teams stats",
        "New all teams stats",
+       UI_STAT_SCOPE_TEAM,
        true,
        false},
       {UiStatsWindowKind::GoalsOverview,
        "goals-overview",
        "Goal labels",
        "New goal labels",
+       UI_STAT_SCOPE_EVENT,
        true,
        true},
-      {UiStatsWindowKind::AdHoc, "ad-hoc", "Ad hoc stats", "New ad hoc stats", true, false},
+      {UiStatsWindowKind::AdHoc,
+       "ad-hoc",
+       "Ad hoc stats",
+       "New ad hoc stats",
+       static_cast<uint8_t>(UI_STAT_SCOPE_PLAYER | UI_STAT_SCOPE_TEAM | UI_STAT_SCOPE_EVENT),
+       true,
+       false},
       {UiStatsWindowKind::StatsModule,
        "stats-module",
        "Stats module",
        "New stats module",
+       0,
        false,
        false},
   }};
@@ -9391,6 +9413,15 @@ const char *SubtrActorPlugin::statsWindowKindLabel(UiStatsWindowKind kind) const
     }
   }
   return "Stats";
+}
+
+uint8_t SubtrActorPlugin::statsWindowKindStatScopes(UiStatsWindowKind kind) const {
+  for (const StatsWindowKindControl &control : statsWindowKindControls()) {
+    if (control.kind == kind) {
+      return control.stat_scopes;
+    }
+  }
+  return 0;
 }
 
 std::string SubtrActorPlugin::statsWindowTitle(const UiStatsWindow &window) const {
@@ -9469,21 +9500,17 @@ bool SubtrActorPlugin::statsWindowSupportsStat(
   if (!definition) {
     return false;
   }
-  switch (window.kind) {
-  case UiStatsWindowKind::Player:
-  case UiStatsWindowKind::AllPlayers:
-    return definition->player;
-  case UiStatsWindowKind::Team:
-  case UiStatsWindowKind::AllTeams:
-    return definition->team;
-  case UiStatsWindowKind::GoalsOverview:
-    return definition->event;
-  case UiStatsWindowKind::AdHoc:
-    return definition->player || definition->team || definition->event;
-  case UiStatsWindowKind::StatsModule:
-    return false;
+  uint8_t definitionScopes = 0;
+  if (definition->player) {
+    definitionScopes |= UI_STAT_SCOPE_PLAYER;
   }
-  return false;
+  if (definition->team) {
+    definitionScopes |= UI_STAT_SCOPE_TEAM;
+  }
+  if (definition->event) {
+    definitionScopes |= UI_STAT_SCOPE_EVENT;
+  }
+  return (statsWindowKindStatScopes(window.kind) & definitionScopes) != 0;
 }
 
 bool SubtrActorPlugin::statsWindowHasStat(

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -6853,6 +6853,7 @@ void SubtrActorPlugin::Render() {
   if (!uiEnabled()) {
     renderLauncherToggleChrome();
     renderLauncherWindow();
+    maybeAutosaveUiConfig();
     return;
   }
 
@@ -7156,6 +7157,14 @@ void SubtrActorPlugin::focusSingletonWindow(UiWindowPlacement &placement) {
 void SubtrActorPlugin::showSingletonWindow(bool &open, UiWindowPlacement &placement) {
   open = true;
   focusSingletonWindow(placement);
+}
+
+void SubtrActorPlugin::hideLauncherWindow() {
+  if (!uiLauncherOpen) {
+    return;
+  }
+  uiLauncherOpen = false;
+  scheduleUiConfigAutosave();
 }
 
 void SubtrActorPlugin::captureWindowPlacement(UiWindowPlacement &placement) {
@@ -7589,7 +7598,7 @@ void SubtrActorPlugin::renderLauncherToggleChrome() {
   if (ImGui::Button("Menu##subtr-actor-launcher-toggle", ImVec2{44.0f, 28.0f})) {
     uiWindowOpen = true;
     if (uiLauncherOpen) {
-      uiLauncherOpen = false;
+      hideLauncherWindow();
     } else {
       showSingletonWindow(uiLauncherOpen, launcherPlacement);
     }
@@ -7675,7 +7684,7 @@ void SubtrActorPlugin::renderWebWindowToggleControls(
         showSingletonWindow(*window.open, *window.placement);
       }
       if (closeLauncherOnToggle) {
-        uiLauncherOpen = false;
+        hideLauncherWindow();
       }
     }
     if (isOpen) {
@@ -7698,7 +7707,7 @@ void SubtrActorPlugin::renderStatsWindowCreationControls(
     if (ImGui::Button(kind.create_label, ImVec2{170.0f, 0.0f})) {
       createStatsWindow(kind.kind);
       if (closeLauncherOnCreate) {
-        uiLauncherOpen = false;
+        hideLauncherWindow();
       }
     }
   }
@@ -7706,7 +7715,7 @@ void SubtrActorPlugin::renderStatsWindowCreationControls(
       ImGui::Button("New stats module", ImVec2{170.0f, 0.0f})) {
     createStatsWindow(UiStatsWindowKind::StatsModule);
     if (closeLauncherOnCreate) {
-      uiLauncherOpen = false;
+      hideLauncherWindow();
     }
   }
   if (uiStatsWindows.empty()) {
@@ -7756,7 +7765,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
     showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
     resetReplayAnnotations();
     tickReplayAnnotations();
-    uiLauncherOpen = false;
+    hideLauncherWindow();
   }
   const bool liveAnalysis = liveProcessingEnabled();
   if (renderModuleSummaryToggle("Live analysis graph", liveAnalysis, "launcher-actions")) {
@@ -7793,17 +7802,17 @@ void SubtrActorPlugin::renderLauncherWindow() {
       ImGui::PushID(moduleName.c_str());
       if (ImGui::SmallButton("Frame")) {
         createStatsModuleWindow(moduleName, 0);
-        uiLauncherOpen = false;
+        hideLauncherWindow();
       }
       ImGui::SameLine();
       if (ImGui::SmallButton("Module")) {
         createStatsModuleWindow(moduleName, 1);
-        uiLauncherOpen = false;
+        hideLauncherWindow();
       }
       ImGui::SameLine();
       if (ImGui::SmallButton("Config")) {
         createStatsModuleWindow(moduleName, 2);
-        uiLauncherOpen = false;
+        hideLauncherWindow();
       }
       ImGui::SameLine();
       ImGui::TextWrapped("%s", moduleName.c_str());
@@ -7816,14 +7825,14 @@ void SubtrActorPlugin::renderLauncherWindow() {
     if (ImGui::Button("Verify graph", ImVec2{170.0f, 0.0f})) {
       showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
       verifyGraphRuntime({"subtr_actor_verify_graph"});
-      uiLauncherOpen = false;
+      hideLauncherWindow();
     }
     if (ImGui::Button("Open modules", ImVec2{170.0f, 0.0f})) {
       showSingletonWindow(uiModuleControlsOpen, moduleControlsPlacement);
-      uiLauncherOpen = false;
+      hideLauncherWindow();
     }
     if (ImGui::Button("Close launcher", ImVec2{170.0f, 0.0f})) {
-      uiLauncherOpen = false;
+      hideLauncherWindow();
     }
 
     ImGui::Separator();
@@ -7833,8 +7842,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
 
   if (uiLauncherOpen && ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !launcherHovered &&
       !uiLauncherToggleHovered) {
-    uiLauncherOpen = false;
-    scheduleUiConfigAutosave();
+    hideLauncherWindow();
   }
 
   ImGui::End();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7943,9 +7943,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
 
     ImGui::Separator();
     renderLauncherWorkspaceControls();
-
-    ImGui::Separator();
-    renderSharedSettingsControls();
     ImGui::TreePop();
   }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9719,47 +9719,69 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
     return;
   }
 
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Pad type");
-  if (ImGui::Checkbox("Big pads", &boostPickupPadBig)) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::Checkbox("Small pads", &boostPickupPadSmall)) {
-    scheduleUiConfigAutosave();
-  }
-  if (ImGui::Checkbox("Ambiguous pads", &boostPickupPadAmbiguous)) {
-    scheduleUiConfigAutosave();
-  }
+  auto selectedCount = [](std::initializer_list<bool> values) {
+    return static_cast<int>(std::count(values.begin(), values.end(), true));
+  };
+  const int padSelected =
+      selectedCount({boostPickupPadBig, boostPickupPadSmall, boostPickupPadAmbiguous});
+  const int activitySelected = selectedCount(
+      {boostPickupActivityActive, boostPickupActivityInactive, boostPickupActivityUnknown});
+  const int fieldSelected =
+      selectedCount({boostPickupFieldOwn, boostPickupFieldOpponent, boostPickupFieldUnknown});
+  const int playerSelected = boostPickupPlayerFilterEnabled
+                                 ? static_cast<int>(boostPickupPlayerIds.size())
+                                 : static_cast<int>(sampledPlayers.size());
+  const bool pickupsHidden = padSelected == 0 || activitySelected == 0 || fieldSelected == 0 ||
+                             (boostPickupPlayerFilterEnabled && playerSelected == 0);
+  const int constrainedGroups =
+      (padSelected < 3 ? 1 : 0) + (activitySelected < 3 ? 1 : 0) +
+      (fieldSelected < 3 ? 1 : 0) +
+      (boostPickupPlayerFilterEnabled &&
+               playerSelected < static_cast<int>(sampledPlayers.size())
+           ? 1
+           : 0);
+  const std::string pickupReadout =
+      pickupsHidden ? "Hidden"
+                    : constrainedGroups == 0 ? "All labels"
+                                             : std::format("{} filters", constrainedGroups);
+  const float pickupReadoutWidth = ImGui::CalcTextSize(pickupReadout.c_str()).x;
+  ImGui::SetCursorPosX(std::max(
+      ImGui::GetCursorPosX(),
+      ImGui::GetWindowContentRegionMax().x - pickupReadoutWidth));
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", pickupReadout.c_str());
 
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Activity");
-  if (ImGui::Checkbox("Active play", &boostPickupActivityActive)) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::Checkbox("Inactive play", &boostPickupActivityInactive)) {
-    scheduleUiConfigAutosave();
-  }
-  if (ImGui::Checkbox("Unknown activity", &boostPickupActivityUnknown)) {
-    scheduleUiConfigAutosave();
-  }
+  auto renderBoostFilterGroupTitle = [](const char *title) {
+    ImGui::TextColored(ImVec4{0.84f, 0.90f, 0.94f, 1.0f}, "%s", title);
+  };
+  auto renderBoostFilterCheckbox = [&](const char *label, bool &value, bool sameLine) {
+    if (sameLine) {
+      ImGui::SameLine();
+    }
+    if (ImGui::Checkbox(label, &value)) {
+      scheduleUiConfigAutosave();
+    }
+  };
 
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Field half");
-  if (ImGui::Checkbox("Own half", &boostPickupFieldOwn)) {
-    scheduleUiConfigAutosave();
-  }
-  ImGui::SameLine();
-  if (ImGui::Checkbox("Opponent half", &boostPickupFieldOpponent)) {
-    scheduleUiConfigAutosave();
-  }
-  if (ImGui::Checkbox("Unknown half", &boostPickupFieldUnknown)) {
-    scheduleUiConfigAutosave();
-  }
+  ImGui::Columns(2, "boost-pickup-filter-grid", false);
+  renderBoostFilterGroupTitle("Pad type");
+  renderBoostFilterCheckbox("Big pads", boostPickupPadBig, false);
+  renderBoostFilterCheckbox("Small pads", boostPickupPadSmall, true);
+  renderBoostFilterCheckbox("Ambiguous pads", boostPickupPadAmbiguous, false);
+  ImGui::NextColumn();
+  renderBoostFilterGroupTitle("Activity");
+  renderBoostFilterCheckbox("Active play", boostPickupActivityActive, false);
+  renderBoostFilterCheckbox("Inactive play", boostPickupActivityInactive, true);
+  renderBoostFilterCheckbox("Unknown activity", boostPickupActivityUnknown, false);
+  ImGui::NextColumn();
+  renderBoostFilterGroupTitle("Field half");
+  renderBoostFilterCheckbox("Own half", boostPickupFieldOwn, false);
+  renderBoostFilterCheckbox("Opponent half", boostPickupFieldOpponent, true);
+  renderBoostFilterCheckbox("Unknown half", boostPickupFieldUnknown, false);
+  ImGui::Columns(1);
 
   if (!sampledPlayers.empty()) {
-    ImGui::Separator();
-    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Player");
+    ImGui::Spacing();
+    renderBoostFilterGroupTitle("Player");
     for (const SaPlayerFrame &player : sampledPlayers) {
       const std::string playerId = webPlayerIdForIndex(player.player_index);
       bool selected =

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9876,11 +9876,16 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
       playbackRateIndex = index;
     }
   }
-  pushPlaybackDisabledStyle(!transportEnabled);
+  const bool playbackRateDisabled = !transportEnabled;
+  pushPlaybackDisabledStyle(playbackRateDisabled);
   ImGui::SetNextItemWidth(96.0f);
-  if (ImGui::BeginCombo("##playback-rate", playbackRateLabels[playbackRateIndex])) {
-    if (!transportEnabled) {
-      ImGui::TextDisabled("%s", playbackRateLabels[playbackRateIndex]);
+  const bool playbackRateOpen =
+      ImGui::BeginCombo("##playback-rate", playbackRateLabels[playbackRateIndex]);
+  popPlaybackDisabledStyle(playbackRateDisabled);
+  if (playbackRateOpen) {
+    if (playbackRateDisabled) {
+      ImGui::CloseCurrentPopup();
+      ImGui::EndCombo();
     } else {
       for (size_t index = 0; index < playbackRateValues.size(); index += 1) {
         const bool selected = index == playbackRateIndex;
@@ -9893,10 +9898,9 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
           ImGui::SetItemDefaultFocus();
         }
       }
+      ImGui::EndCombo();
     }
-    ImGui::EndCombo();
   }
-  popPlaybackDisabledStyle(!transportEnabled);
 
   bool nextSkipPostGoalTransitions = playbackSkipPostGoalTransitions;
   pushPlaybackDisabledStyle(!transportEnabled);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9351,6 +9351,40 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PLAYLIST");
   ImGui::SameLine();
   ImGui::TextDisabled("%zu %s", candidates.size(), candidates.size() == 1 ? "item" : "items");
+  auto renderMechanicsReviewItem = [](const std::string &title,
+                                      const std::string &meta,
+                                      bool active) {
+    const ImGuiStyle &style = ImGui::GetStyle();
+    const float rowWidth = ImGui::GetContentRegionAvail().x;
+    const float rowHeight = std::max(32.0f, ImGui::GetTextLineHeight() + 14.0f);
+    const bool clicked =
+        ImGui::InvisibleButton("##mechanics-review-item", ImVec2{rowWidth, rowHeight});
+    const bool hovered = ImGui::IsItemHovered();
+    const ImVec2 rowMin = ImGui::GetItemRectMin();
+    const ImVec2 rowMax = ImGui::GetItemRectMax();
+    ImDrawList *drawList = ImGui::GetWindowDrawList();
+    const ImVec4 bg = (active || hovered) ? ImVec4{0.29f, 0.58f, 1.0f, 0.16f}
+                                          : ImVec4{1.0f, 1.0f, 1.0f, 0.045f};
+    const ImVec4 border = active ? ImVec4{0.29f, 0.58f, 1.0f, 0.42f}
+                                 : ImVec4{1.0f, 1.0f, 1.0f, 0.09f};
+    drawList->AddRectFilled(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(bg), 6.0f);
+    drawList->AddRect(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(border), 6.0f);
+
+    const std::string metaText = meta.empty() ? "--" : meta;
+    const ImVec2 metaSize = ImGui::CalcTextSize(metaText.c_str());
+    const float textY =
+        rowMin.y + std::max(0.0f, (rowMax.y - rowMin.y - ImGui::GetTextLineHeight()) * 0.5f);
+    const float titleX = rowMin.x + style.FramePadding.x;
+    const float metaX = rowMax.x - style.FramePadding.x - metaSize.x;
+    drawList->PushClipRect(
+        ImVec2{titleX, rowMin.y},
+        ImVec2{std::max(titleX, metaX - 10.0f), rowMax.y},
+        true);
+    drawList->AddText(ImVec2{titleX, textY}, IM_COL32(237, 245, 250, 255), title.c_str());
+    drawList->PopClipRect();
+    drawList->AddText(ImVec2{metaX, textY}, IM_COL32(137, 164, 186, 255), metaText.c_str());
+    return clicked;
+  };
   ImGui::BeginChild("mechanics-review-list", ImVec2{0.0f, 150.0f}, true);
   if (candidates.empty()) {
     ImGui::TextDisabled("No review playlist loaded.");
@@ -9360,13 +9394,6 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     ImGui::PushID(static_cast<int>(i));
     const bool active = i == static_cast<size_t>(mechanicsReviewIndex);
     const std::string title = mechanicsReviewItemTitle(event, i);
-    const std::string label = std::format(
-        "{}##mechanics-review-item",
-        title);
-    if (ImGui::Selectable(label.c_str(), active)) {
-      mechanicsReviewIndex = static_cast<int>(i);
-      scheduleUiConfigAutosave();
-    }
     std::vector<std::string> metaParts;
     if (!event.type.empty()) {
       metaParts.push_back(eventTypeDisplayLabel(event.type));
@@ -9375,7 +9402,11 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
       metaParts.push_back(event.actor);
     }
     metaParts.push_back(mechanicsReviewDecisionLabel(event));
-    ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());
+    const std::string meta = joinStrings(metaParts, " · ");
+    if (renderMechanicsReviewItem(title, meta, active)) {
+      mechanicsReviewIndex = static_cast<int>(i);
+      scheduleUiConfigAutosave();
+    }
     ImGui::PopID();
   }
   ImGui::EndChild();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9256,23 +9256,23 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   const std::string reasonReadout =
       current == nullptr || current->details.empty() ? "--" : current->details;
   ImGui::Columns(2, "mechanics-review-fields", false);
-  ImGui::TextDisabled("Mechanic");
   const std::string mechanicReadout =
       current == nullptr || current->type.empty() ? "--" : eventTypeDisplayLabel(current->type);
-  ImGui::Text("%s", mechanicReadout.c_str());
+  renderWebDetailGridCell("Mechanic", mechanicReadout);
   ImGui::NextColumn();
-  ImGui::TextDisabled("Player");
-  ImGui::Text("%s", current == nullptr || current->actor.empty() ? "--" : current->actor.c_str());
+  renderWebDetailGridCell(
+      "Player",
+      current == nullptr || current->actor.empty() ? "--" : current->actor);
   ImGui::NextColumn();
-  ImGui::TextDisabled("Clip");
-  ImGui::Text("%s", clipReadout.c_str());
+  renderWebDetailGridCell("Clip", clipReadout);
   ImGui::NextColumn();
-  ImGui::TextDisabled("Event");
-  ImGui::Text("%s", eventReadout.c_str());
-  ImGui::NextColumn();
-  ImGui::TextDisabled("Reason");
-  ImGui::TextWrapped("%s", reasonReadout.c_str());
+  renderWebDetailGridCell("Event", eventReadout);
   ImGui::Columns(1);
+  ImGui::Spacing();
+  ImGui::TextColored(ImVec4{0.54f, 0.64f, 0.73f, 1.0f}, "Reason");
+  ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{0.93f, 0.96f, 0.98f, 1.0f});
+  ImGui::TextWrapped("%s", reasonReadout.c_str());
+  ImGui::PopStyleColor();
 
   auto mechanicsReviewButton = [](const char *label,
                                   bool disabled,

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9768,34 +9768,12 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
     return;
   }
 
-  const bool inReplay = gameWrapper->IsInReplay();
-  const bool inGame = gameWrapper->IsInGame();
   ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
   const bool hasReplayServer = !replayServer.IsNull();
-  const char *mode = inReplay ? "replay"
-                              : inGame ? "live match/freeplay" : "waiting for game";
   if (hasReplayServer) {
     playbackCurrentTime = replayServer.GetReplayTimeElapsed();
   }
 
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PLAYBACK");
-  ImGui::Text("Mode: %s", mode);
-  ImGui::Text("Live frame: %llu", static_cast<unsigned long long>(frameNumber));
-  ImGui::Text("Live time: %.2fs", lastTime);
-  if (hasReplayServer) {
-    ImGui::Text("Replay time: %.2fs", replayServer.GetReplayTimeElapsed());
-  } else {
-    ImGui::TextDisabled("Replay time: --");
-  }
-  if (lastProcessedGameTime) {
-    ImGui::Text("Last sampled: %.2fs", *lastProcessedGameTime);
-  } else {
-    ImGui::TextDisabled("Last sampled: --");
-  }
-  ImGui::Text("Status: %s", playbackStatus.c_str());
-
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WEB PLAYBACK CONFIG");
   const bool transportEnabled = hasReplayServer;
   auto pushPlaybackDisabledStyle = [](bool disabled) {
     if (disabled) {
@@ -9839,52 +9817,49 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
     scheduleUiConfigAutosave();
   };
 
-  ImGui::SetNextItemWidth(140.0f);
-  float nextPlaybackCurrentTime = playbackCurrentTime;
-  pushPlaybackDisabledStyle(!transportEnabled);
-  const bool currentTimeChanged =
-      ImGui::InputFloat("Current time", &nextPlaybackCurrentTime, 0.25f, 2.0f, "%.2f");
-  popPlaybackDisabledStyle(!transportEnabled);
-  if (transportEnabled && currentTimeChanged) {
-    playbackCurrentTime = nextPlaybackCurrentTime;
-    scheduleUiConfigAutosave();
-  }
   playbackCurrentTime = std::max(0.0f, playbackCurrentTime);
-  ImGui::SetNextItemWidth(140.0f);
-  float nextPlaybackRate = playbackRate;
-  pushPlaybackDisabledStyle(!transportEnabled);
-  const bool rateChanged =
-      ImGui::SliderFloat("Rate", &nextPlaybackRate, 0.25f, 2.0f, "%.2fx");
-  popPlaybackDisabledStyle(!transportEnabled);
-  if (transportEnabled && rateChanged) {
-    playbackRate = nextPlaybackRate;
-    scheduleUiConfigAutosave();
-  }
+
   if (playbackButton(playbackPlaying ? "Pause" : "Play", !transportEnabled)) {
     applyPlaybackState(!playbackPlaying);
   }
   ImGui::SameLine();
-  if (playbackButton("Seek", !transportEnabled)) {
-    applyPlaybackState(false);
+  constexpr std::array<const char *, 5> playbackRateLabels{{"0.25x", "0.5x", "1.0x", "1.5x", "2.0x"}};
+  constexpr std::array<float, 5> playbackRateValues{{0.25f, 0.5f, 1.0f, 1.5f, 2.0f}};
+  size_t playbackRateIndex = 2;
+  float playbackRateDistance = std::numeric_limits<float>::infinity();
+  for (size_t index = 0; index < playbackRateValues.size(); index += 1) {
+    const float distance = std::abs(playbackRate - playbackRateValues[index]);
+    if (distance < playbackRateDistance) {
+      playbackRateDistance = distance;
+      playbackRateIndex = index;
+    }
   }
-  ImGui::SameLine();
-  if (playbackButton("Live replay time", !hasReplayServer)) {
-    playbackCurrentTime = replayServer.GetReplayTimeElapsed();
-    playbackStatus = std::format("Captured {:.2f}s", playbackCurrentTime);
-    scheduleUiConfigAutosave();
-  }
-  bool nextPlaying = playbackPlaying;
   pushPlaybackDisabledStyle(!transportEnabled);
-  const bool playingChanged = ImGui::Checkbox("Playing", &nextPlaying);
-  popPlaybackDisabledStyle(!transportEnabled);
-  if (transportEnabled && playingChanged) {
-    applyPlaybackState(nextPlaying);
+  ImGui::SetNextItemWidth(96.0f);
+  if (ImGui::BeginCombo("##playback-rate", playbackRateLabels[playbackRateIndex])) {
+    if (!transportEnabled) {
+      ImGui::TextDisabled("%s", playbackRateLabels[playbackRateIndex]);
+    } else {
+      for (size_t index = 0; index < playbackRateValues.size(); index += 1) {
+        const bool selected = index == playbackRateIndex;
+        if (ImGui::Selectable(playbackRateLabels[index], selected)) {
+          playbackRate = playbackRateValues[index];
+          playbackRateIndex = index;
+          scheduleUiConfigAutosave();
+        }
+        if (selected) {
+          ImGui::SetItemDefaultFocus();
+        }
+      }
+    }
+    ImGui::EndCombo();
   }
-  ImGui::SameLine();
+  popPlaybackDisabledStyle(!transportEnabled);
+
   bool nextSkipPostGoalTransitions = playbackSkipPostGoalTransitions;
   pushPlaybackDisabledStyle(!transportEnabled);
   const bool skipGoalChanged =
-      ImGui::Checkbox("Skip goal transitions", &nextSkipPostGoalTransitions);
+      ImGui::Checkbox("Skip post-goal resets", &nextSkipPostGoalTransitions);
   popPlaybackDisabledStyle(!transportEnabled);
   if (transportEnabled && skipGoalChanged) {
     playbackSkipPostGoalTransitions = nextSkipPostGoalTransitions;
@@ -9892,7 +9867,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   }
   bool nextSkipKickoffs = playbackSkipKickoffs;
   pushPlaybackDisabledStyle(!transportEnabled);
-  const bool skipKickoffsChanged = ImGui::Checkbox("Skip kickoffs", &nextSkipKickoffs);
+  const bool skipKickoffsChanged = ImGui::Checkbox("Skip kickoff countdowns", &nextSkipKickoffs);
   popPlaybackDisabledStyle(!transportEnabled);
   if (transportEnabled && skipKickoffsChanged) {
     playbackSkipKickoffs = nextSkipKickoffs;
@@ -9900,74 +9875,24 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   }
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ANALYSIS");
-  auto checkboxCvar = [this](const char *label, const char *name, bool defaultValue) {
-    bool value = cvarBool(name, defaultValue);
-    if (ImGui::Checkbox(label, &value)) {
-      setCvarBool(name, value);
-    }
-  };
-  checkboxCvar("Live analysis graph", "subtr_actor_enabled", false);
-  checkboxCvar("Replay annotations", "subtr_actor_replay_annotations_enabled", true);
-  checkboxCvar("Profile timing", "subtr_actor_profile_enabled", false);
-
-  auto intervalCvar = cvarManager->getCvar("subtr_actor_sample_interval_ms");
-  int intervalMs = static_cast<bool>(intervalCvar) ? intervalCvar.getIntValue() : 8;
-  if (ImGui::SliderInt("Sample interval ms", &intervalMs, 1, 1000) &&
-      static_cast<bool>(intervalCvar)) {
-    intervalCvar.setValue(intervalMs);
-  }
-
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ANNOTATIONS");
-  ImGui::Text(
-      "Status: %s",
-      replayAnnotations ? "loaded" : replayAnnotationLoadFailed ? "failed" : "idle");
-  if (replayAnnotations && replayAnnotationCount) {
-    ImGui::Text("Replay events: %zu", replayAnnotationCount(replayAnnotations));
-  }
-  if (!replayAnnotationPath.empty()) {
-    ImGui::TextWrapped("Replay: %s", replayAnnotationPath.c_str());
-  }
-
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "TIMING");
-  if (profileSampleCount == 0) {
-    ImGui::TextDisabled("No timing samples yet.");
+  const float durationSeconds = std::max(lastTime, playbackCurrentTime);
+  ImGui::Columns(2, "playback-detail-grid", false);
+  ImGui::TextDisabled("Time");
+  ImGui::Text("%.2fs", playbackCurrentTime);
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Frame");
+  ImGui::Text("%llu", static_cast<unsigned long long>(frameNumber));
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Duration");
+  if (durationSeconds > 0.0f) {
+    ImGui::Text("%.2fs", durationSeconds);
   } else {
-    const double divisor = static_cast<double>(profileSampleCount);
-    ImGui::Text("Samples: %llu", static_cast<unsigned long long>(profileSampleCount));
-    ImGui::Text(
-        "Avg total: %.3fms",
-        (profileSamplingMs + profileProcessingMs + profileDrainMs) / divisor);
-    ImGui::Text(
-        "Sample %.3f / process %.3f / drain %.3fms",
-        profileSamplingMs / divisor,
-        profileProcessingMs / divisor,
-        profileDrainMs / divisor);
+    ImGui::TextDisabled("--");
   }
-
-  ImGui::Separator();
-  if (ImGui::Button("Reset live state")) {
-    if (engine && engineReset) {
-      engineReset(engine);
-    }
-    resetLiveState();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Verify graph")) {
-    verifyGraphRuntime({"subtr_actor_verify_graph"});
-  }
-  if (ImGui::Button("Open status")) {
-    showSingletonWindow(uiStatusOpen, statusPlacement);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Open playlist")) {
-    showSingletonWindow(uiEventPlaylistOpen, eventPlaylistPlacement);
-  }
-  if (ImGui::Button("Open modules")) {
-    showSingletonWindow(uiModuleControlsOpen, moduleControlsPlacement);
-  }
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Status");
+  ImGui::Text("%s", playbackPlaying ? "Playing" : transportEnabled ? "Paused" : "Stopped");
+  ImGui::Columns(1);
 
   ImGui::End();
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7426,6 +7426,71 @@ void SubtrActorPlugin::renderLauncherWindow() {
   }
 
   ImGui::Separator();
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WORKSPACES");
+  if (ImGui::Button("Default workspace")) {
+    applyDefaultUiWorkspace();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Review workspace")) {
+    applyReplayReviewUiWorkspace();
+  }
+  if (ImGui::Button("Debug workspace")) {
+    applyGraphDebugUiWorkspace();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Recording workspace")) {
+    applyRecordingUiWorkspace();
+  }
+  if (ImGui::Button("Reset positions")) {
+    resetWindowPlacements();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Default stats windows")) {
+    resetDefaultStatsWindows();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Hide side windows")) {
+    for (const SingletonWindowControl &window : singletonWindowControls()) {
+      if (std::string_view{window.config_id} == "scoreboard") {
+        continue;
+      }
+      *window.open = false;
+    }
+  }
+  if (ImGui::Button("Save layout")) {
+    saveUiConfig();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Reload layout")) {
+    loadUiConfig();
+  }
+  if (ImGui::Button("Copy layout JSON")) {
+    const std::string json = uiConfigJson();
+    ImGui::SetClipboardText(json.c_str());
+    cvarManager->log(std::format("subtr-actor: copied {} UI config bytes", json.size()));
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Copy layout cfg")) {
+    const std::string json = uiConfigJson();
+    const std::string cfg = std::format("#cfg={}", urlEncode(json));
+    ImGui::SetClipboardText(cfg.c_str());
+    cvarManager->log(std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Paste layout")) {
+    const char *clipboardText = ImGui::GetClipboardText();
+    if (clipboardText == nullptr || clipboardText[0] == '\0') {
+      cvarManager->log("subtr-actor: clipboard does not contain UI config JSON or cfg");
+    } else if (const std::optional<std::string> configJson =
+                   statsPlayerCfgJsonFromClipboard(clipboardText)) {
+      applyUiConfigJson(*configJson, "clipboard");
+    } else {
+      cvarManager->log(
+          "subtr-actor: clipboard does not contain raw UI config JSON or a raw JSON cfg value");
+    }
+  }
+
+  ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "VISUALIZATIONS");
   renderModuleSummaryControls("launcher-module-summary");
 
@@ -7484,72 +7549,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
       }
     }
     renderSingletonWindowManager();
-
-    ImGui::Separator();
-    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "LAYOUT");
-    if (ImGui::Button("Default workspace")) {
-      applyDefaultUiWorkspace();
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Review workspace")) {
-      applyReplayReviewUiWorkspace();
-    }
-    if (ImGui::Button("Debug workspace")) {
-      applyGraphDebugUiWorkspace();
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Recording workspace")) {
-      applyRecordingUiWorkspace();
-    }
-    if (ImGui::Button("Reset positions")) {
-      resetWindowPlacements();
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Default stats windows")) {
-      resetDefaultStatsWindows();
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Hide side windows")) {
-      for (const SingletonWindowControl &window : singletonWindowControls()) {
-        if (std::string_view{window.config_id} == "scoreboard") {
-          continue;
-        }
-        *window.open = false;
-      }
-    }
-    if (ImGui::Button("Save layout")) {
-      saveUiConfig();
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Reload layout")) {
-      loadUiConfig();
-    }
-    if (ImGui::Button("Copy layout JSON")) {
-      const std::string json = uiConfigJson();
-      ImGui::SetClipboardText(json.c_str());
-      cvarManager->log(std::format("subtr-actor: copied {} UI config bytes", json.size()));
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Copy layout cfg")) {
-      const std::string json = uiConfigJson();
-      const std::string cfg = std::format("#cfg={}", urlEncode(json));
-      ImGui::SetClipboardText(cfg.c_str());
-      cvarManager->log(
-          std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Paste layout")) {
-      const char *clipboardText = ImGui::GetClipboardText();
-      if (clipboardText == nullptr || clipboardText[0] == '\0') {
-        cvarManager->log("subtr-actor: clipboard does not contain UI config JSON or cfg");
-      } else if (const std::optional<std::string> configJson =
-                     statsPlayerCfgJsonFromClipboard(clipboardText)) {
-        applyUiConfigJson(*configJson, "clipboard");
-      } else {
-        cvarManager->log(
-            "subtr-actor: clipboard does not contain raw UI config JSON or a raw JSON cfg value");
-      }
-    }
 
     ImGui::Separator();
     renderSharedSettingsControls();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3687,6 +3687,10 @@ void SubtrActorPlugin::applyUiConfigJson(
           : hasWebStatsWindows ? parseJsonObjectArrayProperty(json, "statsWindows")
                                : std::vector<std::string>{};
   for (const std::string &object : statsWindowObjects) {
+    const auto idString = parseJsonStringProperty(object, "id");
+    if (statsWindowObjectsFromWeb && !idString) {
+      continue;
+    }
     const auto kind = parseJsonStringProperty(object, "kind");
     if (!kind) {
       continue;
@@ -3700,7 +3704,7 @@ void SubtrActorPlugin::applyUiConfigJson(
     UiStatsWindow window{};
     window.kind = *parsedKind;
 
-    if (const auto idString = parseJsonStringProperty(object, "id")) {
+    if (idString) {
       window.config_id = *idString;
       const size_t digitOffset = idString->find_first_of("0123456789");
       if (digitOffset != std::string::npos) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7296,11 +7296,9 @@ void SubtrActorPlugin::applyStatsWindowPlacement(UiStatsWindow &window) {
     window.pending_apply_placement = false;
     return;
   }
-  const float offset = static_cast<float>((window.id - 1) * 24);
   const auto [width, height] = defaultStatsWindowSize(window.kind);
-  ImGui::SetNextWindowPos(
-      mapWindowPositionToViewport(96.0f + offset, 96.0f + offset, width, height, 0.0f, 0.0f),
-      ImGuiCond_FirstUseEver);
+  const auto [x, y] = defaultStatsWindowPosition(window.id - 1);
+  ImGui::SetNextWindowPos(ImVec2{x, y}, ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowSize(ImVec2{width, height}, ImGuiCond_FirstUseEver);
 }
 
@@ -10533,24 +10531,28 @@ std::pair<float, float> SubtrActorPlugin::defaultStatsWindowSize(UiStatsWindowKi
   return {416.0f, 330.0f};
 }
 
+std::pair<float, float> SubtrActorPlugin::defaultStatsWindowPosition(size_t stackIndex) const {
+  const float offset = static_cast<float>(stackIndex * 18);
+  const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+  const float viewportWidth = displaySize.x > 0.0f ? displaySize.x : 1440.0f;
+  const float viewportHeight = displaySize.y > 0.0f ? displaySize.y : 900.0f;
+  return {
+      std::max(12.0f, std::min(viewportWidth - 360.0f, 96.0f + offset)),
+      std::max(64.0f, std::min(viewportHeight - 240.0f, 96.0f + offset)),
+  };
+}
+
 void SubtrActorPlugin::initializeStatsWindowPlacement(UiStatsWindow &window) {
   resetStatsWindowPlacement(window, uiStatsWindows.size());
 }
 
 void SubtrActorPlugin::resetStatsWindowPlacement(UiStatsWindow &window, size_t stackIndex) {
-  const float offset = static_cast<float>(stackIndex * 18);
   const auto [width, height] = defaultStatsWindowSize(window.kind);
   window.width = width;
   window.height = height;
-  const ImVec2 position = mapWindowPositionToViewport(
-      96.0f + offset,
-      96.0f + offset,
-      window.width,
-      window.height,
-      0.0f,
-      0.0f);
-  window.x = position.x;
-  window.y = position.y;
+  const auto [x, y] = defaultStatsWindowPosition(stackIndex);
+  window.x = x;
+  window.y = y;
   const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
   window.viewport_width = displaySize.x;
   window.viewport_height = displaySize.y;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8043,7 +8043,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
   renderWebWindowToggleControls("launcher-web-windows", true, false, true);
-  renderStatsWindowCreationControls("launcher-stats-windows", true, false, false, true);
+  renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);
 
   ImGui::Separator();
   renderModuleSummaryControls("launcher-module-summary", false, 0.0f, false);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -12088,6 +12088,54 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
     ImGui::PopStyleColor(2);
     ImGui::PopStyleVar(2);
   };
+  auto renderStatsPickerItem = [&](std::string_view label,
+                                   std::string_view meta,
+                                   std::string_view id,
+                                   bool disabled = false) {
+    const ImGuiStyle &style = ImGui::GetStyle();
+    const std::string buttonId = std::format("##stats-picker-item-{}-{}", window.id, id);
+    const float rowWidth = ImGui::GetContentRegionAvail().x;
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2{8.0f, 5.0f});
+    ImGui::PushStyleColor(
+        ImGuiCol_Button,
+        disabled ? ImVec4{1.0f, 1.0f, 1.0f, 0.03f} : ImVec4{1.0f, 1.0f, 1.0f, 0.06f});
+    ImGui::PushStyleColor(
+        ImGuiCol_ButtonHovered,
+        disabled ? ImVec4{1.0f, 1.0f, 1.0f, 0.03f} : ImVec4{1.0f, 1.0f, 1.0f, 0.10f});
+    ImGui::PushStyleColor(
+        ImGuiCol_ButtonActive,
+        disabled ? ImVec4{1.0f, 1.0f, 1.0f, 0.03f} : ImVec4{1.0f, 1.0f, 1.0f, 0.14f});
+    const bool clicked = ImGui::Button(buttonId.c_str(), ImVec2{rowWidth, 0.0f});
+    ImGui::PopStyleColor(3);
+    ImGui::PopStyleVar(2);
+
+    const ImVec2 rowMin = ImGui::GetItemRectMin();
+    const ImVec2 rowMax = ImGui::GetItemRectMax();
+    const float textY =
+        rowMin.y + std::max(0.0f, (rowMax.y - rowMin.y - ImGui::GetTextLineHeight()) * 0.5f);
+    const std::string labelString{label};
+    const std::string metaString = uppercaseHeaderLabel(meta);
+    const ImVec2 metaSize = ImGui::CalcTextSize(metaString.c_str());
+    const float rightX = rowMax.x - style.FramePadding.x - metaSize.x;
+    ImDrawList *drawList = ImGui::GetWindowDrawList();
+    const ImU32 labelColor =
+        disabled ? IM_COL32(115, 132, 146, 255) : IM_COL32(237, 245, 250, 255);
+    drawList->PushClipRect(
+        ImVec2{rowMin.x + style.FramePadding.x, rowMin.y},
+        ImVec2{rightX - 8.0f, rowMax.y},
+        true);
+    drawList->AddText(
+        ImVec2{rowMin.x + style.FramePadding.x, textY},
+        labelColor,
+        labelString.c_str());
+    drawList->PopClipRect();
+    drawList->AddText(
+        ImVec2{rightX, textY},
+        disabled ? IM_COL32(107, 133, 156, 255) : IM_COL32(135, 175, 212, 255),
+        metaString.c_str());
+    return clicked && !disabled;
+  };
 
   std::array<char, 128> queryBuffer{};
   const size_t querySize = std::min(window.picker_query.size(), queryBuffer.size() - 1);
@@ -12161,9 +12209,10 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
     if (count < 2) {
       continue;
     }
-    const std::string label =
-        std::format("Add all {}   {}##{}-{}", category, count, window.id, category);
-    if (ImGui::SmallButton(label.c_str())) {
+    if (renderStatsPickerItem(
+            std::format("Add all {}", category),
+            std::to_string(count),
+            std::format("all-{}", category))) {
       bool added = false;
       for (const UiStatDefinitionMatch &match : matches) {
         if (category != match.definition.category) {
@@ -12193,20 +12242,12 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   for (const UiStatDefinitionMatch &match : matches) {
     const UiStatDefinitionCandidate &definition = match.definition;
     const bool alreadySelected = statsWindowHasStat(window, definition.id);
-    const std::string itemLabel = std::format(
-        "{}   {}##{}-{}",
-        definition.label,
-        uiStatScopeLabel(definition),
-        window.id,
-        definition.id);
-    if (alreadySelected && window.kind != UiStatsWindowKind::AdHoc) {
-      ImGui::TextDisabled(
-          "%s   %s",
-          definition.label.c_str(),
-          uiStatScopeLabel(definition));
-      continue;
-    }
-    if (ImGui::Selectable(itemLabel.c_str(), alreadySelected)) {
+    const bool disabled = alreadySelected && window.kind != UiStatsWindowKind::AdHoc;
+    if (renderStatsPickerItem(
+            definition.label,
+            uiStatScopeLabel(definition),
+            definition.id,
+            disabled)) {
       if (window.kind == UiStatsWindowKind::AdHoc) {
         const std::string targetId = defaultAdHocTargetId(definition.id);
         if (!statsWindowHasStat(window, definition.id, targetId)) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11171,7 +11171,7 @@ void SubtrActorPlugin::renderAdHocTargetSelector(
   }
 }
 
-void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t stackIndex) {
+void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t /*stackIndex*/) {
   applyStatsWindowPlacement(window);
   if (window.pending_focus) {
     ImGui::SetNextWindowFocus();
@@ -11193,21 +11193,14 @@ void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t stackInde
         statsWindowKindLabel(window.kind));
     ImGui::SameLine();
   }
-  const std::string resetLabel = std::format("Reset##stats-window-reset-{}", window.id);
   const std::string hideLabel = std::format("Hide##stats-window-hide-{}", window.id);
   const float buttonPadding = ImGui::GetStyle().FramePadding.x * 2.0f;
-  const float resetWidth = ImGui::CalcTextSize("Reset").x + buttonPadding;
   const float hideWidth =
       ImGui::CalcTextSize("Hide").x + buttonPadding;
-  const float controlsWidth = resetWidth + ImGui::GetStyle().ItemSpacing.x + hideWidth;
-  const float rightAlignedX = ImGui::GetWindowContentRegionMax().x - controlsWidth;
+  const float rightAlignedX = ImGui::GetWindowContentRegionMax().x - hideWidth;
   if (rightAlignedX > ImGui::GetCursorPosX()) {
     ImGui::SetCursorPosX(rightAlignedX);
   }
-  if (ImGui::SmallButton(resetLabel.c_str())) {
-    resetStatsWindowPlacement(window, stackIndex);
-  }
-  ImGui::SameLine();
   if (ImGui::SmallButton(hideLabel.c_str())) {
     window.open = false;
     scheduleUiConfigAutosave();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9282,10 +9282,10 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
   }
   const char *status = !annotationsEnabled
                            ? "Disabled"
-                           : !inReplay       ? "Waiting for replay"
+                           : !inReplay       ? "Pending"
                            : replayAnnotations ? "Loaded"
                            : replayAnnotationLoadFailed ? "Failed"
-                                                        : "Scanning";
+                                                        : "Loading";
   const bool hasReplaySource =
       replayPath || !rawReplayPath.empty() || !replayAnnotationPath.empty();
   const std::string replaySummary = hasReplaySource ? "1 replay" : "0 replays";

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7544,7 +7544,8 @@ void SubtrActorPlugin::renderModuleSummaryControls(const char *idSuffix, bool co
 
 void SubtrActorPlugin::renderModuleSettingsControls(
     const char *idSuffix,
-    bool includeOpenButtons) {
+    bool includeOpenButtons,
+    bool webCardHeaders) {
   ImGui::PushID(idSuffix);
 
   auto settingReadout = [](std::initializer_list<std::pair<bool, const char *>> parts,
@@ -7562,15 +7563,22 @@ void SubtrActorPlugin::renderModuleSettingsControls(
     return readout.empty() ? std::string{"Total only"} : readout;
   };
 
-  ImGui::TextDisabled("Movement breakdown");
-  ImGui::SameLine();
-  ImGui::TextColored(
-      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
-      "%s",
+  auto renderSettingsHeader = [&](const char *title, const std::string &readout) {
+    if (webCardHeaders) {
+      ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STAT DISPLAY");
+      ImGui::Text("%s", title);
+    } else {
+      ImGui::TextDisabled("%s", title);
+    }
+    ImGui::SameLine();
+    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", readout.c_str());
+  };
+
+  renderSettingsHeader(
+      "Movement breakdown",
       settingReadout(
           {{movementBreakdownSpeed, "Speed band"}, {movementBreakdownHeight, "Height band"}},
-          " + ")
-          .c_str());
+          " + "));
   if (ImGui::Checkbox("Speed band##movement-breakdown", &movementBreakdownSpeed)) {
     scheduleUiConfigAutosave();
   }
@@ -7582,15 +7590,14 @@ void SubtrActorPlugin::renderModuleSettingsControls(
     createStatsModuleWindow("movement", 0);
   }
 
-  ImGui::TextDisabled("Possession breakdown");
-  ImGui::SameLine();
-  ImGui::TextColored(
-      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
-      "%s",
+  if (webCardHeaders) {
+    ImGui::Spacing();
+  }
+  renderSettingsHeader(
+      "Possession breakdown",
       settingReadout(
           {{possessionBreakdownState, "Control"}, {possessionBreakdownThird, "Third"}},
-          " x ")
-          .c_str());
+          " x "));
   if (ImGui::Checkbox("Control##possession-breakdown", &possessionBreakdownState)) {
     scheduleUiConfigAutosave();
   }
@@ -7835,7 +7842,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
   renderModuleSummaryControls("launcher-module-summary", false);
 
   ImGui::Separator();
-  renderModuleSettingsControls("launcher-module-settings", false);
+  renderModuleSettingsControls("launcher-module-settings", false, true);
 
   if (ImGui::TreeNode("Plugin tools##launcher-plugin-tools")) {
     if (ImGui::Button("Verify graph", ImVec2{170.0f, 0.0f})) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -4260,6 +4260,44 @@ void SubtrActorPlugin::maybeAutosaveUiConfig() {
   saveUiConfig();
 }
 
+void SubtrActorPlugin::renderLayoutConfigControls(const char *idSuffix) {
+  ImGui::PushID(idSuffix);
+  if (ImGui::Button("Save layout")) {
+    saveUiConfig();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Reload layout")) {
+    loadUiConfig();
+  }
+  if (ImGui::Button("Copy layout JSON")) {
+    const std::string json = uiConfigJson();
+    ImGui::SetClipboardText(json.c_str());
+    cvarManager->log(std::format("subtr-actor: copied {} UI config bytes", json.size()));
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Copy layout cfg")) {
+    const std::string json = uiConfigJson();
+    const std::optional<std::string> encodedCfg = statsPlayerCfgFromJson(json);
+    const std::string cfg = encodedCfg.value_or(std::format("#cfg={}", urlEncode(json)));
+    ImGui::SetClipboardText(cfg.c_str());
+    cvarManager->log(std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Paste layout")) {
+    const char *clipboardText = ImGui::GetClipboardText();
+    if (clipboardText == nullptr || clipboardText[0] == '\0') {
+      cvarManager->log("subtr-actor: clipboard does not contain UI config JSON or cfg");
+    } else if (const std::optional<std::string> configJson =
+                   statsPlayerCfgJsonFromClipboard(clipboardText)) {
+      applyUiConfigJson(*configJson, "clipboard");
+    } else {
+      cvarManager->log(
+          "subtr-actor: clipboard does not contain UI config JSON or a stats-player cfg value");
+    }
+  }
+  ImGui::PopID();
+}
+
 float SubtrActorPlugin::sampleIntervalSeconds() {
   auto intervalCvar = cvarManager->getCvar("subtr_actor_sample_interval_ms");
   const float intervalMs =
@@ -6934,6 +6972,10 @@ void SubtrActorPlugin::renderSharedSettingsControls() {
       static_cast<bool>(maxMessagesCvar)) {
     maxMessagesCvar.setValue(maxMessages);
   }
+
+  ImGui::Separator();
+  ImGui::Text("Layout");
+  renderLayoutConfigControls("settings-layout");
 }
 
 bool SubtrActorPlugin::renderEventFilterCombo(const char *label) {
@@ -7535,40 +7577,7 @@ void SubtrActorPlugin::renderLauncherWorkspaceControls() {
       *window.open = false;
     }
   }
-  if (ImGui::Button("Save layout")) {
-    saveUiConfig();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Reload layout")) {
-    loadUiConfig();
-  }
-  if (ImGui::Button("Copy layout JSON")) {
-    const std::string json = uiConfigJson();
-    ImGui::SetClipboardText(json.c_str());
-    cvarManager->log(std::format("subtr-actor: copied {} UI config bytes", json.size()));
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Copy layout cfg")) {
-    const std::string json = uiConfigJson();
-    const std::optional<std::string> encodedCfg = statsPlayerCfgFromJson(json);
-    const std::string cfg =
-        encodedCfg.value_or(std::format("#cfg={}", urlEncode(json)));
-    ImGui::SetClipboardText(cfg.c_str());
-    cvarManager->log(std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Paste layout")) {
-    const char *clipboardText = ImGui::GetClipboardText();
-    if (clipboardText == nullptr || clipboardText[0] == '\0') {
-      cvarManager->log("subtr-actor: clipboard does not contain UI config JSON or cfg");
-    } else if (const std::optional<std::string> configJson =
-                   statsPlayerCfgJsonFromClipboard(clipboardText)) {
-      applyUiConfigJson(*configJson, "clipboard");
-    } else {
-      cvarManager->log(
-          "subtr-actor: clipboard does not contain UI config JSON or a stats-player cfg value");
-    }
-  }
+  renderLayoutConfigControls("launcher-workspace-layout");
 }
 
 void SubtrActorPlugin::renderLauncherStatsWindowControls() {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3533,7 +3533,6 @@ void SubtrActorPlugin::applyUiConfigJson(
             .value_or(playbackSkipPostGoalTransitions);
     playbackSkipKickoffs =
         parseJsonBoolProperty(*playback, "skipKickoffs").value_or(playbackSkipKickoffs);
-    playbackStatus = parseJsonStringProperty(*playback, "status").value_or(playbackStatus);
     applyPlaybackConfig = true;
   }
   touchControlsMode = static_cast<int>(
@@ -4065,7 +4064,6 @@ std::string SubtrActorPlugin::uiConfigJson() {
        << ",\"skipPostGoalTransitions\":"
        << (playbackSkipPostGoalTransitions ? "true" : "false")
        << ",\"skipKickoffs\":" << (playbackSkipKickoffs ? "true" : "false")
-       << ",\"status\":\"" << escapeJsonString(playbackStatus) << "\""
        << "},\n";
   file << "  \"camera\": {";
   file << "\"mode\":\"" << (cameraViewMode == 1 ? "follow" : "free") << "\"";
@@ -9296,15 +9294,13 @@ void SubtrActorPlugin::renderCameraWindow() {
 }
 
 void SubtrActorPlugin::applyPlaybackConfigToReplay(std::string_view sourceLabel) {
+  (void)sourceLabel;
   if (!gameWrapper || !gameWrapper->IsInReplay()) {
-    playbackStatus = std::format("Loaded playback config from {}", sourceLabel);
     return;
   }
 
   ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
   if (replayServer.IsNull()) {
-    playbackStatus =
-        std::format("Loaded playback config from {}; replay controls unavailable", sourceLabel);
     return;
   }
 
@@ -9312,10 +9308,6 @@ void SubtrActorPlugin::applyPlaybackConfigToReplay(std::string_view sourceLabel)
   playbackCurrentTime = std::max(0.0f, playbackCurrentTime);
   if (playbackPlaying) {
     replayServer.StartPlaybackAtTime(playbackCurrentTime);
-    playbackStatus = std::format(
-        "Applied {} playback config: playing from {:.2f}s",
-        sourceLabel,
-        playbackCurrentTime);
     return;
   }
 
@@ -9324,10 +9316,6 @@ void SubtrActorPlugin::applyPlaybackConfigToReplay(std::string_view sourceLabel)
   if (!replay.IsNull()) {
     replay.StopPlayback();
   }
-  playbackStatus = std::format(
-      "Applied {} playback config: paused at {:.2f}s",
-      sourceLabel,
-      playbackCurrentTime);
 }
 
 void SubtrActorPlugin::renderPlaybackControlsWindow() {
@@ -9377,14 +9365,12 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
     playbackCurrentTime = std::max(0.0f, playbackCurrentTime);
     playbackPlaying = shouldPlay;
     if (!hasReplayServer) {
-      playbackStatus = "Open a Rocket League replay to control playback";
       scheduleUiConfigAutosave();
       return;
     }
 
     if (shouldPlay) {
       replayServer.StartPlaybackAtTime(playbackCurrentTime);
-      playbackStatus = std::format("Playing from {:.2f}s", playbackCurrentTime);
       scheduleUiConfigAutosave();
       return;
     }
@@ -9394,7 +9380,6 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
     if (!replay.IsNull()) {
       replay.StopPlayback();
     }
-    playbackStatus = std::format("Paused at {:.2f}s", playbackCurrentTime);
     scheduleUiConfigAutosave();
   };
 
@@ -11593,10 +11578,10 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
       showSingletonWindow(uiPlaybackControlsOpen, playbackControlsPlacement);
       if (hasReplayServer) {
         replayServer.StartPlaybackAtTime(seekTime);
-        playbackStatus = std::format("Watching goal from {:.2f}s", seekTime);
       } else {
-        playbackStatus =
-            std::format("Selected goal at {:.2f}s; open a replay to seek", seekTime);
+        cvarManager->log(std::format(
+            "subtr-actor: selected goal at {:.2f}s; open a replay to seek",
+            seekTime));
       }
     }
     ImGui::SameLine();
@@ -11613,10 +11598,10 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
         if (!replay.IsNull()) {
           replay.StopPlayback();
         }
-        playbackStatus = std::format("Cued goal at {:.2f}s", seekTime);
       } else {
-        playbackStatus =
-            std::format("Selected goal at {:.2f}s; open a replay to seek", seekTime);
+        cvarManager->log(std::format(
+            "subtr-actor: selected goal at {:.2f}s; open a replay to seek",
+            seekTime));
       }
     }
     ImGui::Spacing();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3434,9 +3434,6 @@ void SubtrActorPlugin::applyUiConfigJson(
       parseJsonNumberProperty(json, "recording_playback_rate_index").value_or(1.0),
       0.0,
       3.0));
-  recordingFinishBeforeDump =
-      parseJsonBoolProperty(json, "recording_finish_before_dump")
-          .value_or(recordingFinishBeforeDump);
 
   if (const auto camera = parseJsonObjectProperty(json, "camera")) {
     const std::optional<std::string> mode = parseJsonStringProperty(*camera, "mode");
@@ -4174,8 +4171,6 @@ std::string SubtrActorPlugin::uiConfigJson() {
   file << "  \"camera_custom_transition_speed\": " << cameraCustomTransitionSpeed << ",\n";
   file << "  \"recording_fps\": " << recordingFps << ",\n";
   file << "  \"recording_playback_rate_index\": " << recordingPlaybackRateIndex << ",\n";
-  file << "  \"recording_finish_before_dump\": "
-       << (recordingFinishBeforeDump ? "true" : "false") << ",\n";
   file << "  \"touch_controls_mode\": " << touchControlsMode << ",\n";
   file << "  \"touch_marker_decay_seconds\": " << touchMarkerDecaySeconds << ",\n";
   file << "  \"touch_breakdown_kind\": " << (touchBreakdownKind ? "true" : "false")
@@ -9631,7 +9626,7 @@ void SubtrActorPlugin::renderRecordingWindow() {
   ImGui::SameLine();
   if (recordingButton("Stop", !recordingActive)) {
     recordingActive = false;
-    dumpSnapshot(recordingFinishBeforeDump);
+    dumpSnapshot(false);
   }
   if (recordingButton("Download", recordingActive || !hasGraphSnapshot)) {
     cvarManager->log(std::format(

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -12384,6 +12384,19 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
 
   ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
   const bool hasReplayServer = !replayServer.IsNull();
+  auto renderGoalTagChip = [](std::string_view text, bool empty, size_t chipIndex) {
+    const ImVec4 background = empty ? ImVec4{0.28f, 0.31f, 0.35f, 0.72f}
+                                    : ImVec4{0.12f, 0.29f, 0.46f, 0.82f};
+    const ImVec4 foreground = empty ? ImVec4{0.75f, 0.80f, 0.84f, 1.0f}
+                                    : ImVec4{0.81f, 0.90f, 1.0f, 1.0f};
+    const std::string label = std::format("{}##goal-tag-chip-{}", text, chipIndex);
+    ImGui::PushStyleColor(ImGuiCol_Button, background);
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, background);
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, background);
+    ImGui::PushStyleColor(ImGuiCol_Text, foreground);
+    ImGui::SmallButton(label.c_str());
+    ImGui::PopStyleColor(4);
+  };
   for (size_t ordinal = 0; ordinal < goalEventIndexes.size(); ordinal += 1) {
     const size_t index = goalEventIndexes[ordinal];
     const UiEventRecord &event = recentUiEvents[index];
@@ -12406,7 +12419,16 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
         formatEventPlaylistTime(event.time).c_str(),
         event.actor.empty() ? "Unknown scorer" : event.actor.c_str());
     const std::vector<std::string> tags = goalTagsForEvent(event);
-    ImGui::TextDisabled("%s", tags.empty() ? "Unlabeled" : joinStrings(tags, " · ").c_str());
+    if (tags.empty()) {
+      renderGoalTagChip("Unlabeled", true, 0);
+    } else {
+      for (size_t tagIndex = 0; tagIndex < tags.size(); tagIndex += 1) {
+        if (tagIndex > 0) {
+          ImGui::SameLine();
+        }
+        renderGoalTagChip(tags[tagIndex], false, tagIndex);
+      }
+    }
     if (watchClicked) {
       mechanicsReviewClipActive = false;
       playbackCurrentTime = seekTime;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9048,6 +9048,12 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
   }
   ImGui::SameLine();
   if (mechanicsReviewButton("Replay clip", replayDisabled)) {
+    if (current != nullptr && current->has_player != 0) {
+      cameraSelectedPlayerIndex = current->player_index;
+      cameraSelectedPlayerId = webPlayerIdForIndex(cameraSelectedPlayerIndex);
+      cameraViewMode = 1;
+      cameraFreePreset = -1;
+    }
     playbackCurrentTime = clipStart;
     playbackPlaying = true;
     playbackSkipPostGoalTransitions = false;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -4277,30 +4277,39 @@ void SubtrActorPlugin::maybeAutosaveUiConfig() {
   saveUiConfig();
 }
 
-void SubtrActorPlugin::renderLayoutConfigControls(const char *idSuffix) {
+void SubtrActorPlugin::renderLayoutConfigControls(const char *idSuffix, bool fullWidth) {
   ImGui::PushID(idSuffix);
-  if (ImGui::Button("Save layout")) {
+  auto buttonSize = [fullWidth]() {
+    return ImVec2{fullWidth ? ImGui::GetContentRegionAvail().x : 0.0f, 0.0f};
+  };
+  if (ImGui::Button("Save layout", buttonSize())) {
     saveUiConfig();
   }
-  ImGui::SameLine();
-  if (ImGui::Button("Reload layout")) {
+  if (!fullWidth) {
+    ImGui::SameLine();
+  }
+  if (ImGui::Button("Reload layout", buttonSize())) {
     loadUiConfig();
   }
-  if (ImGui::Button("Copy layout JSON")) {
+  if (ImGui::Button("Copy layout JSON", buttonSize())) {
     const std::string json = uiConfigJson();
     ImGui::SetClipboardText(json.c_str());
     cvarManager->log(std::format("subtr-actor: copied {} UI config bytes", json.size()));
   }
-  ImGui::SameLine();
-  if (ImGui::Button("Copy layout cfg")) {
+  if (!fullWidth) {
+    ImGui::SameLine();
+  }
+  if (ImGui::Button("Copy layout cfg", buttonSize())) {
     const std::string json = uiConfigJson();
     const std::optional<std::string> encodedCfg = statsPlayerCfgFromJson(json);
     const std::string cfg = encodedCfg.value_or(std::format("#cfg={}", urlEncode(json)));
     ImGui::SetClipboardText(cfg.c_str());
     cvarManager->log(std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
   }
-  ImGui::SameLine();
-  if (ImGui::Button("Paste layout")) {
+  if (!fullWidth) {
+    ImGui::SameLine();
+  }
+  if (ImGui::Button("Paste layout", buttonSize())) {
     const char *clipboardText = ImGui::GetClipboardText();
     if (clipboardText == nullptr || clipboardText[0] == '\0') {
       cvarManager->log("subtr-actor: clipboard does not contain UI config JSON or cfg");
@@ -7738,29 +7747,26 @@ void SubtrActorPlugin::applyLauncherMenuPlacement() {
 
 void SubtrActorPlugin::renderLauncherWorkspaceControls() {
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WORKSPACES");
-  if (ImGui::Button("Default workspace")) {
+  const float workspaceButtonWidth = ImGui::GetContentRegionAvail().x;
+  if (ImGui::Button("Default workspace", ImVec2{workspaceButtonWidth, 0.0f})) {
     applyDefaultUiWorkspace();
   }
-  ImGui::SameLine();
-  if (ImGui::Button("Review workspace")) {
+  if (ImGui::Button("Review workspace", ImVec2{workspaceButtonWidth, 0.0f})) {
     applyReplayReviewUiWorkspace();
   }
-  if (ImGui::Button("Debug workspace")) {
+  if (ImGui::Button("Debug workspace", ImVec2{workspaceButtonWidth, 0.0f})) {
     applyGraphDebugUiWorkspace();
   }
-  ImGui::SameLine();
-  if (ImGui::Button("Recording workspace")) {
+  if (ImGui::Button("Recording workspace", ImVec2{workspaceButtonWidth, 0.0f})) {
     applyRecordingUiWorkspace();
   }
-  if (ImGui::Button("Reset positions")) {
+  if (ImGui::Button("Reset positions", ImVec2{workspaceButtonWidth, 0.0f})) {
     resetWindowPlacements();
   }
-  ImGui::SameLine();
-  if (ImGui::Button("Default stats windows")) {
+  if (ImGui::Button("Default stats windows", ImVec2{workspaceButtonWidth, 0.0f})) {
     resetDefaultStatsWindows();
   }
-  ImGui::SameLine();
-  if (ImGui::Button("Hide side windows")) {
+  if (ImGui::Button("Hide side windows", ImVec2{workspaceButtonWidth, 0.0f})) {
     for (const SingletonWindowControl &window : singletonWindowControls()) {
       if (std::string_view{window.config_id} == "scoreboard") {
         continue;
@@ -7768,7 +7774,7 @@ void SubtrActorPlugin::renderLauncherWorkspaceControls() {
       hideSingletonWindow(*window.open);
     }
   }
-  renderLayoutConfigControls("launcher-workspace-layout");
+  renderLayoutConfigControls("launcher-workspace-layout", true);
 }
 
 void SubtrActorPlugin::renderWebWindowToggleControls(

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7141,7 +7141,30 @@ void SubtrActorPlugin::renderModuleSettingsControls(
     bool includeOpenButtons) {
   ImGui::PushID(idSuffix);
 
+  auto settingReadout = [](std::initializer_list<std::pair<bool, const char *>> parts,
+                           std::string_view separator) {
+    std::string readout;
+    for (const auto &[enabled, label] : parts) {
+      if (!enabled) {
+        continue;
+      }
+      if (!readout.empty()) {
+        readout += separator;
+      }
+      readout += label;
+    }
+    return readout.empty() ? std::string{"Total only"} : readout;
+  };
+
   ImGui::TextDisabled("Movement breakdown");
+  ImGui::SameLine();
+  ImGui::TextColored(
+      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
+      "%s",
+      settingReadout(
+          {{movementBreakdownSpeed, "Speed band"}, {movementBreakdownHeight, "Height band"}},
+          " + ")
+          .c_str());
   ImGui::Checkbox("Speed band##movement-breakdown", &movementBreakdownSpeed);
   ImGui::SameLine();
   ImGui::Checkbox("Height band##movement-breakdown", &movementBreakdownHeight);
@@ -7150,6 +7173,14 @@ void SubtrActorPlugin::renderModuleSettingsControls(
   }
 
   ImGui::TextDisabled("Possession breakdown");
+  ImGui::SameLine();
+  ImGui::TextColored(
+      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
+      "%s",
+      settingReadout(
+          {{possessionBreakdownState, "Control"}, {possessionBreakdownThird, "Third"}},
+          " x ")
+          .c_str());
   ImGui::Checkbox("Control##possession-breakdown", &possessionBreakdownState);
   ImGui::SameLine();
   ImGui::Checkbox("Third##possession-breakdown", &possessionBreakdownThird);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9858,14 +9858,28 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
     }
     return readout.empty() ? std::string{"Total only"} : readout;
   };
+  auto renderTouchSettingsHeader = [](const char *eyebrow,
+                                      const char *title,
+                                      const std::string &readout) {
+    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", eyebrow);
+    const float readoutWidth = ImGui::CalcTextSize(readout.c_str()).x;
+    const float readoutX =
+        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - readoutWidth);
+    ImGui::Text("%s", title);
+    ImGui::SameLine(readoutX);
+    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "%s", readout.c_str());
+  };
 
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Touch markers");
-  ImGui::Text("Touch decay");
-  ImGui::SameLine();
-  ImGui::TextColored(
-      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
-      "%.1fs",
-      touchMarkerDecaySeconds);
+  ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.0f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{13.0f, 12.0f});
+  ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4{1.0f, 1.0f, 1.0f, 0.035f});
+  ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{1.0f, 1.0f, 1.0f, 0.08f});
+  ImGui::BeginChild("touch-settings-card", ImVec2{0.0f, 0.0f}, true);
+
+  renderTouchSettingsHeader(
+      "Touch markers",
+      "Touch decay",
+      std::format("{:.1f}s", touchMarkerDecaySeconds));
   ImGui::TextDisabled("Keep each marker visible after the touch");
   if (ImGui::SliderFloat(
           "##touch-marker-decay-seconds", &touchMarkerDecaySeconds, 1.0f, 10.0f, "%.1fs")) {
@@ -9873,12 +9887,9 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
   }
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Overlay");
-  ImGui::Text("Touch mode");
-  ImGui::SameLine();
-  ImGui::TextColored(
-      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
-      "%s",
+  renderTouchSettingsHeader(
+      "Overlay",
+      "Touch mode",
       touchControlsMode == 1 ? "Advancement" : "Markers");
   if (ImGui::RadioButton("Markers##touch-mode", &touchControlsMode, 0)) {
     setCvarString("subtr_actor_overlay_event_types", "touch");
@@ -9891,13 +9902,7 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
   }
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Stat display");
-  ImGui::Text("Touch breakdown");
-  ImGui::SameLine();
-  ImGui::TextColored(
-      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
-      "%s",
-      touchBreakdownReadout().c_str());
+  renderTouchSettingsHeader("Stat display", "Touch breakdown", touchBreakdownReadout());
   if (ImGui::Checkbox("Kind", &touchBreakdownKind)) {
     scheduleUiConfigAutosave();
   }
@@ -9913,6 +9918,9 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
     scheduleUiConfigAutosave();
   }
 
+  ImGui::EndChild();
+  ImGui::PopStyleColor(2);
+  ImGui::PopStyleVar(2);
   ImGui::End();
 }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -5162,6 +5162,7 @@ void SubtrActorPlugin::resetLiveState() {
   nextBoostPadId = 1;
   messages.clear();
   recentUiEvents.clear();
+  eventPlaylistLastActiveKey.clear();
   mechanicsReviewDecisions.clear();
   mechanicsReviewIndex = 0;
   cachedStatsJson.clear();
@@ -8579,6 +8580,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
       });
 
   if (playlistSources.empty()) {
+    eventPlaylistLastActiveKey.clear();
     ImGui::TextDisabled(
         recentUiEvents.empty() && replayAnnotations == nullptr ? "Load a replay to see events."
                                                                : "No events loaded.");
@@ -8593,17 +8595,20 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
   const bool filtersOpen = ImGui::TreeNode(filterSummary.c_str());
   ImGui::SameLine();
   if (ImGui::Checkbox("Auto-follow", &eventPlaylistAutoFollow)) {
+    eventPlaylistLastActiveKey.clear();
     scheduleUiConfigAutosave();
   }
 
   if (filtersOpen) {
     if (ImGui::Button("All##event-playlist-sources-all")) {
       eventPlaylistSourceFilter = "all";
+      eventPlaylistLastActiveKey.clear();
       scheduleUiConfigAutosave();
     }
     ImGui::SameLine();
     if (ImGui::Button("None##event-playlist-sources-none")) {
       eventPlaylistSourceFilter = "none";
+      eventPlaylistLastActiveKey.clear();
       scheduleUiConfigAutosave();
     }
 
@@ -8632,6 +8637,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
           appendUniqueFilterToken(selectedSources, option.value);
         }
         eventPlaylistSourceFilter = eventFilterFromSelectedSources(selectedSources);
+        eventPlaylistLastActiveKey.clear();
         scheduleUiConfigAutosave();
       }
       ImGui::PopID();
@@ -8663,6 +8669,8 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
       activeEventIndex = index;
     }
   }
+  const std::string activeEventKey =
+      activeEventIndex ? mechanicsReviewKey(recentUiEvents[*activeEventIndex]) : "";
 
   ImGui::BeginChild("event-playlist-list", ImVec2{0.0f, 0.0f}, true);
   for (const size_t index : playlistEventIndexes) {
@@ -8705,12 +8713,13 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     if (!event.details.empty()) {
       ImGui::TextDisabled("%s", event.details.c_str());
     }
-    if (active && eventPlaylistAutoFollow) {
+    if (active && eventPlaylistAutoFollow && activeEventKey != eventPlaylistLastActiveKey) {
       ImGui::SetScrollHereY(0.5f);
     }
     ImGui::Separator();
     ImGui::PopID();
   }
+  eventPlaylistLastActiveKey = activeEventKey;
   if (playlistEventIndexes.empty()) {
     ImGui::TextWrapped(
         selectedSourceCount == 0 ? "No event types selected."
@@ -10495,6 +10504,7 @@ void SubtrActorPlugin::applyReplayReviewUiWorkspace() {
   eventPlaylistGoalContextEnabled = true;
   eventPlaylistAutoFollow = true;
   eventPlaylistSourceFilter = "default";
+  eventPlaylistLastActiveKey.clear();
   resetWindowPlacements();
   mechanicsReviewPlacement.pending_focus = true;
   replayLoadingPlacement.pending_focus = true;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10147,7 +10147,16 @@ void SubtrActorPlugin::resetStatsWindowPlacement(UiStatsWindow &window, size_t s
 }
 
 void SubtrActorPlugin::renderStatsWindows() {
+  std::vector<size_t> renderOrder;
+  renderOrder.reserve(uiStatsWindows.size());
   for (size_t index = 0; index < uiStatsWindows.size(); index += 1) {
+    renderOrder.push_back(index);
+  }
+  std::stable_sort(renderOrder.begin(), renderOrder.end(), [&](size_t left, size_t right) {
+    return uiStatsWindows[left].z_index < uiStatsWindows[right].z_index;
+  });
+
+  for (const size_t index : renderOrder) {
     UiStatsWindow &window = uiStatsWindows[index];
     if (window.open) {
       renderStatsWindow(window, index);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11596,6 +11596,11 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
   }
 }
 
+void renderStatsWindowEmpty(std::string_view message) {
+  ImGui::Spacing();
+  ImGui::TextDisabled("%s", std::string{message}.c_str());
+}
+
 void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   if (window.kind == UiStatsWindowKind::StatsModule) {
     if (ImGui::RadioButton(
@@ -11743,7 +11748,7 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   }
 
   if (matches.empty()) {
-    ImGui::Text("No matching stats.");
+    renderStatsWindowEmpty("No matching stats.");
     ImGui::EndChild();
     ImGui::Separator();
     return;
@@ -11780,11 +11785,6 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   }
   ImGui::EndChild();
   ImGui::Separator();
-}
-
-void renderStatsWindowEmpty(std::string_view message) {
-  ImGui::Spacing();
-  ImGui::TextDisabled("%s", std::string{message}.c_str());
 }
 
 void SubtrActorPlugin::renderStatsWindowEntries(UiStatsWindow &window) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8633,23 +8633,34 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
       mechanicsReviewIndex + 1,
       candidates.size());
   ImGui::TextWrapped("%s", current.label.c_str());
-  ImGui::Text("Decision: %s", mechanicsReviewDecisionLabel(current));
-  ImGui::Text("Mechanic: %s", current.type.c_str());
-  ImGui::Text("Player: %s", current.actor.c_str());
-  ImGui::Text("Clip: %.2fs to %.2fs", clipStart, clipEnd);
-  if (mechanicsReviewClipActive) {
-    ImGui::TextColored(
-        ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
-        "Active clip: %.2fs to %.2fs",
-        mechanicsReviewClipStartSeconds,
-        mechanicsReviewClipEndSeconds);
-  }
-  if (!mechanicsReviewStatus.empty()) {
-    ImGui::TextWrapped("Status: %s", mechanicsReviewStatus.c_str());
-  }
-  ImGui::Text("Event: frame %llu", static_cast<unsigned long long>(current.frame_number));
-  if (!current.details.empty()) {
-    ImGui::TextWrapped("Reason: %s", current.details.c_str());
+  const std::string clipReadout = std::format("{:.2f}s to {:.2f}s", clipStart, clipEnd);
+  const std::string eventReadout =
+      std::format("frame {}", static_cast<unsigned long long>(current.frame_number));
+  const std::string reasonReadout = current.details.empty() ? "--" : current.details;
+  ImGui::Columns(2, "mechanics-review-fields", false);
+  ImGui::TextDisabled("Mechanic");
+  ImGui::Text("%s", current.type.empty() ? "--" : current.type.c_str());
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Player");
+  ImGui::Text("%s", current.actor.empty() ? "--" : current.actor.c_str());
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Clip");
+  ImGui::Text("%s", clipReadout.c_str());
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Event");
+  ImGui::Text("%s", eventReadout.c_str());
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Reason");
+  ImGui::TextWrapped("%s", reasonReadout.c_str());
+  ImGui::Columns(1);
+  if (mechanicsReviewClipActive || !mechanicsReviewStatus.empty()) {
+    const std::string status = mechanicsReviewClipActive
+                                   ? std::format(
+                                         "Playing clip {:.2f}s to {:.2f}s",
+                                         mechanicsReviewClipStartSeconds,
+                                         mechanicsReviewClipEndSeconds)
+                                   : mechanicsReviewStatus;
+    ImGui::TextWrapped("%s", status.c_str());
   }
 
   if (ImGui::Button("Prev") && mechanicsReviewIndex > 0) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9544,12 +9544,13 @@ void SubtrActorPlugin::renderCameraWindow() {
   };
   cameraViewMode = std::clamp(cameraViewMode, 0, static_cast<int>(viewModes.size()) - 1);
 
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "CAMERA PROFILE");
   const std::string selectedLabel =
       targetPlayer == nullptr
           ? "Free camera"
           : playerLabel(targetPlayer->player_index, targetPlayer->is_team_0);
-  if (ImGui::BeginCombo("Target", selectedLabel.c_str())) {
+  ImGui::TextDisabled("Camera profile");
+  ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+  if (ImGui::BeginCombo("##attached-player", selectedLabel.c_str())) {
     if (ImGui::Selectable("Free camera", cameraViewMode != 1)) {
       cameraViewMode = 0;
       cameraFreePreset = -1;
@@ -9667,49 +9668,34 @@ void SubtrActorPlugin::renderCameraWindow() {
   const float fov = cameraCustomSettingsEnabled ? cameraCustomFov : 110.0f;
   const float height = cameraCustomSettingsEnabled ? cameraCustomHeight : 100.0f;
   const float pitch = cameraCustomSettingsEnabled ? cameraCustomPitch : -4.0f;
-  const float distance = (cameraCustomSettingsEnabled ? cameraCustomDistance : 270.0f) *
-                         cameraDistanceScale;
+  const float distance = cameraCustomSettingsEnabled ? cameraCustomDistance : 270.0f;
   const float stiffness = cameraCustomSettingsEnabled ? cameraCustomStiffness : 0.0f;
+  const std::string profileReadout = targetPlayer == nullptr
+                                         ? "Free camera"
+                                         : cameraCustomSettingsEnabled
+                                               ? std::format("{} custom", selectedLabel)
+                                               : selectedLabel;
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "READOUT");
-  ImGui::Text("Mode: %s", viewModes[static_cast<size_t>(cameraViewMode)]);
-  ImGui::Text("Target: %s", selectedLabel.c_str());
-  ImGui::Text("FOV %.0f  Height %.0f  Pitch %.1f", fov, height, pitch);
-  ImGui::Text("Distance %.0f  Stiffness %.2f", distance, stiffness);
-  ImGui::Text("Ball cam: %s", cameraBallCamEnabled ? "on" : "off");
-  if (targetPlayer == nullptr) {
-    ImGui::TextDisabled("No player target selected.");
-  } else if (targetPlayer->has_rigid_body == 0) {
-    ImGui::TextDisabled("Selected player has no rigid body sample.");
-  } else {
-    const SaVec3 location = targetPlayer->rigid_body.location;
-    const SaVec3 velocity = targetPlayer->rigid_body.linear_velocity;
-    ImGui::Text(
-        "Location: %.0f, %.0f, %.0f", location.x, location.y, location.z);
-    if (targetPlayer->rigid_body.has_linear_velocity != 0) {
-      ImGui::Text(
-          "Velocity: %.0f, %.0f, %.0f", velocity.x, velocity.y, velocity.z);
-    }
-  }
-
-  ImGui::Separator();
-  if (ImGui::Button("Open playback")) {
-    showSingletonWindow(uiPlaybackControlsOpen, playbackControlsPlacement);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Open recording")) {
-    showSingletonWindow(uiRecordingOpen, recordingPlacement);
-  }
-  if (targetPlayer != nullptr && ImGui::Button("Open player stats")) {
-    createStatsWindow(UiStatsWindowKind::Player, true);
-    if (!uiStatsWindows.empty()) {
-      UiStatsWindow &window = uiStatsWindows.back();
-      window.selected_player_index = targetPlayer->player_index;
-      window.selected_player_id = webPlayerIdForIndex(window.selected_player_index);
-      window.selected_team_is_team_0 = targetPlayer->is_team_0;
-    }
-  }
+  ImGui::Columns(2, "camera-detail-grid", false);
+  ImGui::TextDisabled("Profile");
+  ImGui::Text("%s", profileReadout.c_str());
+  ImGui::NextColumn();
+  ImGui::TextDisabled("FOV");
+  ImGui::Text("%.0f", fov);
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Height");
+  ImGui::Text("%.0f", height);
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Pitch");
+  ImGui::Text("%.1f", pitch);
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Distance");
+  ImGui::Text("%.0f", distance);
+  ImGui::NextColumn();
+  ImGui::TextDisabled("Stiffness");
+  ImGui::Text("%.2f", stiffness);
+  ImGui::Columns(1);
 
   ImGui::End();
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7494,11 +7494,40 @@ void SubtrActorPlugin::renderEventSourceControls() {
     return;
   }
 
+  const std::string currentFilter = cvarString("subtr_actor_overlay_event_types", "all");
+  const bool allSelected = allEventSourcesSelected(currentFilter);
   std::vector<std::string> selected =
-      selectedEventSourceTokens(cvarString("subtr_actor_overlay_event_types", "all"));
+      selectedEventSourceTokens(currentFilter);
   auto applySelection = [&]() {
     setCvarString("subtr_actor_overlay_event_types", eventFilterFromSelectedSources(selected));
   };
+
+  struct DisplaySource {
+    const EventFilterOption *option = nullptr;
+    size_t count = 0;
+    bool enabled = false;
+  };
+
+  std::vector<DisplaySource> displaySources;
+  displaySources.reserve(EVENT_FILTER_OPTIONS.size());
+  for (const EventFilterOption &option : EVENT_FILTER_OPTIONS) {
+    if (std::string_view{option.value} == "all") {
+      continue;
+    }
+
+    size_t count = 0;
+    for (const UiEventRecord &event : recentUiEvents) {
+      if (eventFilterAllows(option.value, event.category, event.type)) {
+        count += 1;
+      }
+    }
+
+    const bool enabled = containsString(selected, option.value);
+    if (count == 0 && (allSelected || !enabled)) {
+      continue;
+    }
+    displaySources.push_back(DisplaySource{&option, count, enabled});
+  }
 
   if (ImGui::SmallButton("All events##event-sources")) {
     selected = selectedEventSourceTokens("all");
@@ -7513,13 +7542,19 @@ void SubtrActorPlugin::renderEventSourceControls() {
   const std::string preview =
       eventFilterPreview(cvarString("subtr_actor_overlay_event_types", "all"));
   ImGui::TextDisabled("%s", preview.c_str());
+  ImGui::TextDisabled("%zu loaded sources", displaySources.size());
 
   ImGui::BeginChild("event-source-list", ImVec2{0.0f, 185.0f}, true);
+  if (displaySources.empty()) {
+    ImGui::TextDisabled("No events loaded.");
+    ImGui::EndChild();
+    ImGui::TreePop();
+    return;
+  }
+
   std::string_view currentGroup;
-  for (const EventFilterOption &option : EVENT_FILTER_OPTIONS) {
-    if (std::string_view{option.value} == "all") {
-      continue;
-    }
+  for (const DisplaySource &source : displaySources) {
+    const EventFilterOption &option = *source.option;
     const std::string_view optionGroup{option.group};
     if (currentGroup != optionGroup) {
       if (!currentGroup.empty()) {
@@ -7529,16 +7564,9 @@ void SubtrActorPlugin::renderEventSourceControls() {
       currentGroup = optionGroup;
     }
 
-    size_t count = 0;
-    for (const UiEventRecord &event : recentUiEvents) {
-      if (eventFilterAllows(option.value, event.category, event.type)) {
-        count += 1;
-      }
-    }
-
     ImGui::PushID(option.value);
-    bool enabled = containsString(selected, option.value);
-    const std::string label = std::format("{} ({})", option.label, count);
+    bool enabled = source.enabled;
+    const std::string label = std::format("{} ({})", option.label, source.count);
     if (renderModuleSummaryToggle(label.c_str(), enabled, "event-sources")) {
       if (enabled) {
         selected.erase(

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9066,11 +9066,27 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
                                        : "Loaded review playlist.";
   ImGui::TextWrapped("%s", statusReadout.c_str());
   const std::string clipReadout =
-      current == nullptr ? "--" : std::format("{:.2f}s to {:.2f}s", clipStart, clipEnd);
-  const std::string eventReadout =
       current == nullptr
           ? "--"
-          : std::format("frame {}", static_cast<unsigned long long>(current->frame_number));
+          : std::format(
+                "{:.2f}s to {:.2f}s · {:.1f}s clip · {:.1f}s preroll · {:.1f}s postroll",
+                clipStart,
+                clipEnd,
+                std::max(0.0f, clipEnd - clipStart),
+                std::max(0.0f, current->time - clipStart),
+                std::max(0.0f, clipEnd - current->time));
+  const std::string eventReadout = [&]() {
+    if (current == nullptr) {
+      return std::string{"--"};
+    }
+    if (current->frame_number == 0) {
+      return std::format("{:.2f}s", current->time);
+    }
+    return std::format(
+        "{:.2f}s · frame {}",
+        current->time,
+        static_cast<unsigned long long>(current->frame_number));
+  }();
   const std::string reasonReadout =
       current == nullptr || current->details.empty() ? "--" : current->details;
   ImGui::Columns(2, "mechanics-review-fields", false);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -12178,6 +12178,26 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
       goalEventIndexes.push_back(index);
     }
   }
+  for (size_t index = 0; index < recentUiEvents.size(); index += 1) {
+    const UiEventRecord &event = recentUiEvents[index];
+    if (!isGoalTagEvent(event)) {
+      continue;
+    }
+    const bool hasMatchingGoalEvent = std::any_of(
+        goalEventIndexes.begin(),
+        goalEventIndexes.end(),
+        [&](size_t goalIndex) {
+          const UiEventRecord &goalEvent = recentUiEvents[goalIndex];
+          const bool samePlayer = goalEvent.has_player == 0 || event.has_player == 0 ||
+                                  goalEvent.player_index == event.player_index;
+          const bool sameFrame = goalEvent.frame_number == event.frame_number;
+          const bool nearbyTime = std::fabs(goalEvent.time - event.time) <= 0.25f;
+          return samePlayer && (sameFrame || nearbyTime);
+        });
+    if (!hasMatchingGoalEvent) {
+      goalEventIndexes.push_back(index);
+    }
+  }
   std::sort(goalEventIndexes.begin(), goalEventIndexes.end(), [&](size_t left, size_t right) {
     const UiEventRecord &leftEvent = recentUiEvents[left];
     const UiEventRecord &rightEvent = recentUiEvents[right];

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11948,10 +11948,28 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
   }
 
   const std::string addButton = std::format("+##add-stat-{}", window.id);
-  if (statsWindowKindHasScopeSelector(window.kind)) {
+  const bool hasScopeSelector = statsWindowKindHasScopeSelector(window.kind);
+  const float addButtonSize = ImGui::GetFrameHeight();
+  auto renderAddButton = [&]() {
+    if (window.picker_open) {
+      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{1.0f, 1.0f, 1.0f, 0.10f});
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{1.0f, 1.0f, 1.0f, 0.14f});
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{1.0f, 1.0f, 1.0f, 0.18f});
+    }
+    const bool clicked = ImGui::Button(addButton.c_str(), ImVec2{addButtonSize, 0.0f});
+    if (window.picker_open) {
+      ImGui::PopStyleColor(3);
+    }
+    return clicked;
+  };
+  if (hasScopeSelector) {
     ImGui::SameLine();
+  } else {
+    const float addButtonX =
+        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - addButtonSize);
+    ImGui::SetCursorPosX(addButtonX);
   }
-  if (ImGui::Button(addButton.c_str())) {
+  if (renderAddButton()) {
     window.picker_open = !window.picker_open;
   }
   if (ImGui::IsItemHovered()) {
@@ -11963,10 +11981,19 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
     return;
   }
 
+  ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 6.0f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{12.0f, 10.0f});
+  ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4{1.0f, 1.0f, 1.0f, 0.04f});
+  ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{1.0f, 1.0f, 1.0f, 0.08f});
   ImGui::BeginChild(
       std::format("stat-picker-{}", window.id).c_str(),
       ImVec2{0.0f, 190.0f},
       true);
+  auto endStatsPickerPanel = [&]() {
+    ImGui::EndChild();
+    ImGui::PopStyleColor(2);
+    ImGui::PopStyleVar(2);
+  };
 
   std::array<char, 128> queryBuffer{};
   const size_t querySize = std::min(window.picker_query.size(), queryBuffer.size() - 1);
@@ -12064,7 +12091,7 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
 
   if (matches.empty()) {
     renderStatsWindowEmpty("No matching stats.");
-    ImGui::EndChild();
+    endStatsPickerPanel();
     ImGui::Separator();
     return;
   }
@@ -12098,7 +12125,7 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
       }
     }
   }
-  ImGui::EndChild();
+  endStatsPickerPanel();
   ImGui::Separator();
 }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7565,6 +7565,7 @@ void SubtrActorPlugin::renderModuleSettingsControls(
 }
 
 void SubtrActorPlugin::renderLauncherToggleChrome() {
+  uiLauncherToggleHovered = false;
   if (!uiEnabled() && !uiLauncherOpen) {
     return;
   }
@@ -7597,6 +7598,7 @@ void SubtrActorPlugin::renderLauncherToggleChrome() {
   if (uiLauncherOpen) {
     ImGui::PopStyleColor(3);
   }
+  uiLauncherToggleHovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
   ImGui::End();
   ImGui::PopStyleVar(2);
 }
@@ -7747,6 +7749,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
     return;
   }
   captureWindowPlacement(launcherPlacement);
+  const bool launcherHovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
 
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ACTIONS");
   if (ImGui::Button("Load Replay...")) {
@@ -7826,6 +7829,12 @@ void SubtrActorPlugin::renderLauncherWindow() {
     ImGui::Separator();
     renderSharedSettingsControls();
     ImGui::TreePop();
+  }
+
+  if (uiLauncherOpen && ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !launcherHovered &&
+      !uiLauncherToggleHovered) {
+    uiLauncherOpen = false;
+    scheduleUiConfigAutosave();
   }
 
   ImGui::End();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7023,9 +7023,9 @@ void SubtrActorPlugin::captureWindowPlacement(UiWindowPlacement &placement) {
   const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
   placement.viewport_width = displaySize.x;
   placement.viewport_height = displaySize.y;
-  if (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) &&
+  if (ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows) &&
       ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-    placement.z_index = std::max(placement.z_index, nextUiWindowZIndex++);
+    placement.z_index = nextUiWindowZIndex++;
   }
 }
 
@@ -7131,9 +7131,9 @@ void SubtrActorPlugin::captureStatsWindowPlacement(UiStatsWindow &window) {
   const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
   window.viewport_width = displaySize.x;
   window.viewport_height = displaySize.y;
-  if (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) &&
+  if (ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows) &&
       ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-    window.z_index = std::max(window.z_index, nextUiWindowZIndex++);
+    window.z_index = nextUiWindowZIndex++;
   }
 }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -5282,6 +5282,7 @@ void SubtrActorPlugin::recordGoal(
     return;
   }
   rememberTeamScores(event);
+  pushGoalEventMessage(event);
   pendingGoals.push_back(event);
 
   recordExplicitPlayerStat(priForScoreIndex(server, assistIndex), SaPlayerStatEventKindAssist);
@@ -6974,6 +6975,27 @@ bool SubtrActorPlugin::uiEventVisible(const UiEventRecord &event) {
     return false;
   }
   return eventFilterAllows(cvarString("subtr_actor_overlay_event_types", "all"), event.category, event.type);
+}
+
+void SubtrActorPlugin::pushGoalEventMessage(const SaGoalEvent &event) {
+  const bool isBlue = event.scoring_team_is_team_0 != 0;
+  const std::string actor =
+      event.has_player != 0 ? playerLabel(event.player_index, event.scoring_team_is_team_0)
+                            : teamLabel(event.scoring_team_is_team_0);
+  std::string details = teamLabel(event.scoring_team_is_team_0);
+  if (event.has_team_zero_score != 0 && event.has_team_one_score != 0) {
+    details = std::format("Blue {} - {} Orange", event.team_zero_score, event.team_one_score);
+  }
+  appendUiEvent(UiEventRecord{
+      "goal",
+      "goal",
+      actor,
+      std::format("{} goal", actor),
+      details,
+      isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
+      event.timing.frame_number,
+      event.timing.time,
+  });
 }
 
 void SubtrActorPlugin::pushEventMessage(const SaMechanicEvent &event) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10228,9 +10228,14 @@ void SubtrActorPlugin::renderRecordingWindow() {
   }
 
   ImGui::Separator();
+  const std::string recordingStatusReadout =
+      recordingActive   ? "Recording"
+      : hasGraphSnapshot ? "Ready"
+      : !loaded || !engine ? "No replay"
+                           : recordingStatus;
   ImGui::Columns(2, "recording-detail-grid", false);
   ImGui::TextDisabled("Status");
-  ImGui::Text("%s", recordingStatus.c_str());
+  ImGui::Text("%s", recordingStatusReadout.c_str());
   ImGui::NextColumn();
   ImGui::TextDisabled("Elapsed");
   ImGui::Text("%.1fs", elapsedSeconds);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1039,6 +1039,76 @@ std::string urlEncode(std::string_view value) {
   return encoded;
 }
 
+int urlHexValue(char ch) {
+  if (ch >= '0' && ch <= '9') {
+    return ch - '0';
+  }
+  if (ch >= 'A' && ch <= 'F') {
+    return ch - 'A' + 10;
+  }
+  if (ch >= 'a' && ch <= 'f') {
+    return ch - 'a' + 10;
+  }
+  return -1;
+}
+
+std::optional<std::string> urlDecode(std::string_view value) {
+  std::string decoded;
+  decoded.reserve(value.size());
+  for (size_t index = 0; index < value.size(); index += 1) {
+    const char ch = value[index];
+    if (ch == '+') {
+      decoded.push_back(' ');
+      continue;
+    }
+    if (ch != '%') {
+      decoded.push_back(ch);
+      continue;
+    }
+    if (index + 2 >= value.size()) {
+      return std::nullopt;
+    }
+    const int high = urlHexValue(value[index + 1]);
+    const int low = urlHexValue(value[index + 2]);
+    if (high < 0 || low < 0) {
+      return std::nullopt;
+    }
+    decoded.push_back(static_cast<char>((high << 4) | low));
+    index += 2;
+  }
+  return decoded;
+}
+
+std::optional<std::string> statsPlayerCfgJsonFromClipboard(std::string_view clipboardText) {
+  const size_t firstByte = clipboardText.find_first_not_of(" \t\r\n");
+  if (firstByte == std::string_view::npos) {
+    return std::nullopt;
+  }
+  if (clipboardText[firstByte] == '{') {
+    return std::string{clipboardText.substr(firstByte)};
+  }
+
+  const size_t cfgOffset = clipboardText.find("cfg=");
+  if (cfgOffset == std::string_view::npos) {
+    return std::nullopt;
+  }
+  const size_t valueStart = cfgOffset + 4;
+  size_t valueEnd = clipboardText.find_first_of("&# \t\r\n", valueStart);
+  if (valueEnd == std::string_view::npos) {
+    valueEnd = clipboardText.size();
+  }
+  std::optional<std::string> decoded =
+      urlDecode(clipboardText.substr(valueStart, valueEnd - valueStart));
+  if (!decoded) {
+    return std::nullopt;
+  }
+  const size_t decodedFirstByte = decoded->find_first_not_of(" \t\r\n");
+  if (decodedFirstByte == std::string::npos || (*decoded)[decodedFirstByte] != '{') {
+    return std::nullopt;
+  }
+  return decoded->substr(decodedFirstByte);
+}
+
 std::string clippedDisplayText(std::string value, size_t maxBytes = 24000) {
   if (value.size() <= maxBytes) {
     return value;
@@ -7414,12 +7484,16 @@ void SubtrActorPlugin::renderLauncherWindow() {
           std::format("subtr-actor: copied {} UI config hash bytes", cfg.size()));
     }
     ImGui::SameLine();
-    if (ImGui::Button("Paste layout JSON")) {
+    if (ImGui::Button("Paste layout")) {
       const char *clipboardText = ImGui::GetClipboardText();
       if (clipboardText == nullptr || clipboardText[0] == '\0') {
-        cvarManager->log("subtr-actor: clipboard does not contain UI config JSON");
+        cvarManager->log("subtr-actor: clipboard does not contain UI config JSON or cfg");
+      } else if (const std::optional<std::string> configJson =
+                     statsPlayerCfgJsonFromClipboard(clipboardText)) {
+        applyUiConfigJson(*configJson, "clipboard");
       } else {
-        applyUiConfigJson(clipboardText, "clipboard");
+        cvarManager->log(
+            "subtr-actor: clipboard does not contain raw UI config JSON or a raw JSON cfg value");
       }
     }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7067,7 +7067,6 @@ void SubtrActorPlugin::applyWindowPlacement(
   auto applyFocus = [&]() {
     if (placement.pending_focus) {
       ImGui::SetNextWindowFocus();
-      placement.z_index = nextUiWindowZIndex++;
       placement.pending_focus = false;
     }
   };
@@ -7247,7 +7246,6 @@ void SubtrActorPlugin::applyScoreboardWindowPlacement() {
   auto applyFocus = [&]() {
     if (scoreboardPlacement.pending_focus) {
       ImGui::SetNextWindowFocus();
-      scoreboardPlacement.z_index = nextUiWindowZIndex++;
       scoreboardPlacement.pending_focus = false;
     }
   };
@@ -11279,7 +11277,6 @@ void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t /*stackIn
   applyStatsWindowPlacement(window);
   if (window.pending_focus) {
     ImGui::SetNextWindowFocus();
-    window.z_index = nextUiWindowZIndex++;
     window.pending_focus = false;
   }
   const std::string title = statsWindowTitle(window);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3106,6 +3106,20 @@ void SubtrActorPlugin::applyUiConfigJson(
       loadPlacementObject(*placement, touchControlsPlacement, &uiTouchControlsOpen);
     }
   }
+  for (const std::string &object : parseJsonObjectArrayProperty(json, "pluginWindows")) {
+    const std::string id = parseJsonStringProperty(object, "id").value_or("");
+    const auto placement = parseJsonObjectProperty(object, "placement");
+    if (!placement) {
+      continue;
+    }
+    for (const SingletonWindowControl &window : singletonWindowControls()) {
+      if (window.web_config || id != window.config_id) {
+        continue;
+      }
+      loadPlacementObject(*placement, *window.placement, window.open);
+      break;
+    }
+  }
 
   uiStatsWindows.clear();
   nextUiStatsWindowId = 1;
@@ -3258,7 +3272,7 @@ void SubtrActorPlugin::applyUiConfigJson(
   nextUiConfigAutosave = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 }
 
-std::string SubtrActorPlugin::uiConfigJson() const {
+std::string SubtrActorPlugin::uiConfigJson() {
   auto kindValue = [](UiStatsWindowKind kind) {
     switch (kind) {
     case UiStatsWindowKind::Player:
@@ -3619,33 +3633,33 @@ std::string SubtrActorPlugin::uiConfigJson() const {
   writePlacement(file, boostPickupControlsPlacement, uiBoostPickupControlsOpen);
   file << "\n  },\n";
   file << "  \"singletonWindows\": [\n";
-  auto writeSingletonWindow = [&](
-                                  const char *id,
-                                  const UiWindowPlacement &placement,
-                                  bool visible,
-                                  bool last) {
-    file << "    {\"id\":\"" << id << "\",\"placement\":";
-    writePlacement(file, placement, visible);
+  auto writeWindowConfig = [&](const SingletonWindowControl &window, bool last) {
+    const bool visible = window.open != nullptr && *window.open;
+    file << "    {\"id\":\"" << window.config_id << "\",\"placement\":";
+    writePlacement(file, *window.placement, visible);
     file << "}";
     if (!last) {
       file << ",";
     }
     file << "\n";
   };
-  writeSingletonWindow("camera", cameraPlacement, uiCameraOpen, false);
-  writeSingletonWindow("scoreboard", scoreboardPlacement, uiScoreboardOpen, false);
-  writeSingletonWindow("playback", playbackControlsPlacement, uiPlaybackControlsOpen, false);
-  writeSingletonWindow("recording", recordingPlacement, uiRecordingOpen, false);
-  writeSingletonWindow("mechanics", eventsPlacement, uiEventsOpen, false);
-  writeSingletonWindow("event-playlist", eventPlaylistPlacement, uiEventPlaylistOpen, false);
-  writeSingletonWindow("mechanics-review", mechanicsReviewPlacement, uiMechanicsReviewOpen, false);
-  writeSingletonWindow("replay-loading", replayLoadingPlacement, uiReplayLoadingOpen, false);
-  writeSingletonWindow(
-      "boost-pickups",
-      boostPickupControlsPlacement,
-      uiBoostPickupControlsOpen,
-      false);
-  writeSingletonWindow("touch-controls", touchControlsPlacement, uiTouchControlsOpen, true);
+  std::vector<SingletonWindowControl> webWindows;
+  std::vector<SingletonWindowControl> pluginWindows;
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    if (window.web_config) {
+      webWindows.push_back(window);
+    } else {
+      pluginWindows.push_back(window);
+    }
+  }
+  for (size_t index = 0; index < webWindows.size(); index += 1) {
+    writeWindowConfig(webWindows[index], index + 1 == webWindows.size());
+  }
+  file << "  ],\n";
+  file << "  \"pluginWindows\": [\n";
+  for (size_t index = 0; index < pluginWindows.size(); index += 1) {
+    writeWindowConfig(pluginWindows[index], index + 1 == pluginWindows.size());
+  }
   file << "  ],\n";
   file << "  \"stats_windows\": [\n";
   for (size_t i = 0; i < uiStatsWindows.size(); i += 1) {
@@ -8941,26 +8955,48 @@ SubtrActorPlugin::singletonWindowControls() {
   const float touchControlsX = rightAnchoredUiX(410.0f);
 
   return {{
-      {"Scoreboard", &uiScoreboardOpen, &scoreboardPlacement, 0.0f, 11.0f, 88.0f, 34.0f},
-      {"Events", &uiEventsOpen, &eventsPlacement, 16.0f, 256.0f, 520.0f, 360.0f},
+      {"Scoreboard",
+       "scoreboard",
+       true,
+       &uiScoreboardOpen,
+       &scoreboardPlacement,
+       0.0f,
+       11.0f,
+       88.0f,
+       34.0f},
+      {"Events", "mechanics", true, &uiEventsOpen, &eventsPlacement, 16.0f, 256.0f, 520.0f, 360.0f},
       {"Event playlist",
+       "event-playlist",
+       true,
        &uiEventPlaylistOpen,
        &eventPlaylistPlacement,
        eventPlaylistX,
        256.0f,
        430.0f,
        430.0f},
-      {"Status", &uiStatusOpen, &statusPlacement, statusX, 68.0f, 330.0f, 220.0f},
-      {"Camera", &uiCameraOpen, &cameraPlacement, 16.0f, 68.0f, 416.0f, 500.0f},
+      {"Status", "status", false, &uiStatusOpen, &statusPlacement, statusX, 68.0f, 330.0f, 220.0f},
+      {"Camera", "camera", true, &uiCameraOpen, &cameraPlacement, 16.0f, 68.0f, 416.0f, 500.0f},
       {"Playback",
+       "playback",
+       true,
        &uiPlaybackControlsOpen,
        &playbackControlsPlacement,
        playbackX,
        68.0f,
        336.0f,
        430.0f},
-      {"Recording", &uiRecordingOpen, &recordingPlacement, recordingX, 384.0f, 416.0f, 380.0f},
+      {"Recording",
+       "recording",
+       true,
+       &uiRecordingOpen,
+       &recordingPlacement,
+       recordingX,
+       384.0f,
+       416.0f,
+       380.0f},
       {"Graph inspector",
+       "graph-inspector",
+       false,
        &uiGraphInspectorOpen,
        &graphInspectorPlacement,
        360.0f,
@@ -8968,6 +9004,8 @@ SubtrActorPlugin::singletonWindowControls() {
        700.0f,
        520.0f},
       {"Mechanics review",
+       "mechanics-review",
+       true,
        &uiMechanicsReviewOpen,
        &mechanicsReviewPlacement,
        mechanicsReviewX,
@@ -8975,6 +9013,8 @@ SubtrActorPlugin::singletonWindowControls() {
        500.0f,
        560.0f},
       {"Replay loading",
+       "replay-loading",
+       true,
        &uiReplayLoadingOpen,
        &replayLoadingPlacement,
        replayLoadingX,
@@ -8982,6 +9022,8 @@ SubtrActorPlugin::singletonWindowControls() {
        520.0f,
        360.0f},
       {"Module controls",
+       "module-controls",
+       false,
        &uiModuleControlsOpen,
        &moduleControlsPlacement,
        moduleControlsX,
@@ -8989,6 +9031,8 @@ SubtrActorPlugin::singletonWindowControls() {
        430.0f,
        520.0f},
       {"Touch controls",
+       "touch-controls",
+       true,
        &uiTouchControlsOpen,
        &touchControlsPlacement,
        touchControlsX,
@@ -8996,6 +9040,8 @@ SubtrActorPlugin::singletonWindowControls() {
        410.0f,
        380.0f},
       {"Boost pickup filters",
+       "boost-pickups",
+       true,
        &uiBoostPickupControlsOpen,
        &boostPickupControlsPlacement,
        16.0f,

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1600,6 +1600,36 @@ std::vector<UiStatDefinitionCandidate> graphStatDefinitionsFromReplayFrameJson(
   return definitions;
 }
 
+std::vector<std::string> replayStatsModuleNamesFromFrameJson(const std::string &frameJson) {
+  std::vector<std::string> names;
+  std::unordered_set<std::string> seen;
+  auto appendName = [&](const std::string &moduleName) {
+    if (moduleName == "player_id" || moduleName == "name" || moduleName == "is_team_0") {
+      return;
+    }
+    if (seen.insert(moduleName).second) {
+      names.push_back(moduleName);
+    }
+  };
+
+  if (const auto teamZero = parseJsonObjectProperty(frameJson, "team_zero")) {
+    for (const std::string &moduleName : parseJsonObjectKeys(*teamZero)) {
+      appendName(moduleName);
+    }
+  }
+  if (const auto teamOne = parseJsonObjectProperty(frameJson, "team_one")) {
+    for (const std::string &moduleName : parseJsonObjectKeys(*teamOne)) {
+      appendName(moduleName);
+    }
+  }
+  for (const std::string &player : parseJsonObjectArrayProperty(frameJson, "players")) {
+    for (const std::string &moduleName : parseJsonObjectKeys(player)) {
+      appendName(moduleName);
+    }
+  }
+  return names;
+}
+
 std::string replayStatsModuleFrameJson(
     const std::string &frameJson,
     const std::string &moduleName) {
@@ -9180,9 +9210,9 @@ void SubtrActorPlugin::renderModuleControlsWindow() {
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "GRAPH STATS MODULES");
-  const std::vector<std::string> &moduleNames = statsModuleNames();
+  const std::vector<std::string> moduleNames = availableStatsModuleNames();
   if (moduleNames.empty()) {
-    ImGui::TextWrapped("Start live analysis to list graph-backed stats modules.");
+    ImGui::TextWrapped("Start live analysis or load replay annotations to list graph-backed stats modules.");
   } else {
     ImGui::BeginChild("module-controls-module-list", ImVec2{0.0f, 170.0f}, true);
     for (const std::string &moduleName : moduleNames) {
@@ -10687,7 +10717,7 @@ void SubtrActorPlugin::createStatsWindow(UiStatsWindowKind kind, bool initialize
   window.kind = kind;
   initializeStatsWindowPlacement(window);
   if (kind == UiStatsWindowKind::StatsModule) {
-    const std::vector<std::string> &moduleNames = statsModuleNames();
+    const std::vector<std::string> moduleNames = availableStatsModuleNames();
     if (!moduleNames.empty()) {
       window.module_name = moduleNames.front();
     }
@@ -11061,6 +11091,21 @@ const std::vector<std::string> &SubtrActorPlugin::statsModuleNames() {
     cachedStatsModuleNames = std::move(names);
   }
   return cachedStatsModuleNames;
+}
+
+std::vector<std::string> SubtrActorPlugin::availableStatsModuleNames() {
+  std::vector<std::string> names = statsModuleNames();
+  std::unordered_set<std::string> seen(names.begin(), names.end());
+  auto appendName = [&](const std::string &moduleName) {
+    if (seen.insert(moduleName).second) {
+      names.push_back(moduleName);
+    }
+  };
+  for (const std::string &moduleName :
+       replayStatsModuleNamesFromFrameJson(currentReplayFrameJson())) {
+    appendName(moduleName);
+  }
+  return names;
 }
 
 const std::string &SubtrActorPlugin::currentStatsJson() const {
@@ -11524,7 +11569,7 @@ void SubtrActorPlugin::renderStatsWindowScopeSelector(UiStatsWindow &window) {
   }
 
   if (window.kind == UiStatsWindowKind::StatsModule) {
-    const std::vector<std::string> &moduleNames = statsModuleNames();
+    const std::vector<std::string> moduleNames = availableStatsModuleNames();
     const char *selectedModule =
         window.module_name.empty() ? "Select module" : window.module_name.c_str();
     if (ImGui::BeginCombo("Module", selectedModule)) {
@@ -12198,7 +12243,7 @@ void SubtrActorPlugin::renderStatsModuleWindow(UiStatsWindow &window) {
     return;
   }
 
-  const std::vector<std::string> &moduleNames = statsModuleNames();
+  const std::vector<std::string> moduleNames = availableStatsModuleNames();
   if (window.module_name.empty() && !moduleNames.empty()) {
     window.module_name = moduleNames.front();
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -6447,6 +6447,21 @@ void SubtrActorPlugin::applyWindowPlacement(
   applyFocus();
 }
 
+void SubtrActorPlugin::applySingletonWindowPlacement(UiWindowPlacement &placement) {
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    if (window.placement != &placement) {
+      continue;
+    }
+    if (window.placement == &scoreboardPlacement) {
+      applyScoreboardWindowPlacement();
+      return;
+    }
+    applyWindowPlacement(placement, window.x, window.y, window.width, window.height);
+    return;
+  }
+  applyWindowPlacement(placement, 16.0f, 68.0f, 340.0f, 430.0f);
+}
+
 void SubtrActorPlugin::resetSingletonWindowPlacement(
     UiWindowPlacement &placement,
     float x,
@@ -7079,7 +7094,7 @@ void SubtrActorPlugin::renderEventsWindow() {
   if (!uiEventsOpen) {
     return;
   }
-  applyWindowPlacement(eventsPlacement, 16.0f, 505.0f, 520.0f, 360.0f);
+  applySingletonWindowPlacement(eventsPlacement);
   if (!ImGui::Begin("Events##subtr-actor", &uiEventsOpen, UI_FLOATING_WINDOW_FLAGS)) {
     ImGui::End();
     return;
@@ -7251,7 +7266,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     return;
   }
 
-  applyWindowPlacement(eventPlaylistPlacement, 545.0f, 505.0f, 430.0f, 430.0f);
+  applySingletonWindowPlacement(eventPlaylistPlacement);
   if (!ImGui::Begin(
           "Event playlist##subtr-actor",
           &uiEventPlaylistOpen,
@@ -7419,7 +7434,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     return;
   }
 
-  applyWindowPlacement(mechanicsReviewPlacement, 980.0f, 160.0f, 500.0f, 560.0f);
+  applySingletonWindowPlacement(mechanicsReviewPlacement);
   if (!ImGui::Begin(
           "Mechanics review##subtr-actor",
           &uiMechanicsReviewOpen,
@@ -7628,7 +7643,7 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
     return;
   }
 
-  applyWindowPlacement(replayLoadingPlacement, 960.0f, 68.0f, 520.0f, 360.0f);
+  applySingletonWindowPlacement(replayLoadingPlacement);
   if (!ImGui::Begin(
           "Replay loading##subtr-actor",
           &uiReplayLoadingOpen,
@@ -7800,7 +7815,7 @@ void SubtrActorPlugin::renderModuleControlsWindow() {
     return;
   }
 
-  applyWindowPlacement(moduleControlsPlacement, 980.0f, 305.0f, 430.0f, 520.0f);
+  applySingletonWindowPlacement(moduleControlsPlacement);
   if (!ImGui::Begin(
           "Module controls##subtr-actor",
           &uiModuleControlsOpen,
@@ -7907,7 +7922,7 @@ void SubtrActorPlugin::renderBoostPickupControlsWindow() {
     return;
   }
 
-  applyWindowPlacement(boostPickupControlsPlacement, 1000.0f, 560.0f, 430.0f, 420.0f);
+  applySingletonWindowPlacement(boostPickupControlsPlacement);
   if (!ImGui::Begin(
           "Boost pickup filters##subtr-actor",
           &uiBoostPickupControlsOpen,
@@ -8023,7 +8038,7 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
     return;
   }
 
-  applyWindowPlacement(touchControlsPlacement, 980.0f, 160.0f, 410.0f, 380.0f);
+  applySingletonWindowPlacement(touchControlsPlacement);
   if (!ImGui::Begin(
           "Touch controls##subtr-actor",
           &uiTouchControlsOpen,
@@ -8100,7 +8115,7 @@ void SubtrActorPlugin::renderStatusWindow() {
   if (!uiStatusOpen) {
     return;
   }
-  applyWindowPlacement(statusPlacement, 1230.0f, 68.0f, 330.0f, 220.0f);
+  applySingletonWindowPlacement(statusPlacement);
   if (!ImGui::Begin("Status##subtr-actor", &uiStatusOpen, UI_FLOATING_WINDOW_FLAGS)) {
     ImGui::End();
     return;
@@ -8140,7 +8155,7 @@ void SubtrActorPlugin::renderCameraWindow() {
   }
   const SaPlayerFrame *targetPlayer = cameraViewMode == 1 ? selectedPlayer : nullptr;
 
-  applyWindowPlacement(cameraPlacement, 720.0f, 68.0f, 360.0f, 500.0f);
+  applySingletonWindowPlacement(cameraPlacement);
   if (!ImGui::Begin("Camera##subtr-actor", &uiCameraOpen, UI_FLOATING_WINDOW_FLAGS)) {
     ImGui::End();
     return;
@@ -8316,7 +8331,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
     return;
   }
 
-  applyWindowPlacement(playbackControlsPlacement, 880.0f, 68.0f, 360.0f, 430.0f);
+  applySingletonWindowPlacement(playbackControlsPlacement);
   if (!ImGui::Begin(
           "Playback##subtr-actor",
           &uiPlaybackControlsOpen,
@@ -8531,7 +8546,7 @@ void SubtrActorPlugin::renderRecordingWindow() {
     return;
   }
 
-  applyWindowPlacement(recordingPlacement, 990.0f, 250.0f, 400.0f, 380.0f);
+  applySingletonWindowPlacement(recordingPlacement);
   if (!ImGui::Begin("Recording##subtr-actor", &uiRecordingOpen, UI_FLOATING_WINDOW_FLAGS)) {
     ImGui::End();
     return;
@@ -8736,7 +8751,7 @@ void SubtrActorPlugin::renderGraphInspectorWindow() {
     return;
   }
 
-  applyWindowPlacement(graphInspectorPlacement, 360.0f, 68.0f, 700.0f, 520.0f);
+  applySingletonWindowPlacement(graphInspectorPlacement);
   if (!ImGui::Begin(
           "Graph inspector##subtr-actor",
           &uiGraphInspectorOpen,
@@ -9164,19 +9179,9 @@ void SubtrActorPlugin::focusTopLoadedWindow() {
     topStatsWindow = nullptr;
   };
 
-  considerPlacement(uiScoreboardOpen, scoreboardPlacement);
-  considerPlacement(uiEventsOpen, eventsPlacement);
-  considerPlacement(uiStatusOpen, statusPlacement);
-  considerPlacement(uiCameraOpen, cameraPlacement);
-  considerPlacement(uiPlaybackControlsOpen, playbackControlsPlacement);
-  considerPlacement(uiRecordingOpen, recordingPlacement);
-  considerPlacement(uiGraphInspectorOpen, graphInspectorPlacement);
-  considerPlacement(uiEventPlaylistOpen, eventPlaylistPlacement);
-  considerPlacement(uiMechanicsReviewOpen, mechanicsReviewPlacement);
-  considerPlacement(uiReplayLoadingOpen, replayLoadingPlacement);
-  considerPlacement(uiModuleControlsOpen, moduleControlsPlacement);
-  considerPlacement(uiTouchControlsOpen, touchControlsPlacement);
-  considerPlacement(uiBoostPickupControlsOpen, boostPickupControlsPlacement);
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    considerPlacement(*window.open, *window.placement);
+  }
 
   for (UiStatsWindow &window : uiStatsWindows) {
     window.pending_focus = false;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3680,6 +3680,7 @@ void SubtrActorPlugin::applyUiConfigJson(
   nextUiStatsWindowId = 1;
   const bool hasLegacyStatsWindows = jsonPropertyExists(json, "stats_windows");
   const bool hasWebStatsWindows = jsonPropertyExists(json, "statsWindows");
+  const bool statsWindowObjectsFromWeb = !hasLegacyStatsWindows && hasWebStatsWindows;
   const std::vector<std::string> statsWindowObjects =
       hasLegacyStatsWindows
           ? parseJsonObjectArrayProperty(json, "stats_windows")
@@ -3723,7 +3724,11 @@ void SubtrActorPlugin::applyUiConfigJson(
     nextUiStatsWindowId = std::max(nextUiStatsWindowId, window.id + 1);
     window.open = parseJsonBoolProperty(object, "open").value_or(true);
     window.open = parseJsonBoolProperty(object, "visible").value_or(window.open);
-    if (const auto placement = parseJsonObjectProperty(object, "placement")) {
+    std::optional<std::string> placement = parseJsonObjectProperty(object, "placement");
+    if (!placement && statsWindowObjectsFromWeb) {
+      placement = R"({"x":8,"y":8,"viewport":{"width":1,"height":1},"visible":true})";
+    }
+    if (placement) {
       window.open = parseJsonBoolProperty(*placement, "visible").value_or(window.open);
       window.has_placement = true;
       window.pending_apply_placement = true;
@@ -3790,7 +3795,7 @@ void SubtrActorPlugin::applyUiConfigJson(
       }
       window.entries.push_back(UiStatsWindow::Entry{statId, targetId});
     }
-    if (!hasEntriesProperty && window.entries.empty() &&
+    if (!statsWindowObjectsFromWeb && !hasEntriesProperty && window.entries.empty() &&
         window.kind != UiStatsWindowKind::StatsModule) {
       initializeStatsWindowEntries(window);
     }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7168,6 +7168,14 @@ void SubtrActorPlugin::hideSingletonWindow(bool &open) {
   scheduleUiConfigAutosave();
 }
 
+void SubtrActorPlugin::hideStatsWindow(UiStatsWindow &window) {
+  if (!window.open) {
+    return;
+  }
+  window.open = false;
+  scheduleUiConfigAutosave();
+}
+
 void SubtrActorPlugin::hideLauncherWindow() {
   if (!uiLauncherOpen) {
     return;
@@ -10258,9 +10266,8 @@ void SubtrActorPlugin::renderStatsWindowManager() {
   ImGui::SameLine();
   if (ImGui::SmallButton("Hide all##stats-windows")) {
     for (UiStatsWindow &window : uiStatsWindows) {
-      window.open = false;
+      hideStatsWindow(window);
     }
-    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (ImGui::SmallButton("Focus visible##stats-windows")) {
@@ -10299,8 +10306,7 @@ void SubtrActorPlugin::renderStatsWindowManager() {
 
     if (window.open) {
       if (ImGui::SmallButton("Hide")) {
-        window.open = false;
-        scheduleUiConfigAutosave();
+        hideStatsWindow(window);
       }
       ImGui::SameLine();
       if (ImGui::SmallButton("Focus")) {
@@ -11197,8 +11203,7 @@ void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t /*stackIn
     ImGui::SetCursorPosX(rightAlignedX);
   }
   if (ImGui::SmallButton(hideLabel.c_str())) {
-    window.open = false;
-    scheduleUiConfigAutosave();
+    hideStatsWindow(window);
     ImGui::End();
     return;
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -2334,6 +2334,45 @@ const char *eventFilterLabel(std::string_view value) {
   return value.empty() ? "All events" : "Custom filter";
 }
 
+std::string eventTypeDisplayLabel(std::string_view value) {
+  const std::string normalized = normalizeEventFilterToken(value);
+  if (normalized == "shot") {
+    return "Shot";
+  }
+  if (normalized == "save") {
+    return "Save";
+  }
+  if (normalized == "assist") {
+    return "Assist";
+  }
+  if (normalized == "core") {
+    return "Core event";
+  }
+  if (normalized == "goal") {
+    return "Goal";
+  }
+  for (const EventFilterOption &option : EVENT_FILTER_OPTIONS) {
+    if (normalized == option.value) {
+      return option.label;
+    }
+  }
+
+  std::string label;
+  label.reserve(normalized.size());
+  bool capitalizeNext = true;
+  for (const char ch : normalized) {
+    if (ch == '_') {
+      label.push_back(' ');
+      capitalizeNext = false;
+      continue;
+    }
+    label.push_back(
+        capitalizeNext ? static_cast<char>(std::toupper(static_cast<unsigned char>(ch))) : ch);
+    capitalizeNext = false;
+  }
+  return label.empty() ? "Event" : label;
+}
+
 std::string eventFilterPreview(std::string_view rawFilter) {
   if (eventPlaylistUsesDefaultSources(rawFilter)) {
     return "Default events";
@@ -9025,7 +9064,9 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
       current == nullptr || current->details.empty() ? "--" : current->details;
   ImGui::Columns(2, "mechanics-review-fields", false);
   ImGui::TextDisabled("Mechanic");
-  ImGui::Text("%s", current == nullptr || current->type.empty() ? "--" : current->type.c_str());
+  const std::string mechanicReadout =
+      current == nullptr || current->type.empty() ? "--" : eventTypeDisplayLabel(current->type);
+  ImGui::Text("%s", mechanicReadout.c_str());
   ImGui::NextColumn();
   ImGui::TextDisabled("Player");
   ImGui::Text("%s", current == nullptr || current->actor.empty() ? "--" : current->actor.c_str());
@@ -9145,7 +9186,7 @@ void SubtrActorPlugin::renderMechanicsReviewWindow() {
     }
     std::vector<std::string> metaParts;
     if (!event.type.empty()) {
-      metaParts.push_back(event.type);
+      metaParts.push_back(eventTypeDisplayLabel(event.type));
     }
     metaParts.push_back(mechanicsReviewDecisionLabel(event));
     ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -9207,40 +9207,34 @@ void SubtrActorPlugin::resetDefaultStatsWindows() {
   createStatsWindow(UiStatsWindowKind::GoalsOverview, true);
 }
 
+void SubtrActorPlugin::applyWorkspaceWindowVisibility(
+    bool launcherOpen,
+    std::initializer_list<std::string_view> openWindowIds) {
+  uiLauncherOpen = launcherOpen;
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    *window.open = std::find(openWindowIds.begin(), openWindowIds.end(), window.config_id) !=
+                   openWindowIds.end();
+  }
+}
+
 void SubtrActorPlugin::applyDefaultUiWorkspace() {
-  uiLauncherOpen = false;
-  uiScoreboardOpen = true;
-  uiEventsOpen = false;
-  uiEventPlaylistOpen = false;
-  uiStatusOpen = false;
-  uiCameraOpen = true;
-  uiPlaybackControlsOpen = false;
-  uiRecordingOpen = false;
-  uiGraphInspectorOpen = false;
-  uiMechanicsReviewOpen = false;
-  uiReplayLoadingOpen = false;
-  uiModuleControlsOpen = false;
-  uiTouchControlsOpen = false;
-  uiBoostPickupControlsOpen = false;
+  applyWorkspaceWindowVisibility(false, {"scoreboard", "camera"});
   resetWindowPlacements();
   cameraPlacement.pending_focus = true;
 }
 
 void SubtrActorPlugin::applyReplayReviewUiWorkspace() {
-  uiLauncherOpen = true;
-  uiScoreboardOpen = true;
-  uiEventsOpen = true;
-  uiEventPlaylistOpen = true;
-  uiStatusOpen = false;
-  uiCameraOpen = true;
-  uiPlaybackControlsOpen = true;
-  uiRecordingOpen = false;
-  uiGraphInspectorOpen = false;
-  uiMechanicsReviewOpen = true;
-  uiReplayLoadingOpen = true;
-  uiModuleControlsOpen = false;
-  uiTouchControlsOpen = true;
-  uiBoostPickupControlsOpen = true;
+  applyWorkspaceWindowVisibility(
+      true,
+      {"scoreboard",
+       "mechanics",
+       "event-playlist",
+       "camera",
+       "playback",
+       "mechanics-review",
+       "replay-loading",
+       "touch-controls",
+       "boost-pickups"});
   eventPlaylistMechanicsEnabled = true;
   eventPlaylistTeamEventsEnabled = true;
   eventPlaylistGoalContextEnabled = true;
@@ -9251,40 +9245,23 @@ void SubtrActorPlugin::applyReplayReviewUiWorkspace() {
 }
 
 void SubtrActorPlugin::applyGraphDebugUiWorkspace() {
-  uiLauncherOpen = true;
-  uiScoreboardOpen = false;
-  uiEventsOpen = true;
-  uiEventPlaylistOpen = true;
-  uiStatusOpen = true;
-  uiCameraOpen = false;
-  uiPlaybackControlsOpen = true;
-  uiRecordingOpen = false;
-  uiGraphInspectorOpen = true;
-  uiMechanicsReviewOpen = false;
-  uiReplayLoadingOpen = false;
-  uiModuleControlsOpen = true;
-  uiTouchControlsOpen = false;
-  uiBoostPickupControlsOpen = false;
+  applyWorkspaceWindowVisibility(
+      true,
+      {"mechanics",
+       "event-playlist",
+       "status",
+       "playback",
+       "graph-inspector",
+       "module-controls"});
   resetWindowPlacements();
   graphInspectorPlacement.pending_focus = true;
   moduleControlsPlacement.pending_focus = true;
 }
 
 void SubtrActorPlugin::applyRecordingUiWorkspace() {
-  uiLauncherOpen = true;
-  uiScoreboardOpen = true;
-  uiEventsOpen = false;
-  uiEventPlaylistOpen = false;
-  uiStatusOpen = true;
-  uiCameraOpen = true;
-  uiPlaybackControlsOpen = true;
-  uiRecordingOpen = true;
-  uiGraphInspectorOpen = false;
-  uiMechanicsReviewOpen = false;
-  uiReplayLoadingOpen = false;
-  uiModuleControlsOpen = false;
-  uiTouchControlsOpen = false;
-  uiBoostPickupControlsOpen = false;
+  applyWorkspaceWindowVisibility(
+      true,
+      {"scoreboard", "status", "camera", "playback", "recording"});
   resetWindowPlacements();
   recordingPlacement.pending_focus = true;
   cameraPlacement.pending_focus = true;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3731,7 +3731,6 @@ void SubtrActorPlugin::applyUiConfigJson(
     window.module_name = parseJsonStringProperty(object, "module_name").value_or("");
     window.module_view = static_cast<int>(
         std::max(0.0, parseJsonNumberProperty(object, "module_view").value_or(0.0)));
-    window.picker_query = parseJsonStringProperty(object, "picker_query").value_or("");
     const bool hasEntriesProperty = object.find("\"entries\"") != std::string::npos;
     for (const std::string &statId : parseJsonStringArrayProperty(object, "entries")) {
       window.entries.push_back(UiStatsWindow::Entry{normalizeUiStatId(statId), ""});
@@ -4153,7 +4152,6 @@ std::string SubtrActorPlugin::uiConfigJson() {
          << (window.selected_team_is_team_0 != 0 ? "true" : "false")
          << ",\"module_name\":\"" << escapeJsonString(window.module_name) << "\""
          << ",\"module_view\":" << window.module_view
-         << ",\"picker_query\":\"" << escapeJsonString(window.picker_query) << "\""
          << ",\"has_placement\":" << (window.has_placement ? "true" : "false")
          << ",\"x\":" << window.x << ",\"y\":" << window.y
          << ",\"width\":" << window.width << ",\"height\":" << window.height
@@ -11470,13 +11468,11 @@ void SubtrActorPlugin::renderStatsWindowAddControl(UiStatsWindow &window) {
           queryBuffer.data(),
           queryBuffer.size())) {
     window.picker_query = queryBuffer.data();
-    scheduleUiConfigAutosave();
   }
   if (!window.picker_query.empty()) {
     ImGui::SameLine();
     if (ImGui::SmallButton(std::format("Clear##stat-search-{}", window.id).c_str())) {
       window.picker_query.clear();
-      scheduleUiConfigAutosave();
     }
   }
 

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8037,7 +8037,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
     showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);
     resetReplayAnnotations();
     tickReplayAnnotations();
-    hideLauncherWindow();
   }
 
   ImGui::Separator();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7699,12 +7699,29 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
       playlistSources.begin(),
       playlistSources.end(),
       [](const PlaylistSource &source) { return source.enabled; }));
-  size_t selectedCount = 0;
-  for (const UiEventRecord &event : recentUiEvents) {
+
+  std::vector<size_t> playlistEventIndexes;
+  playlistEventIndexes.reserve(recentUiEvents.size());
+  for (size_t index = 0; index < recentUiEvents.size(); index += 1) {
+    const UiEventRecord &event = recentUiEvents[index];
     if (eventPlaylistSourceEnabled(event) && uiEventVisible(event)) {
-      selectedCount += 1;
+      playlistEventIndexes.push_back(index);
     }
   }
+  std::sort(
+      playlistEventIndexes.begin(),
+      playlistEventIndexes.end(),
+      [&](size_t left, size_t right) {
+        const UiEventRecord &leftEvent = recentUiEvents[left];
+        const UiEventRecord &rightEvent = recentUiEvents[right];
+        if (leftEvent.time != rightEvent.time) {
+          return leftEvent.time < rightEvent.time;
+        }
+        if (leftEvent.label != rightEvent.label) {
+          return leftEvent.label < rightEvent.label;
+        }
+        return left < right;
+      });
 
   const bool allSourcesEnabled = eventPlaylistMechanicsEnabled && eventPlaylistTeamEventsEnabled &&
                                  eventPlaylistGoalContextEnabled && allEventSourcesEnabled;
@@ -7768,7 +7785,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     ImGui::EndChild();
   }
 
-  ImGui::Text("%zu selected / %zu recent", selectedCount, recentUiEvents.size());
+  ImGui::Text("%zu selected / %zu recent", playlistEventIndexes.size(), recentUiEvents.size());
   if (!eventPlaylistStatus.empty()) {
     ImGui::TextWrapped("Status: %s", eventPlaylistStatus.c_str());
   }
@@ -7787,11 +7804,8 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
 
   std::optional<size_t> activeEventIndex;
   float activeEventDistance = std::numeric_limits<float>::infinity();
-  for (size_t index = 0; index < recentUiEvents.size(); index += 1) {
+  for (const size_t index : playlistEventIndexes) {
     const UiEventRecord &event = recentUiEvents[index];
-    if (!eventPlaylistSourceEnabled(event) || !uiEventVisible(event)) {
-      continue;
-    }
     const float distance = std::abs(event.time - currentPlaybackTime);
     if (distance < activeEventDistance) {
       activeEventDistance = distance;
@@ -7800,13 +7814,8 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
   }
 
   ImGui::BeginChild("event-playlist-list", ImVec2{0.0f, 0.0f}, true);
-  bool renderedAny = false;
-  for (size_t index = 0; index < recentUiEvents.size(); index += 1) {
+  for (const size_t index : playlistEventIndexes) {
     const UiEventRecord &event = recentUiEvents[index];
-    if (!eventPlaylistSourceEnabled(event) || !uiEventVisible(event)) {
-      continue;
-    }
-    renderedAny = true;
 
     ImGui::PushID(static_cast<int>(index));
     const ImVec4 color = toImVec4(event.color);
@@ -7845,7 +7854,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     ImGui::Separator();
     ImGui::PopID();
   }
-  if (!renderedAny) {
+  if (playlistEventIndexes.empty()) {
     ImGui::TextWrapped(
         noSourcesEnabled ? "No event types selected."
                          : "No events match the selected playlist filters.");

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -4246,6 +4246,13 @@ void SubtrActorPlugin::saveUiConfig() {
   nextUiConfigAutosave = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 }
 
+void SubtrActorPlugin::scheduleUiConfigAutosave(std::chrono::milliseconds delay) {
+  const auto nextSave = std::chrono::steady_clock::now() + delay;
+  if (nextSave < nextUiConfigAutosave) {
+    nextUiConfigAutosave = nextSave;
+  }
+}
+
 void SubtrActorPlugin::maybeAutosaveUiConfig() {
   const auto now = std::chrono::steady_clock::now();
   if (now < nextUiConfigAutosave) {
@@ -7121,6 +7128,7 @@ void SubtrActorPlugin::resetSingletonWindowPlacement(
   placement.viewport_width = displaySize.x;
   placement.viewport_height = displaySize.y;
   placement.z_index = nextUiWindowZIndex++;
+  scheduleUiConfigAutosave();
 }
 
 void SubtrActorPlugin::resetScoreboardWindowPlacement(bool focus) {
@@ -7134,6 +7142,7 @@ void SubtrActorPlugin::resetScoreboardWindowPlacement(bool focus) {
 void SubtrActorPlugin::focusSingletonWindow(UiWindowPlacement &placement) {
   placement.pending_focus = true;
   placement.z_index = nextUiWindowZIndex++;
+  scheduleUiConfigAutosave();
 }
 
 void SubtrActorPlugin::showSingletonWindow(bool &open, UiWindowPlacement &placement) {
@@ -7142,6 +7151,14 @@ void SubtrActorPlugin::showSingletonWindow(bool &open, UiWindowPlacement &placem
 }
 
 void SubtrActorPlugin::captureWindowPlacement(UiWindowPlacement &placement) {
+  const bool hadPlacement = placement.has_placement;
+  const float previousX = placement.x;
+  const float previousY = placement.y;
+  const float previousWidth = placement.width;
+  const float previousHeight = placement.height;
+  const float previousViewportWidth = placement.viewport_width;
+  const float previousViewportHeight = placement.viewport_height;
+  const int previousZIndex = placement.z_index;
   const ImVec2 position = ImGui::GetWindowPos();
   const ImVec2 size = ImGui::GetWindowSize();
   placement.has_placement = true;
@@ -7155,6 +7172,13 @@ void SubtrActorPlugin::captureWindowPlacement(UiWindowPlacement &placement) {
   if (ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows) &&
       ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
     placement.z_index = nextUiWindowZIndex++;
+  }
+  if (!hadPlacement || previousX != placement.x || previousY != placement.y ||
+      previousWidth != placement.width || previousHeight != placement.height ||
+      previousViewportWidth != placement.viewport_width ||
+      previousViewportHeight != placement.viewport_height ||
+      previousZIndex != placement.z_index) {
+    scheduleUiConfigAutosave();
   }
 }
 
@@ -7170,6 +7194,7 @@ bool SubtrActorPlugin::renderSingletonWindowHeader(const char *label, bool &open
   }
   if (ImGui::SmallButton(hideLabel.c_str())) {
     open = false;
+    scheduleUiConfigAutosave();
     return true;
   }
   ImGui::Separator();
@@ -7250,6 +7275,14 @@ void SubtrActorPlugin::applyStatsWindowPlacement(UiStatsWindow &window) {
 }
 
 void SubtrActorPlugin::captureStatsWindowPlacement(UiStatsWindow &window) {
+  const bool hadPlacement = window.has_placement;
+  const float previousX = window.x;
+  const float previousY = window.y;
+  const float previousWidth = window.width;
+  const float previousHeight = window.height;
+  const float previousViewportWidth = window.viewport_width;
+  const float previousViewportHeight = window.viewport_height;
+  const int previousZIndex = window.z_index;
   const ImVec2 position = ImGui::GetWindowPos();
   const ImVec2 size = ImGui::GetWindowSize();
   window.has_placement = true;
@@ -7264,11 +7297,19 @@ void SubtrActorPlugin::captureStatsWindowPlacement(UiStatsWindow &window) {
       ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
     window.z_index = nextUiWindowZIndex++;
   }
+  if (!hadPlacement || previousX != window.x || previousY != window.y ||
+      previousWidth != window.width || previousHeight != window.height ||
+      previousViewportWidth != window.viewport_width ||
+      previousViewportHeight != window.viewport_height ||
+      previousZIndex != window.z_index) {
+    scheduleUiConfigAutosave();
+  }
 }
 
 void SubtrActorPlugin::focusStatsWindow(UiStatsWindow &window) {
   window.pending_focus = true;
   window.z_index = nextUiWindowZIndex++;
+  scheduleUiConfigAutosave();
 }
 
 void SubtrActorPlugin::showStatsWindow(UiStatsWindow &window) {
@@ -7577,6 +7618,7 @@ void SubtrActorPlugin::renderLauncherWorkspaceControls() {
       }
       *window.open = false;
     }
+    scheduleUiConfigAutosave();
   }
   renderLayoutConfigControls("launcher-workspace-layout");
 }
@@ -7598,6 +7640,7 @@ void SubtrActorPlugin::renderWebWindowToggleControls(
     if (ImGui::Button(buttonLabel.c_str(), ImVec2{210.0f, 0.0f})) {
       if (*window.open) {
         *window.open = false;
+        scheduleUiConfigAutosave();
       } else {
         showSingletonWindow(*window.open, *window.placement);
       }
@@ -10017,6 +10060,7 @@ void SubtrActorPlugin::renderSingletonWindowManager() {
     for (SingletonWindowControl &window : windows) {
       *window.open = false;
     }
+    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (ImGui::SmallButton("Focus visible##singleton-windows")) {
@@ -10033,6 +10077,7 @@ void SubtrActorPlugin::renderSingletonWindowManager() {
     if (*window.open) {
       if (ImGui::SmallButton("Hide")) {
         *window.open = false;
+        scheduleUiConfigAutosave();
       }
       ImGui::SameLine();
       if (ImGui::SmallButton("Focus")) {
@@ -10087,6 +10132,7 @@ void SubtrActorPlugin::renderStatsWindowManager() {
     for (UiStatsWindow &window : uiStatsWindows) {
       window.open = false;
     }
+    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   if (ImGui::SmallButton("Focus visible##stats-windows")) {
@@ -10110,6 +10156,7 @@ void SubtrActorPlugin::renderStatsWindowManager() {
             uiStatsWindows.end(),
             [](const UiStatsWindow &window) { return !window.open; }),
         uiStatsWindows.end());
+    scheduleUiConfigAutosave();
   }
   ImGui::SameLine();
   ImGui::TextDisabled("%zu hidden", hiddenCount);
@@ -10125,6 +10172,7 @@ void SubtrActorPlugin::renderStatsWindowManager() {
     if (window.open) {
       if (ImGui::SmallButton("Hide")) {
         window.open = false;
+        scheduleUiConfigAutosave();
       }
       ImGui::SameLine();
       if (ImGui::SmallButton("Focus")) {
@@ -10166,9 +10214,11 @@ void SubtrActorPlugin::renderStatsWindowManager() {
   }
   if (removeIndex) {
     uiStatsWindows.erase(uiStatsWindows.begin() + static_cast<std::ptrdiff_t>(*removeIndex));
+    scheduleUiConfigAutosave();
   }
   if (duplicateWindow) {
     uiStatsWindows.push_back(std::move(*duplicateWindow));
+    scheduleUiConfigAutosave();
   }
   ImGui::EndChild();
 }
@@ -10237,6 +10287,7 @@ void SubtrActorPlugin::resetDefaultStatsWindows() {
       createStatsWindow(window.kind, true);
     }
   }
+  scheduleUiConfigAutosave();
 }
 
 void SubtrActorPlugin::applyWorkspaceWindowVisibility(
@@ -10247,6 +10298,7 @@ void SubtrActorPlugin::applyWorkspaceWindowVisibility(
     *window.open = std::find(openWindowIds.begin(), openWindowIds.end(), window.config_id) !=
                    openWindowIds.end();
   }
+  scheduleUiConfigAutosave();
 }
 
 void SubtrActorPlugin::applyDefaultUiWorkspace() {
@@ -10321,6 +10373,7 @@ void SubtrActorPlugin::createStatsWindow(UiStatsWindowKind kind, bool initialize
     initializeStatsWindowEntries(window);
   }
   uiStatsWindows.push_back(window);
+  scheduleUiConfigAutosave();
 }
 
 void SubtrActorPlugin::createStatsModuleWindow(std::string moduleName, int moduleView) {
@@ -10333,6 +10386,7 @@ void SubtrActorPlugin::createStatsModuleWindow(std::string moduleName, int modul
   initializeStatsWindowPlacement(window);
   focusStatsWindow(window);
   uiStatsWindows.push_back(std::move(window));
+  scheduleUiConfigAutosave();
 }
 
 std::pair<float, float> SubtrActorPlugin::defaultStatsWindowSize(UiStatsWindowKind kind) const {
@@ -10367,6 +10421,7 @@ void SubtrActorPlugin::resetStatsWindowPlacement(UiStatsWindow &window, size_t s
   window.pending_apply_placement = true;
   window.pending_focus = window.open;
   window.z_index = nextUiWindowZIndex++;
+  scheduleUiConfigAutosave();
 }
 
 std::array<SubtrActorPlugin::StatsWindowKindControl, 7>
@@ -11016,6 +11071,7 @@ void SubtrActorPlugin::renderStatsWindow(UiStatsWindow &window, size_t stackInde
   ImGui::SameLine();
   if (ImGui::SmallButton(hideLabel.c_str())) {
     window.open = false;
+    scheduleUiConfigAutosave();
     ImGui::End();
     return;
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3813,18 +3813,28 @@ std::string SubtrActorPlugin::uiConfigJson() {
                                        std::ostream &out,
                                        const UiWindowPlacement &placement,
                                        bool visible) {
+    const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+    const float viewportWidth =
+        placement.viewport_width > 0.0f ? placement.viewport_width : std::max(1.0f, displaySize.x);
+    const float viewportHeight = placement.viewport_height > 0.0f ? placement.viewport_height
+                                                                  : std::max(1.0f, displaySize.y);
     out << "{\"x\":" << placement.x << ",\"y\":" << placement.y
-        << ",\"viewport\":{\"width\":" << placement.viewport_width
-        << ",\"height\":" << placement.viewport_height << "}"
+        << ",\"viewport\":{\"width\":" << viewportWidth
+        << ",\"height\":" << viewportHeight << "}"
         << ",\"zIndex\":" << placement.z_index
         << ",\"visible\":" << (visible ? "true" : "false") << "}";
   };
   auto writeStatsPlayerStatsWindowPlacement = [](
                                                   std::ostream &out,
                                                   const UiStatsWindow &window) {
+    const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+    const float viewportWidth =
+        window.viewport_width > 0.0f ? window.viewport_width : std::max(1.0f, displaySize.x);
+    const float viewportHeight =
+        window.viewport_height > 0.0f ? window.viewport_height : std::max(1.0f, displaySize.y);
     out << "{\"x\":" << window.x << ",\"y\":" << window.y
-        << ",\"viewport\":{\"width\":" << window.viewport_width
-        << ",\"height\":" << window.viewport_height << "}"
+        << ",\"viewport\":{\"width\":" << viewportWidth
+        << ",\"height\":" << viewportHeight << "}"
         << ",\"zIndex\":" << window.z_index
         << ",\"visible\":" << (window.open ? "true" : "false") << "}";
   };

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -12239,9 +12239,11 @@ bool SubtrActorPlugin::renderStatsWindowValueRow(
       ImGui::GetCursorPosX(),
       removeX - valueWidth - 12.0f);
   const std::string labelString{label};
-  ImGui::Text("%s", labelString.c_str());
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextColored(ImVec4{0.62f, 0.71f, 0.78f, 1.0f}, "%s", labelString.c_str());
   ImGui::SameLine(valueX);
-  ImGui::Text("%s", valueString.c_str());
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextColored(ImVec4{0.93f, 0.96f, 0.98f, 1.0f}, "%s", valueString.c_str());
   ImGui::SameLine(removeX);
   const std::string removeLabel = idSuffix.empty()
                                       ? std::format("x##remove-stat-{}-{}", window.id, entryIndex)
@@ -12250,11 +12252,15 @@ bool SubtrActorPlugin::renderStatsWindowValueRow(
                                             window.id,
                                             entryIndex,
                                             idSuffix);
+  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2{5.0f, 2.0f});
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 4.0f);
   if (ImGui::SmallButton(removeLabel.c_str())) {
+    ImGui::PopStyleVar(2);
     window.entries.erase(window.entries.begin() + static_cast<std::ptrdiff_t>(entryIndex));
     scheduleUiConfigAutosave();
     return true;
   }
+  ImGui::PopStyleVar(2);
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Remove stat");
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10030,7 +10030,12 @@ void SubtrActorPlugin::renderRecordingWindow() {
   int nextRecordingFps = recordingFps;
   pushRecordingDisabledStyle(recordingSettingsLocked);
   ImGui::SetNextItemWidth(88.0f);
-  const bool fpsChanged = ImGui::InputInt("##recording-fps", &nextRecordingFps, 1, 10);
+  const bool fpsChanged = ImGui::InputInt(
+      "##recording-fps",
+      &nextRecordingFps,
+      1,
+      10,
+      recordingSettingsLocked ? ImGuiInputTextFlags_ReadOnly : 0);
   popRecordingDisabledStyle(recordingSettingsLocked);
   if (!recordingSettingsLocked && fpsChanged) {
     recordingFps = std::clamp(nextRecordingFps, 1, 120);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -1951,6 +1951,11 @@ std::string mechanicLabel(SaMechanicKind kind) {
   }
 }
 
+bool corePlayerStatMechanicKind(SaMechanicKind kind) {
+  return kind == SaMechanicKindShot || kind == SaMechanicKindSave ||
+         kind == SaMechanicKindAssist;
+}
+
 std::string normalizeEventFilterToken(std::string_view token) {
   std::string normalized;
   normalized.reserve(token.size());
@@ -7047,6 +7052,7 @@ void SubtrActorPlugin::pushGoalEventMessage(const SaGoalEvent &event) {
 
 void SubtrActorPlugin::pushEventMessage(const SaMechanicEvent &event) {
   const bool isBlue = event.is_team_0 != 0;
+  const bool isCorePlayerStat = corePlayerStatMechanicKind(event.kind);
   const std::string action = event.confidence < 0.999f
                                  ? std::format(
                                        "{} ({:.0f}%)",
@@ -7056,17 +7062,23 @@ void SubtrActorPlugin::pushEventMessage(const SaMechanicEvent &event) {
   const std::string label =
       std::format("{}: {}", playerLabel(event.player_index, event.is_team_0), action);
   appendUiEvent(UiEventRecord{
-      "mechanics",
+      isCorePlayerStat ? "core" : "mechanics",
       mechanicToken(event.kind),
       playerLabel(event.player_index, event.is_team_0),
       mechanicLabel(event.kind),
-      event.confidence < 0.999f ? std::format("{:.0f}% confidence", event.confidence * 100.0f)
-                                : "high confidence",
+      isCorePlayerStat
+          ? "Shots, saves, assists"
+          : event.confidence < 0.999f
+                ? std::format("{:.0f}% confidence", event.confidence * 100.0f)
+                : "high confidence",
       isBlue ? LinearColor{80, 190, 255, 255} : LinearColor{255, 175, 80, 255},
       event.frame_number,
       event.time,
   });
 
+  if (isCorePlayerStat) {
+    return;
+  }
   if (!overlayMechanicEnabled(event.kind)) {
     return;
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8463,7 +8463,6 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     ImGui::TreePop();
   }
 
-  ImGui::Text("%zu selected / %zu recent", playlistEventIndexes.size(), recentUiEvents.size());
   if (!eventPlaylistStatus.empty()) {
     ImGui::TextWrapped("Status: %s", eventPlaylistStatus.c_str());
   }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8053,64 +8053,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
     renderModuleSettingsControls("launcher-module-settings", false, true, true);
   }
 
-  if (ImGui::TreeNode("Plugin tools##launcher-plugin-tools")) {
-    const float pluginToolButtonWidth = ImGui::GetContentRegionAvail().x;
-    const bool liveAnalysis = liveProcessingEnabled();
-    if (renderModuleSummaryToggle(
-            "Live analysis graph",
-            liveAnalysis,
-            "launcher-plugin-tools",
-            pluginToolButtonWidth)) {
-      setCvarBool("subtr_actor_enabled", !liveAnalysis);
-    }
-    if (ImGui::Button("Verify graph", ImVec2{pluginToolButtonWidth, 0.0f})) {
-      showSingletonWindow(uiGraphInspectorOpen, graphInspectorPlacement);
-      verifyGraphRuntime({"subtr_actor_verify_graph"});
-      hideLauncherWindow();
-    }
-    if (ImGui::Button("Open modules", ImVec2{pluginToolButtonWidth, 0.0f})) {
-      showSingletonWindow(uiModuleControlsOpen, moduleControlsPlacement);
-      hideLauncherWindow();
-    }
-    if (ImGui::Button("Close launcher", ImVec2{pluginToolButtonWidth, 0.0f})) {
-      hideLauncherWindow();
-    }
-
-    ImGui::Separator();
-    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "GRAPH STATS MODULES");
-    const std::vector<std::string> &moduleNames = statsModuleNames();
-    if (moduleNames.empty()) {
-      ImGui::TextWrapped("Start live analysis to list graph-backed stats modules.");
-    } else {
-      ImGui::BeginChild("launcher-graph-stats-modules", ImVec2{0.0f, 130.0f}, true);
-      for (const std::string &moduleName : moduleNames) {
-        ImGui::PushID(moduleName.c_str());
-        if (ImGui::SmallButton("Frame")) {
-          createStatsModuleWindow(moduleName, 0);
-          hideLauncherWindow();
-        }
-        ImGui::SameLine();
-        if (ImGui::SmallButton("Module")) {
-          createStatsModuleWindow(moduleName, 1);
-          hideLauncherWindow();
-        }
-        ImGui::SameLine();
-        if (ImGui::SmallButton("Config")) {
-          createStatsModuleWindow(moduleName, 2);
-          hideLauncherWindow();
-        }
-        ImGui::SameLine();
-        ImGui::TextWrapped("%s", moduleName.c_str());
-        ImGui::PopID();
-      }
-      ImGui::EndChild();
-    }
-
-    ImGui::Separator();
-    renderLauncherWorkspaceControls();
-    ImGui::TreePop();
-  }
-
   if (uiLauncherOpen && ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !launcherHovered &&
       !uiLauncherToggleHovered) {
     hideLauncherWindow();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3530,20 +3530,11 @@ std::string SubtrActorPlugin::uiConfigJson() {
   std::vector<SingletonWindowControl> webWindows;
   std::vector<SingletonWindowControl> pluginWindows;
   for (const SingletonWindowControl &window : singletonWindowControls()) {
-    if (window.web_config) {
-      webWindows.push_back(window);
-    } else {
+    if (!window.web_config) {
       pluginWindows.push_back(window);
     }
   }
-  std::sort(
-      webWindows.begin(),
-      webWindows.end(),
-      [](const SingletonWindowControl &left, const SingletonWindowControl &right) {
-        return left.launcher_order == right.launcher_order
-                   ? std::string_view{left.config_id} < std::string_view{right.config_id}
-                   : left.launcher_order < right.launcher_order;
-      });
+  webWindows = webSingletonWindowControls();
   for (size_t index = 0; index < webWindows.size(); index += 1) {
     writeWindowConfig(webWindows[index], index + 1 == webWindows.size());
   }
@@ -6866,21 +6857,7 @@ void SubtrActorPlugin::renderLauncherWindow() {
     }
   };
 
-  std::vector<SingletonWindowControl> launcherWindows;
-  for (const SingletonWindowControl &window : singletonWindowControls()) {
-    if (window.web_config) {
-      launcherWindows.push_back(window);
-    }
-  }
-  std::sort(
-      launcherWindows.begin(),
-      launcherWindows.end(),
-      [](const SingletonWindowControl &left, const SingletonWindowControl &right) {
-        return left.launcher_order == right.launcher_order
-                   ? std::string_view{left.config_id} < std::string_view{right.config_id}
-                   : left.launcher_order < right.launcher_order;
-      });
-  for (const SingletonWindowControl &window : launcherWindows) {
+  for (const SingletonWindowControl &window : webSingletonWindowControls()) {
     renderLauncherWindowToggle(window);
   }
   for (const StatsWindowKindControl &kind : statsWindowKindControls()) {
@@ -9014,6 +8991,25 @@ SubtrActorPlugin::singletonWindowControls() {
        544.0f,
        420.0f},
   }};
+}
+
+std::vector<SubtrActorPlugin::SingletonWindowControl>
+SubtrActorPlugin::webSingletonWindowControls() {
+  std::vector<SingletonWindowControl> windows;
+  for (const SingletonWindowControl &window : singletonWindowControls()) {
+    if (window.web_config) {
+      windows.push_back(window);
+    }
+  }
+  std::sort(
+      windows.begin(),
+      windows.end(),
+      [](const SingletonWindowControl &left, const SingletonWindowControl &right) {
+        return left.launcher_order == right.launcher_order
+                   ? std::string_view{left.config_id} < std::string_view{right.config_id}
+                   : left.launcher_order < right.launcher_order;
+      });
+  return windows;
 }
 
 void SubtrActorPlugin::renderSingletonWindowManager() {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -98,6 +98,20 @@ std::string joinStrings(const std::vector<std::string> &parts, std::string_view 
   return joined;
 }
 
+void pushWebFloatingWindowStyle() {
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{14.0f, 12.0f});
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f);
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
+  ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2{8.0f, 8.0f});
+  ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4{0.03f, 0.07f, 0.10f, 0.88f});
+  ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{1.0f, 1.0f, 1.0f, 0.12f});
+}
+
+void popWebFloatingWindowStyle() {
+  ImGui::PopStyleColor(2);
+  ImGui::PopStyleVar(4);
+}
+
 constexpr char FRAME_EVENTS_STATE_NODE[] = "frame_events_state";
 constexpr std::array<const char *, 7> FRAME_EVENTS_STATE_EVENT_FIELDS{
     "active_demos",
@@ -7488,6 +7502,12 @@ void SubtrActorPlugin::renderFloatingWindowLayer() {
     int fallback_order = 0;
   };
 
+  auto renderWithFloatingWindowStyle = [](auto &&renderWindow) {
+    pushWebFloatingWindowStyle();
+    renderWindow();
+    popWebFloatingWindowStyle();
+  };
+
   std::vector<RenderEntry> renderOrder;
   for (const SingletonWindowControl &window : singletonWindowControls()) {
     if (*window.open) {
@@ -7522,7 +7542,9 @@ void SubtrActorPlugin::renderFloatingWindowLayer() {
 
   for (const RenderEntry &entry : renderOrder) {
     if (entry.kind == RenderEntryKind::Stats) {
-      renderStatsWindow(uiStatsWindows[entry.stats_index], entry.stats_index);
+      renderWithFloatingWindowStyle([&]() {
+        renderStatsWindow(uiStatsWindows[entry.stats_index], entry.stats_index);
+      });
       continue;
     }
 
@@ -7530,29 +7552,29 @@ void SubtrActorPlugin::renderFloatingWindowLayer() {
     if (id == "scoreboard") {
       renderScoreboardWindow();
     } else if (id == "mechanics") {
-      renderEventsWindow();
+      renderWithFloatingWindowStyle([&]() { renderEventsWindow(); });
     } else if (id == "event-playlist") {
-      renderEventPlaylistWindow();
+      renderWithFloatingWindowStyle([&]() { renderEventPlaylistWindow(); });
     } else if (id == "status") {
-      renderStatusWindow();
+      renderWithFloatingWindowStyle([&]() { renderStatusWindow(); });
     } else if (id == "camera") {
-      renderCameraWindow();
+      renderWithFloatingWindowStyle([&]() { renderCameraWindow(); });
     } else if (id == "playback") {
-      renderPlaybackControlsWindow();
+      renderWithFloatingWindowStyle([&]() { renderPlaybackControlsWindow(); });
     } else if (id == "recording") {
-      renderRecordingWindow();
+      renderWithFloatingWindowStyle([&]() { renderRecordingWindow(); });
     } else if (id == "graph-inspector") {
-      renderGraphInspectorWindow();
+      renderWithFloatingWindowStyle([&]() { renderGraphInspectorWindow(); });
     } else if (id == "mechanics-review") {
-      renderMechanicsReviewWindow();
+      renderWithFloatingWindowStyle([&]() { renderMechanicsReviewWindow(); });
     } else if (id == "replay-loading") {
-      renderReplayLoadingWindow();
+      renderWithFloatingWindowStyle([&]() { renderReplayLoadingWindow(); });
     } else if (id == "module-controls") {
-      renderModuleControlsWindow();
+      renderWithFloatingWindowStyle([&]() { renderModuleControlsWindow(); });
     } else if (id == "touch-controls") {
-      renderTouchControlsWindow();
+      renderWithFloatingWindowStyle([&]() { renderTouchControlsWindow(); });
     } else if (id == "boost-pickups") {
-      renderBoostPickupControlsWindow();
+      renderWithFloatingWindowStyle([&]() { renderBoostPickupControlsWindow(); });
     }
   }
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8940,9 +8940,7 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
   }
   eventPlaylistLastActiveKey = activeEventKey;
   if (playlistEventIndexes.empty()) {
-    ImGui::TextWrapped(
-        selectedSourceCount == 0 ? "No event types selected."
-                                 : "No events match the selected playlist filters.");
+    ImGui::TextDisabled("No event types selected.");
   }
   ImGui::EndChild();
   ImGui::End();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -30,7 +30,7 @@ constexpr float PI = 3.14159265358979323846f;
 constexpr float UNREAL_ROTATOR_TO_RADIANS = (2.0f * PI) / 65536.0f;
 constexpr float GOAL_WATCH_LEAD_SECONDS = 4.0f;
 constexpr ImGuiWindowFlags UI_FLOATING_WINDOW_FLAGS =
-    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse;
+    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse;
 constexpr ImGuiWindowFlags UI_CHROME_WINDOW_FLAGS =
     ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
     ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse |

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8811,19 +8811,11 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
                                                         : "Scanning";
   const std::string replaySummary = replayPath ? "1 replay" : "0 replays";
 
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REPLAY LOADING");
   ImGui::Text("%s", replaySummary.c_str());
   ImGui::SameLine();
   ImGui::Text("%s", status);
-  ImGui::Text("In replay: %s", inReplay ? "yes" : "no");
-  if (hasReplayServer) {
-    ImGui::Text("Replay time: %.2fs", replayServer.GetReplayTimeElapsed());
-  }
-  ImGui::Text("Annotations: %zu", annotationCount);
-  ImGui::Text("Players: %zu", annotationPlayers.size());
 
   ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REPLAY SOURCES");
   ImGui::BeginChild("replay-loading-list", ImVec2{0.0f, 112.0f}, true);
   if (!replayPath && rawReplayPath.empty() && replayAnnotationPath.empty()) {
     ImGui::TextDisabled("No replay sources.");
@@ -8846,14 +8838,7 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
       replayMeta.push_back(std::format("{} players", annotationPlayers.size()));
     }
     if (!replayMeta.empty()) {
-      std::string metaText;
-      for (const std::string &part : replayMeta) {
-        if (!metaText.empty()) {
-          metaText += " | ";
-        }
-        metaText += part;
-      }
-      ImGui::TextDisabled("%s", metaText.c_str());
+      ImGui::TextDisabled("%s", joinStrings(replayMeta, " · ").c_str());
     }
     ImGui::TextColored(
         replayAnnotations ? ImVec4{0.50f, 0.86f, 0.62f, 1.0f}
@@ -8864,72 +8849,6 @@ void SubtrActorPlugin::renderReplayLoadingWindow() {
         status);
   }
   ImGui::EndChild();
-
-  if (!annotationPlayers.empty()) {
-    ImGui::Separator();
-    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PLAYERS");
-    ImGui::BeginChild("replay-loading-players", ImVec2{0.0f, 96.0f}, true);
-    for (const SaReplayPlayerInfo &player : annotationPlayers) {
-      const char *name = player.name == nullptr || player.name[0] == '\0' ? "--" : player.name;
-      ImGui::TextColored(
-          player.is_team_0 != 0 ? ImVec4{0.31f, 0.75f, 1.0f, 1.0f}
-                                : ImVec4{1.0f, 0.69f, 0.31f, 1.0f},
-          "%s",
-          player.is_team_0 != 0 ? "Blue" : "Orange");
-      ImGui::SameLine();
-      ImGui::Text("#%u %s", player.player_index + 1, name);
-    }
-    ImGui::EndChild();
-  }
-
-  ImGui::Separator();
-  bool annotationsValue = annotationsEnabled;
-  if (ImGui::Checkbox("Replay annotations", &annotationsValue)) {
-    setCvarBool("subtr_actor_replay_annotations_enabled", annotationsValue);
-    if (!annotationsValue) {
-      resetReplayAnnotations();
-    }
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Retry load")) {
-    resetReplayAnnotations();
-    tickReplayAnnotations();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Clear load")) {
-    resetReplayAnnotations();
-  }
-
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "CURRENT REPLAY");
-  if (replayPath) {
-    ImGui::TextWrapped("Resolved: %s", replayPath->c_str());
-  } else {
-    ImGui::TextDisabled("Resolved: --");
-  }
-  if (!rawReplayPath.empty()) {
-    ImGui::TextWrapped("Raw: %s", rawReplayPath.c_str());
-  } else {
-    ImGui::TextDisabled("Raw: --");
-  }
-  if (!replayAnnotationPath.empty()) {
-    ImGui::TextWrapped("Processed: %s", replayAnnotationPath.c_str());
-  } else {
-    ImGui::TextDisabled("Processed: --");
-  }
-
-  ImGui::Separator();
-  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WINDOWS");
-  if (ImGui::Button("Open playback")) {
-    showSingletonWindow(uiPlaybackControlsOpen, playbackControlsPlacement);
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Open review")) {
-    showSingletonWindow(uiMechanicsReviewOpen, mechanicsReviewPlacement);
-  }
-  if (ImGui::Button("Open playlist")) {
-    showSingletonWindow(uiEventPlaylistOpen, eventPlaylistPlacement);
-  }
 
   ImGui::End();
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8961,7 +8961,8 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     const bool active = activeEventIndex && *activeEventIndex == index;
     const float seekTime = eventSeekTime(event);
     const std::string timeLabel = formatEventPlaylistTime(event.time);
-    const std::string eventLabel = event.label.empty() ? event.type : event.label;
+    const std::string sourceLabel = sourceLabelForEvent(event);
+    const std::string eventLabel = event.label.empty() ? sourceLabel : event.label;
     const std::string itemLabel =
         std::format("{}  {}##event-playlist-item", timeLabel, eventLabel);
     ImGui::PushStyleColor(ImGuiCol_Text, color);
@@ -8984,7 +8985,6 @@ void SubtrActorPlugin::renderEventPlaylistWindow() {
     if (event.frame_number != 0) {
       metaParts.push_back(std::format("frame {}", event.frame_number));
     }
-    const std::string sourceLabel = sourceLabelForEvent(event);
     if (!sourceLabel.empty()) {
       metaParts.push_back(sourceLabel);
     }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -10048,11 +10048,7 @@ void SubtrActorPlugin::renderPlaybackControlsWindow() {
   ImGui::Text("%llu", static_cast<unsigned long long>(frameNumber));
   ImGui::NextColumn();
   ImGui::TextDisabled("Duration");
-  if (durationSeconds > 0.0f) {
-    ImGui::Text("%.2fs", durationSeconds);
-  } else {
-    ImGui::TextDisabled("--");
-  }
+  ImGui::Text("%.2fs", durationSeconds);
   ImGui::NextColumn();
   ImGui::TextDisabled("Status");
   ImGui::Text("%s", playbackPlaying ? "Playing" : transportEnabled ? "Paused" : "Stopped");

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -55,6 +55,13 @@ constexpr std::array<const char *, 7> VERIFY_GRAPH_OUTPUTS{
     "event_history",
     "graph_info",
 };
+
+float rightAnchoredUiX(float width, float margin = 16.0f) {
+  const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+  const float viewportWidth = displaySize.x > 0.0f ? displaySize.x : 1440.0f;
+  return std::max(16.0f, viewportWidth - width - margin);
+}
+
 constexpr char FRAME_EVENTS_STATE_NODE[] = "frame_events_state";
 constexpr std::array<const char *, 7> FRAME_EVENTS_STATE_EVENT_FIELDS{
     "active_demos",
@@ -8933,20 +8940,77 @@ void SubtrActorPlugin::renderSingletonWindowManager() {
     float height;
   };
 
+  const float eventPlaylistX = rightAnchoredUiX(430.0f);
+  const float statusX = rightAnchoredUiX(330.0f);
+  const float playbackX = rightAnchoredUiX(336.0f, 32.0f);
+  const float recordingX = rightAnchoredUiX(416.0f, 32.0f);
+  const float mechanicsReviewX = rightAnchoredUiX(500.0f);
+  const float replayLoadingX = rightAnchoredUiX(520.0f);
+  const float moduleControlsX = rightAnchoredUiX(430.0f);
+  const float touchControlsX = rightAnchoredUiX(410.0f);
+
   std::array<SingletonWindowControl, 13> windows{{
       {"Scoreboard", &uiScoreboardOpen, &scoreboardPlacement, 0.0f, 11.0f, 88.0f, 34.0f},
-      {"Events", &uiEventsOpen, &eventsPlacement, 16.0f, 505.0f, 520.0f, 360.0f},
-      {"Event playlist", &uiEventPlaylistOpen, &eventPlaylistPlacement, 545.0f, 505.0f, 430.0f, 430.0f},
-      {"Status", &uiStatusOpen, &statusPlacement, 1230.0f, 68.0f, 330.0f, 220.0f},
-      {"Camera", &uiCameraOpen, &cameraPlacement, 720.0f, 68.0f, 360.0f, 500.0f},
-      {"Playback", &uiPlaybackControlsOpen, &playbackControlsPlacement, 880.0f, 68.0f, 360.0f, 430.0f},
-      {"Recording", &uiRecordingOpen, &recordingPlacement, 990.0f, 250.0f, 400.0f, 380.0f},
-      {"Graph inspector", &uiGraphInspectorOpen, &graphInspectorPlacement, 360.0f, 68.0f, 700.0f, 520.0f},
-      {"Mechanics review", &uiMechanicsReviewOpen, &mechanicsReviewPlacement, 980.0f, 160.0f, 500.0f, 560.0f},
-      {"Replay loading", &uiReplayLoadingOpen, &replayLoadingPlacement, 960.0f, 68.0f, 520.0f, 360.0f},
-      {"Module controls", &uiModuleControlsOpen, &moduleControlsPlacement, 980.0f, 305.0f, 430.0f, 520.0f},
-      {"Touch controls", &uiTouchControlsOpen, &touchControlsPlacement, 980.0f, 160.0f, 410.0f, 380.0f},
-      {"Boost pickup filters", &uiBoostPickupControlsOpen, &boostPickupControlsPlacement, 1000.0f, 560.0f, 430.0f, 420.0f},
+      {"Events", &uiEventsOpen, &eventsPlacement, 16.0f, 256.0f, 520.0f, 360.0f},
+      {"Event playlist",
+       &uiEventPlaylistOpen,
+       &eventPlaylistPlacement,
+       eventPlaylistX,
+       256.0f,
+       430.0f,
+       430.0f},
+      {"Status", &uiStatusOpen, &statusPlacement, statusX, 68.0f, 330.0f, 220.0f},
+      {"Camera", &uiCameraOpen, &cameraPlacement, 16.0f, 68.0f, 416.0f, 500.0f},
+      {"Playback",
+       &uiPlaybackControlsOpen,
+       &playbackControlsPlacement,
+       playbackX,
+       68.0f,
+       336.0f,
+       430.0f},
+      {"Recording", &uiRecordingOpen, &recordingPlacement, recordingX, 384.0f, 416.0f, 380.0f},
+      {"Graph inspector",
+       &uiGraphInspectorOpen,
+       &graphInspectorPlacement,
+       360.0f,
+       68.0f,
+       700.0f,
+       520.0f},
+      {"Mechanics review",
+       &uiMechanicsReviewOpen,
+       &mechanicsReviewPlacement,
+       mechanicsReviewX,
+       256.0f,
+       500.0f,
+       560.0f},
+      {"Replay loading",
+       &uiReplayLoadingOpen,
+       &replayLoadingPlacement,
+       replayLoadingX,
+       68.0f,
+       520.0f,
+       360.0f},
+      {"Module controls",
+       &uiModuleControlsOpen,
+       &moduleControlsPlacement,
+       moduleControlsX,
+       305.0f,
+       430.0f,
+       520.0f},
+      {"Touch controls",
+       &uiTouchControlsOpen,
+       &touchControlsPlacement,
+       touchControlsX,
+       256.0f,
+       410.0f,
+       380.0f},
+      {"Boost pickup filters",
+       &uiBoostPickupControlsOpen,
+       &boostPickupControlsPlacement,
+       16.0f,
+       448.0f,
+       544.0f,
+       420.0f},
   }};
 
   const size_t visibleCount = static_cast<size_t>(std::count_if(
@@ -9166,22 +9230,57 @@ void SubtrActorPlugin::resetWindowPlacements() {
   nextUiWindowZIndex = 1;
   resetSingletonWindowPlacement(launcherPlacement, 16.0f, 68.0f, 340.0f, 430.0f, true);
   resetScoreboardWindowPlacement();
-  resetSingletonWindowPlacement(eventsPlacement, 16.0f, 505.0f, 520.0f, 360.0f);
-  resetSingletonWindowPlacement(eventPlaylistPlacement, 545.0f, 505.0f, 430.0f, 430.0f);
-  resetSingletonWindowPlacement(statusPlacement, 1230.0f, 68.0f, 330.0f, 220.0f);
-  resetSingletonWindowPlacement(cameraPlacement, 720.0f, 68.0f, 360.0f, 500.0f);
-  resetSingletonWindowPlacement(playbackControlsPlacement, 880.0f, 68.0f, 360.0f, 430.0f);
-  resetSingletonWindowPlacement(recordingPlacement, 990.0f, 250.0f, 400.0f, 380.0f);
+  resetSingletonWindowPlacement(eventsPlacement, 16.0f, 256.0f, 520.0f, 360.0f);
+  resetSingletonWindowPlacement(
+      eventPlaylistPlacement,
+      rightAnchoredUiX(430.0f),
+      256.0f,
+      430.0f,
+      430.0f);
+  resetSingletonWindowPlacement(statusPlacement, rightAnchoredUiX(330.0f), 68.0f, 330.0f, 220.0f);
+  resetSingletonWindowPlacement(cameraPlacement, 16.0f, 68.0f, 416.0f, 500.0f);
+  resetSingletonWindowPlacement(
+      playbackControlsPlacement,
+      rightAnchoredUiX(336.0f, 32.0f),
+      68.0f,
+      336.0f,
+      430.0f);
+  resetSingletonWindowPlacement(
+      recordingPlacement,
+      rightAnchoredUiX(416.0f, 32.0f),
+      384.0f,
+      416.0f,
+      380.0f);
   resetSingletonWindowPlacement(graphInspectorPlacement, 360.0f, 68.0f, 700.0f, 520.0f);
-  resetSingletonWindowPlacement(mechanicsReviewPlacement, 980.0f, 160.0f, 500.0f, 560.0f);
-  resetSingletonWindowPlacement(replayLoadingPlacement, 960.0f, 68.0f, 520.0f, 360.0f);
-  resetSingletonWindowPlacement(moduleControlsPlacement, 980.0f, 305.0f, 430.0f, 520.0f);
-  resetSingletonWindowPlacement(touchControlsPlacement, 980.0f, 160.0f, 410.0f, 380.0f);
+  resetSingletonWindowPlacement(
+      mechanicsReviewPlacement,
+      rightAnchoredUiX(500.0f),
+      256.0f,
+      500.0f,
+      560.0f);
+  resetSingletonWindowPlacement(
+      replayLoadingPlacement,
+      rightAnchoredUiX(520.0f),
+      68.0f,
+      520.0f,
+      360.0f);
+  resetSingletonWindowPlacement(
+      moduleControlsPlacement,
+      rightAnchoredUiX(430.0f),
+      305.0f,
+      430.0f,
+      520.0f);
+  resetSingletonWindowPlacement(
+      touchControlsPlacement,
+      rightAnchoredUiX(410.0f),
+      256.0f,
+      410.0f,
+      380.0f);
   resetSingletonWindowPlacement(
       boostPickupControlsPlacement,
-      1000.0f,
-      560.0f,
-      430.0f,
+      16.0f,
+      448.0f,
+      544.0f,
       420.0f);
   for (size_t index = 0; index < uiStatsWindows.size(); index += 1) {
     resetStatsWindowPlacement(uiStatsWindows[index], index);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -234,7 +234,7 @@ constexpr std::array<const char *, 24> MECHANIC_FILTER_TOKENS{{
     "dodge_reset",
 }};
 
-constexpr std::array<UiStatDefinition, 15> UI_STAT_DEFINITIONS{{
+constexpr auto UI_STAT_DEFINITIONS = std::to_array<UiStatDefinition>({
     {"score", "Score", "Core", true, true, false},
     {"goals", "Goals", "Core", true, true, false},
     {"assists", "Assists", "Core", true, true, false},
@@ -250,9 +250,58 @@ constexpr std::array<UiStatDefinition, 15> UI_STAT_DEFINITIONS{{
     {"assist", "Assists detected", "Events", false, false, true},
     {"demo", "Demos detected", "Events", false, false, true},
     {"flip_reset", "Flip resets detected", "Events", false, false, true},
-}};
+    {"player:touch.touch_count", "Touches", "Touch", true, false, false},
+    {"player:touch.aerial_touch_count", "Aerial touches", "Touch", true, false, false},
+    {"player:touch.wall_touch_count", "Wall touches", "Touch", true, false, false},
+    {"player:boost.amount_used", "Boost used", "Boost", true, false, false},
+    {"player:boost.amount_collected", "Boost collected", "Boost", true, false, false},
+    {"player:boost.big_pads_collected", "Big pads", "Boost", true, false, false},
+    {"player:boost.small_pads_collected", "Small pads", "Boost", true, false, false},
+    {"player:movement.total_distance", "Distance", "Movement", true, false, false},
+    {"player:movement.time_supersonic_speed", "Supersonic time", "Movement", true, false, false},
+    {"player:speed_flip.count", "Speed flips", "Mechanics", true, false, false},
+    {"player:speed_flip.high_confidence_count", "Clean speed flips", "Mechanics", true, false, false},
+    {"player:half_flip.count", "Half flips", "Mechanics", true, false, false},
+    {"player:half_flip.high_confidence_count", "Clean half flips", "Mechanics", true, false, false},
+    {"player:wavedash.count", "Wavedashes", "Mechanics", true, false, false},
+    {"player:wavedash.high_confidence_count", "Clean wavedashes", "Mechanics", true, false, false},
+    {"player:demo.demos_inflicted", "Demos inflicted", "Contact", true, false, false},
+    {"player:demo.demos_taken", "Demos taken", "Contact", true, false, false},
+    {"player:bump.bumps_inflicted", "Bumps inflicted", "Contact", true, false, false},
+    {"player:bump.bumps_taken", "Bumps taken", "Contact", true, false, false},
+    {"player:double_tap.count", "Double taps", "Mechanics", true, false, false},
+    {"player:air_dribble.count", "Air dribbles", "Mechanics", true, false, false},
+    {"player:ball_carry.carry_count", "Ball carries", "Mechanics", true, false, false},
+    {"player:pass.completed_pass_count", "Completed passes", "Team play", true, false, false},
+    {"player:pass.received_pass_count", "Received passes", "Team play", true, false, false},
+    {"player:flick.count", "Flicks", "Mechanics", true, false, false},
+    {"player:musty_flick.count", "Musty flicks", "Mechanics", true, false, false},
+    {"player:wall_aerial.count", "Wall aerials", "Mechanics", true, false, false},
+    {"player:wall_aerial_shot.count", "Wall aerial shots", "Mechanics", true, false, false},
+    {"player:ceiling_shot.count", "Ceiling shots", "Mechanics", true, false, false},
+    {"player:whiff.whiff_count", "Whiffs", "Mechanics", true, false, false},
+    {"player:powerslide.press_count", "Powerslides", "Movement", true, false, false},
+    {"player:powerslide.total_duration", "Powerslide time", "Movement", true, false, false},
+    {"team:possession.possession_time", "Possession time", "Possession", false, true, false},
+    {"team:possession.opponent_possession_time", "Opponent possession", "Possession", false, true, false},
+    {"team:pressure.offensive_half_time", "Offensive pressure", "Pressure", false, true, false},
+    {"team:pressure.defensive_half_time", "Defensive pressure", "Pressure", false, true, false},
+    {"team:boost.amount_used", "Boost used", "Boost", false, true, false},
+    {"team:boost.amount_collected", "Boost collected", "Boost", false, true, false},
+    {"team:movement.total_distance", "Distance", "Movement", false, true, false},
+    {"team:movement.time_supersonic_speed", "Supersonic time", "Movement", false, true, false},
+    {"team:demo.demos_inflicted", "Demos inflicted", "Contact", false, true, false},
+    {"team:bump.bumps_inflicted", "Bumps inflicted", "Contact", false, true, false},
+    {"team:double_tap.count", "Double taps", "Mechanics", false, true, false},
+    {"team:air_dribble.count", "Air dribbles", "Mechanics", false, true, false},
+    {"team:ball_carry.carry_count", "Ball carries", "Mechanics", false, true, false},
+    {"team:pass.completed_pass_count", "Completed passes", "Team play", false, true, false},
+    {"team:rush.count", "Rushes", "Team play", false, true, false},
+    {"team:fifty_fifty.wins", "50/50 wins", "Team play", false, true, false},
+    {"team:fifty_fifty.losses", "50/50 losses", "Team play", false, true, false},
+});
 
-constexpr std::array<UiStatIdAlias, 20> UI_STAT_ID_ALIASES{{
+constexpr auto UI_STAT_ID_ALIASES = std::to_array<UiStatIdAlias>({
     {"player:core.score", "score"},
     {"player.core.score", "score"},
     {"team:core.score", "score"},
@@ -273,7 +322,7 @@ constexpr std::array<UiStatIdAlias, 20> UI_STAT_ID_ALIASES{{
     {"player.core.shots", "shots"},
     {"team:core.shots", "shots"},
     {"team.core.shots", "shots"},
-}};
+});
 
 bool wantsRequiredEventHistory(const std::vector<std::string> &params) {
   return std::find_if(params.begin(), params.end(), [](const std::string &param) {
@@ -1051,6 +1100,122 @@ std::optional<std::string> parseJsonObjectProperty(
     return std::nullopt;
   }
   return json.substr(start, end - start);
+}
+
+std::optional<std::string> parseJsonPropertyValue(
+    const std::string &json,
+    std::string_view propertyName) {
+  size_t offset = 0;
+  if (!findJsonPropertyValueOffset(json, std::string{propertyName}, offset)) {
+    return std::nullopt;
+  }
+  const size_t start = offset;
+  size_t end = offset;
+  if (!skipJsonValue(json, end)) {
+    return std::nullopt;
+  }
+  return json.substr(start, end - start);
+}
+
+std::vector<std::string_view> dotPathSegments(std::string_view path) {
+  std::vector<std::string_view> segments;
+  size_t offset = 0;
+  while (offset < path.size()) {
+    const size_t end = path.find('.', offset);
+    segments.emplace_back(
+        path.data() + offset,
+        (end == std::string_view::npos ? path.size() : end) - offset);
+    if (end == std::string_view::npos) {
+      break;
+    }
+    offset = end + 1;
+  }
+  return segments;
+}
+
+std::optional<std::string> jsonDisplayValueAtPath(
+    const std::string &json,
+    std::string_view path) {
+  std::string current = json;
+  const std::vector<std::string_view> segments = dotPathSegments(path);
+  if (segments.empty()) {
+    return std::nullopt;
+  }
+  for (size_t index = 0; index < segments.size(); index += 1) {
+    const auto value = parseJsonPropertyValue(current, segments[index]);
+    if (!value) {
+      return std::nullopt;
+    }
+    if (index + 1 == segments.size()) {
+      return summarizeJsonValueAt(*value, 0);
+    }
+    size_t offset = 0;
+    skipJsonWhitespace(*value, offset);
+    if (offset >= value->size() || (*value)[offset] != '{') {
+      return std::nullopt;
+    }
+    current = *value;
+  }
+  return std::nullopt;
+}
+
+std::optional<double> parseJsonNumberValue(const std::string &json) {
+  size_t offset = 0;
+  skipJsonWhitespace(json, offset);
+  const size_t start = offset;
+  if (offset < json.size() && json[offset] == '-') {
+    ++offset;
+  }
+  while (offset < json.size() &&
+         std::isdigit(static_cast<unsigned char>(json[offset])) != 0) {
+    ++offset;
+  }
+  if (offset < json.size() && json[offset] == '.') {
+    ++offset;
+    while (offset < json.size() &&
+           std::isdigit(static_cast<unsigned char>(json[offset])) != 0) {
+      ++offset;
+    }
+  }
+  if (offset == start) {
+    return std::nullopt;
+  }
+  try {
+    return std::stod(json.substr(start, offset - start));
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+struct GraphStatId {
+  std::string_view scope;
+  std::string_view module;
+  std::string_view path;
+};
+
+std::optional<GraphStatId> parseGraphStatId(std::string_view statId) {
+  const size_t scopeEnd = statId.find(':');
+  if (scopeEnd == std::string_view::npos) {
+    return std::nullopt;
+  }
+  const size_t moduleEnd = statId.find('.', scopeEnd + 1);
+  if (moduleEnd == std::string_view::npos || moduleEnd + 1 >= statId.size()) {
+    return std::nullopt;
+  }
+  return GraphStatId{
+      statId.substr(0, scopeEnd),
+      statId.substr(scopeEnd + 1, moduleEnd - scopeEnd - 1),
+      statId.substr(moduleEnd + 1),
+  };
+}
+
+bool jsonPlayerIdMatchesIndex(const std::string &playerIdJson, uint32_t playerIndex) {
+  const auto splitScreenValue = parseJsonPropertyValue(playerIdJson, "SplitScreen");
+  if (!splitScreenValue) {
+    return false;
+  }
+  const auto parsedIndex = parseJsonNumberValue(*splitScreenValue);
+  return parsedIndex && static_cast<uint32_t>(*parsedIndex) == playerIndex;
 }
 
 static_assert(sizeof(SaBoostPadEventKind) == 4);
@@ -3987,6 +4152,8 @@ void SubtrActorPlugin::tick(std::string) {
         std::format("subtr-actor: live frame processing failed: {}", processResult));
     return;
   }
+  cachedStatsJson.clear();
+  cachedStatsJsonFrameNumber = std::numeric_limits<uint64_t>::max();
 
   commitPendingFrameEvents();
   clearPendingFrameEvents();
@@ -4236,6 +4403,8 @@ void SubtrActorPlugin::resetLiveState() {
   recentUiEvents.clear();
   mechanicsReviewDecisions.clear();
   mechanicsReviewIndex = 0;
+  cachedStatsJson.clear();
+  cachedStatsJsonFrameNumber = std::numeric_limits<uint64_t>::max();
 }
 
 void SubtrActorPlugin::clearPendingFrameEvents() {
@@ -4776,7 +4945,7 @@ bool SubtrActorPlugin::goalEventIsDuplicate(const SaGoalEvent &goal) const {
              GOAL_EVENT_DEDUPE_WINDOW_SECONDS;
 }
 
-std::string SubtrActorPlugin::readJsonBuffer(JsonLen len, WriteJson write) {
+std::string SubtrActorPlugin::readJsonBuffer(JsonLen len, WriteJson write) const {
   if (!engine || !len || !write) {
     return {};
   }
@@ -4796,7 +4965,7 @@ std::string SubtrActorPlugin::readJsonBuffer(JsonLen len, WriteJson write) {
 std::string SubtrActorPlugin::readNamedJsonBuffer(
     NamedJsonLen len,
     WriteNamedJson write,
-    const std::string &name) {
+    const std::string &name) const {
   if (!engine || !len || !write) {
     return {};
   }
@@ -9528,7 +9697,10 @@ void SubtrActorPlugin::initializeStatsWindowEntries(UiStatsWindow &window) {
   case UiStatsWindowKind::Player:
     window.entries = {
         {"score", ""}, {"goals", ""}, {"assists", ""}, {"saves", ""},
-        {"shots", ""}, {"boost", ""}, {"recent_events", ""}};
+        {"shots", ""}, {"boost", ""}, {"player:touch.touch_count", ""},
+        {"player:boost.amount_used", ""}, {"player:speed_flip.count", ""},
+        {"player:half_flip.count", ""}, {"player:wavedash.count", ""},
+        {"recent_events", ""}};
     break;
   case UiStatsWindowKind::Team:
     window.entries = {
@@ -9539,12 +9711,16 @@ void SubtrActorPlugin::initializeStatsWindowEntries(UiStatsWindow &window) {
         {"saves", ""},
         {"shots", ""},
         {"average_boost", ""},
+        {"team:possession.possession_time", ""},
+        {"team:pressure.offensive_half_time", ""},
+        {"team:boost.amount_used", ""},
         {"recent_events", ""}};
     break;
   case UiStatsWindowKind::AllPlayers:
     window.entries = {
         {"score", ""}, {"goals", ""}, {"assists", ""}, {"saves", ""},
-        {"shots", ""}, {"boost", ""}, {"recent_events", ""}};
+        {"shots", ""}, {"boost", ""}, {"player:touch.touch_count", ""},
+        {"player:boost.amount_used", ""}, {"recent_events", ""}};
     break;
   case UiStatsWindowKind::AllTeams:
     window.entries = {
@@ -9553,6 +9729,8 @@ void SubtrActorPlugin::initializeStatsWindowEntries(UiStatsWindow &window) {
         {"goals", ""},
         {"shots", ""},
         {"average_boost", ""},
+        {"team:possession.possession_time", ""},
+        {"team:boost.amount_used", ""},
         {"recent_events", ""}};
     break;
   case UiStatsWindowKind::GoalsOverview:
@@ -9667,6 +9845,93 @@ const std::vector<std::string> &SubtrActorPlugin::statsModuleNames() {
   return cachedStatsModuleNames;
 }
 
+const std::string &SubtrActorPlugin::currentStatsJson() const {
+  if (!loaded || !engine || !statsJsonLen || !writeStatsJson) {
+    cachedStatsJson.clear();
+    cachedStatsJsonFrameNumber = std::numeric_limits<uint64_t>::max();
+    return cachedStatsJson;
+  }
+
+  if (cachedStatsJsonFrameNumber != frameNumber) {
+    cachedStatsJson = readJsonBuffer(statsJsonLen, writeStatsJson);
+    cachedStatsJsonFrameNumber = frameNumber;
+  }
+  return cachedStatsJson;
+}
+
+std::optional<std::string> SubtrActorPlugin::graphPlayerStatValue(
+    const SaPlayerFrame &player,
+    std::string_view statId) const {
+  const auto parsed = parseGraphStatId(statId);
+  if (!parsed || parsed->scope != "player") {
+    return std::nullopt;
+  }
+
+  const std::string &statsJson = currentStatsJson();
+  if (statsJson.empty()) {
+    return std::nullopt;
+  }
+  const auto frame = parseJsonObjectProperty(statsJson, "frame");
+  if (!frame) {
+    return std::nullopt;
+  }
+  const auto modules = parseJsonObjectProperty(*frame, "modules");
+  if (!modules) {
+    return std::nullopt;
+  }
+  const auto module = parseJsonObjectProperty(*modules, std::string{parsed->module});
+  if (!module) {
+    return std::nullopt;
+  }
+
+  const std::vector<std::string> playerStats =
+      parseJsonObjectArrayProperty(*module, "player_stats");
+  for (const std::string &entry : playerStats) {
+    const auto playerId = parseJsonObjectProperty(entry, "player_id");
+    if (!playerId || !jsonPlayerIdMatchesIndex(*playerId, player.player_index)) {
+      continue;
+    }
+    const auto stats = parseJsonObjectProperty(entry, "stats");
+    if (!stats) {
+      return std::nullopt;
+    }
+    return jsonDisplayValueAtPath(*stats, parsed->path);
+  }
+  return std::nullopt;
+}
+
+std::optional<std::string> SubtrActorPlugin::graphTeamStatValue(
+    uint8_t isTeam0,
+    std::string_view statId) const {
+  const auto parsed = parseGraphStatId(statId);
+  if (!parsed || parsed->scope != "team") {
+    return std::nullopt;
+  }
+
+  const std::string &statsJson = currentStatsJson();
+  if (statsJson.empty()) {
+    return std::nullopt;
+  }
+  const auto frame = parseJsonObjectProperty(statsJson, "frame");
+  if (!frame) {
+    return std::nullopt;
+  }
+  const auto modules = parseJsonObjectProperty(*frame, "modules");
+  if (!modules) {
+    return std::nullopt;
+  }
+  const auto module = parseJsonObjectProperty(*modules, std::string{parsed->module});
+  if (!module) {
+    return std::nullopt;
+  }
+  const auto team =
+      parseJsonObjectProperty(*module, isTeam0 != 0 ? "team_zero" : "team_one");
+  if (!team) {
+    return std::nullopt;
+  }
+  return jsonDisplayValueAtPath(*team, parsed->path);
+}
+
 std::string SubtrActorPlugin::playerStatValue(
     const SaPlayerFrame &player,
     std::string_view statId) const {
@@ -9693,6 +9958,9 @@ std::string SubtrActorPlugin::playerStatValue(
     return std::format(
         "{}",
         recentEventCountForActor(playerLabel(player.player_index, player.is_team_0)));
+  }
+  if (const auto graphValue = graphPlayerStatValue(player, localStatId)) {
+    return *graphValue;
   }
   return "--";
 }
@@ -9744,6 +10012,9 @@ std::string SubtrActorPlugin::teamStatValue(uint8_t isTeam0, std::string_view st
   }
   if (localStatId == "recent_events") {
     return std::format("{}", recentEventCountForTeam(isTeam0));
+  }
+  if (const auto graphValue = graphTeamStatValue(isTeam0, localStatId)) {
+    return *graphValue;
   }
   return "--";
 }

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8517,8 +8517,39 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
     return;
   }
 
+  auto touchBreakdownReadout = [&]() {
+    std::string readout;
+    for (const auto &[enabled, label] : {
+             std::pair<bool, const char *>{touchBreakdownKind, "Kind"},
+             std::pair<bool, const char *>{touchBreakdownHeight, "Height"},
+             std::pair<bool, const char *>{touchBreakdownSurface, "Surface"},
+             std::pair<bool, const char *>{touchBreakdownDodge, "Dodge"},
+         }) {
+      if (!enabled) {
+        continue;
+      }
+      if (!readout.empty()) {
+        readout += " + ";
+      }
+      readout += label;
+    }
+    return readout.empty() ? std::string{"Total only"} : readout;
+  };
+
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "TOUCH MARKERS");
+  ImGui::SameLine();
+  ImGui::TextColored(
+      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
+      "%.1fs",
+      touchMarkerDecaySeconds);
   ImGui::SliderFloat("Marker decay seconds", &touchMarkerDecaySeconds, 1.0f, 10.0f, "%.1fs");
+
+  ImGui::TextDisabled("Touch mode");
+  ImGui::SameLine();
+  ImGui::TextColored(
+      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
+      "%s",
+      touchControlsMode == 1 ? "Advancement" : "Markers");
   if (ImGui::RadioButton("Markers##touch-mode", &touchControlsMode, 0)) {
     setCvarString("subtr_actor_overlay_event_types", "touch");
   }
@@ -8529,6 +8560,11 @@ void SubtrActorPlugin::renderTouchControlsWindow() {
 
   ImGui::Separator();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "STAT BREAKDOWN");
+  ImGui::SameLine();
+  ImGui::TextColored(
+      ImVec4{0.53f, 0.69f, 0.83f, 1.0f},
+      "%s",
+      touchBreakdownReadout().c_str());
   ImGui::Checkbox("Kind", &touchBreakdownKind);
   ImGui::SameLine();
   ImGui::Checkbox("Height", &touchBreakdownHeight);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7429,6 +7429,36 @@ void SubtrActorPlugin::renderLauncherWindow() {
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "MODULE SETTINGS");
   renderModuleSettingsControls("launcher-module-settings", true);
 
+  ImGui::Separator();
+  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "GRAPH STATS MODULES");
+  const std::vector<std::string> &moduleNames = statsModuleNames();
+  if (moduleNames.empty()) {
+    ImGui::TextWrapped("Start live analysis to list graph-backed stats modules.");
+  } else {
+    ImGui::BeginChild("launcher-graph-stats-modules", ImVec2{0.0f, 130.0f}, true);
+    for (const std::string &moduleName : moduleNames) {
+      ImGui::PushID(moduleName.c_str());
+      if (ImGui::SmallButton("Frame")) {
+        createStatsModuleWindow(moduleName, 0);
+        uiLauncherOpen = false;
+      }
+      ImGui::SameLine();
+      if (ImGui::SmallButton("Module")) {
+        createStatsModuleWindow(moduleName, 1);
+        uiLauncherOpen = false;
+      }
+      ImGui::SameLine();
+      if (ImGui::SmallButton("Config")) {
+        createStatsModuleWindow(moduleName, 2);
+        uiLauncherOpen = false;
+      }
+      ImGui::SameLine();
+      ImGui::TextWrapped("%s", moduleName.c_str());
+      ImGui::PopID();
+    }
+    ImGui::EndChild();
+  }
+
   if (ImGui::TreeNode("Plugin tools##launcher-plugin-tools")) {
     const bool liveAnalysis = liveProcessingEnabled();
     if (ImGui::Button(liveAnalysis ? "Stop analysis" : "Start analysis", ImVec2{170.0f, 0.0f})) {
@@ -7519,24 +7549,6 @@ void SubtrActorPlugin::renderLauncherWindow() {
         cvarManager->log(
             "subtr-actor: clipboard does not contain raw UI config JSON or a raw JSON cfg value");
       }
-    }
-
-    ImGui::Separator();
-    ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "GRAPH MODULES");
-    const std::vector<std::string> &moduleNames = statsModuleNames();
-    if (moduleNames.empty()) {
-      ImGui::TextWrapped("Start live analysis to list graph-backed stats modules.");
-    } else {
-      ImGui::BeginChild("module-summary", ImVec2{0.0f, 150.0f}, true);
-      for (const std::string &moduleName : moduleNames) {
-        if (ImGui::SmallButton(std::format("Open##module-{}", moduleName).c_str())) {
-          createStatsModuleWindow(moduleName);
-          uiLauncherOpen = false;
-        }
-        ImGui::SameLine();
-        ImGui::Text("%s", moduleName.c_str());
-      }
-      ImGui::EndChild();
     }
 
     ImGui::Separator();

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -3352,7 +3352,13 @@ void SubtrActorPlugin::applyUiConfigJson(
           appendUniqueFilterToken(selectedFilters, token);
         }
       }
-      if (hasMechanicFilters && !mechanicFilters.empty()) {
+      const bool hasSelectedMechanicFilter = std::any_of(
+          selectedFilters.begin(),
+          selectedFilters.end(),
+          [](const std::string &token) {
+            return token == "mechanics" || isMechanicFilterToken(token);
+          });
+      if ((hasMechanicFilters && !mechanicFilters.empty()) || hasSelectedMechanicFilter) {
         eventPlaylistMechanicsEnabled = true;
       }
       setCvarString(
@@ -4008,7 +4014,6 @@ std::string SubtrActorPlugin::uiConfigJson() {
     file << "\"" << id << "\"";
     wroteOverlayValue = true;
   };
-  writeOverlayId("mechanics", eventPlaylistMechanicsEnabled);
   writeOverlayId("team", eventPlaylistTeamEventsEnabled);
   writeOverlayId("goal_context", eventPlaylistGoalContextEnabled);
   if (!allEventSourcesSelected(currentEventFilter)) {
@@ -4031,19 +4036,27 @@ std::string SubtrActorPlugin::uiConfigJson() {
   file << "],\n";
   file << "    \"mechanics\": [";
   const bool allMechanicsSelected =
-      allEventSourcesSelected(currentEventFilter) ||
-      containsString(currentEventFilterTokens, "mechanics");
+      eventPlaylistMechanicsEnabled &&
+      (allEventSourcesSelected(currentEventFilter) ||
+       containsString(currentEventFilterTokens, "mechanics"));
   bool wroteMechanicFilter = false;
-  if (!allMechanicsSelected) {
+  auto writeMechanicFilterId = [&](std::string_view token) {
+    if (wroteMechanicFilter) {
+      file << ",";
+    }
+    file << "\"" << escapeJsonString(token) << "\"";
+    wroteMechanicFilter = true;
+  };
+  if (allMechanicsSelected) {
+    for (const char *token : MECHANIC_FILTER_TOKENS) {
+      writeMechanicFilterId(token);
+    }
+  } else if (eventPlaylistMechanicsEnabled) {
     for (const std::string &token : currentEventFilterTokens) {
       if (!isMechanicFilterToken(token)) {
         continue;
       }
-      if (wroteMechanicFilter) {
-        file << ",";
-      }
-      file << "\"" << escapeJsonString(token) << "\"";
-      wroteMechanicFilter = true;
+      writeMechanicFilterId(token);
     }
   }
   file << "],\n";

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -8663,9 +8663,13 @@ void SubtrActorPlugin::renderScoreboardWindow() {
       ImGuiWindowFlags_NoSavedSettings;
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{10.0f, 6.0f});
   ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 999.0f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 1.0f);
+  ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4{0.03f, 0.07f, 0.10f, 0.88f});
+  ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{1.0f, 1.0f, 1.0f, 0.12f});
   if (!ImGui::Begin("Scoreboard##subtr-actor", &uiScoreboardOpen, scoreboardFlags)) {
     ImGui::End();
-    ImGui::PopStyleVar(2);
+    ImGui::PopStyleColor(2);
+    ImGui::PopStyleVar(3);
     return;
   }
   captureWindowPlacement(scoreboardPlacement);
@@ -8685,7 +8689,8 @@ void SubtrActorPlugin::renderScoreboardWindow() {
     ImGui::TextDisabled("Load a replay to show the scoreboard.");
   }
   ImGui::End();
-  ImGui::PopStyleVar(2);
+  ImGui::PopStyleColor(2);
+  ImGui::PopStyleVar(3);
 }
 
 void SubtrActorPlugin::renderEventsWindow() {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -12389,15 +12389,25 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
     const UiEventRecord &event = recentUiEvents[index];
     const float seekTime = std::max(0.0f, event.time - GOAL_WATCH_LEAD_SECONDS);
     ImGui::PushID(static_cast<int>(index));
+    const float buttonPadding = ImGui::GetStyle().FramePadding.x * 2.0f;
+    const float watchWidth = ImGui::CalcTextSize("Watch").x + buttonPadding;
+    const float cueWidth = ImGui::CalcTextSize("Cue").x + buttonPadding;
+    const float actionsX = std::max(
+        ImGui::GetCursorPosX(),
+        ImGui::GetWindowContentRegionMax().x - watchWidth - cueWidth -
+            ImGui::GetStyle().ItemSpacing.x);
     ImGui::TextColored(toImVec4(event.color), "Goal %zu", ordinal + 1);
+    ImGui::SameLine(actionsX);
+    const bool watchClicked = ImGui::SmallButton("Watch");
     ImGui::SameLine();
+    const bool cueClicked = ImGui::SmallButton("Cue");
     ImGui::TextDisabled(
         "%s · %s",
         formatEventPlaylistTime(event.time).c_str(),
         event.actor.empty() ? "Unknown scorer" : event.actor.c_str());
     const std::vector<std::string> tags = goalTagsForEvent(event);
     ImGui::TextDisabled("%s", tags.empty() ? "Unlabeled" : joinStrings(tags, " · ").c_str());
-    if (ImGui::SmallButton("Watch")) {
+    if (watchClicked) {
       mechanicsReviewClipActive = false;
       playbackCurrentTime = seekTime;
       playbackPlaying = true;
@@ -12408,12 +12418,11 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
         replayServer.StartPlaybackAtTime(seekTime);
       } else {
         cvarManager->log(std::format(
-            "subtr-actor: selected goal at {:.2f}s; open a replay to seek",
-            seekTime));
+          "subtr-actor: selected goal at {:.2f}s; open a replay to seek",
+          seekTime));
       }
     }
-    ImGui::SameLine();
-    if (ImGui::SmallButton("Cue")) {
+    if (cueClicked) {
       mechanicsReviewClipActive = false;
       playbackCurrentTime = seekTime;
       playbackPlaying = false;

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7422,6 +7422,11 @@ void SubtrActorPlugin::renderLauncherStatsWindowControls() {
       uiLauncherOpen = false;
     }
   }
+  if (!statsModuleNames().empty() &&
+      ImGui::Button("New stats module", ImVec2{170.0f, 0.0f})) {
+    createStatsWindow(UiStatsWindowKind::StatsModule);
+    uiLauncherOpen = false;
+  }
   if (uiStatsWindows.empty()) {
     return;
   }
@@ -10035,6 +10040,12 @@ void SubtrActorPlugin::createStatsWindow(UiStatsWindowKind kind, bool initialize
   window.kind = kind;
   initializeStatsWindowPlacement(window);
   focusStatsWindow(window);
+  if (kind == UiStatsWindowKind::StatsModule) {
+    const std::vector<std::string> &moduleNames = statsModuleNames();
+    if (!moduleNames.empty()) {
+      window.module_name = moduleNames.front();
+    }
+  }
   if (!sampledPlayers.empty()) {
     window.selected_player_index = sampledPlayers.front().player_index;
     window.selected_player_id = webPlayerIdForIndex(window.selected_player_index);

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -11824,7 +11824,6 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
     return leftEvent.time < rightEvent.time;
   });
 
-  ImGui::BeginChild("goal-labels", ImVec2{0.0f, 0.0f}, true);
   ReplayServerWrapper replayServer = gameWrapper->GetGameEventAsReplay();
   const bool hasReplayServer = !replayServer.IsNull();
   for (size_t ordinal = 0; ordinal < goalEventIndexes.size(); ordinal += 1) {
@@ -11834,13 +11833,11 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
     ImGui::PushID(static_cast<int>(index));
     ImGui::TextColored(toImVec4(event.color), "Goal %zu", ordinal + 1);
     ImGui::SameLine();
-    ImGui::TextDisabled("%.2fs - %s", event.time, event.actor.c_str());
-    ImGui::TextWrapped("%s", event.label.c_str());
-    if (!event.details.empty()) {
-      ImGui::TextDisabled("%s", event.details.c_str());
-    } else {
-      ImGui::TextDisabled("Unlabeled");
-    }
+    ImGui::TextDisabled(
+        "%s · %s",
+        formatEventPlaylistTime(event.time).c_str(),
+        event.actor.empty() ? "Unknown scorer" : event.actor.c_str());
+    ImGui::TextDisabled("%s", event.details.empty() ? "Unlabeled" : event.details.c_str());
     if (ImGui::SmallButton("Watch")) {
       mechanicsReviewClipActive = false;
       playbackCurrentTime = seekTime;
@@ -11876,13 +11873,12 @@ void SubtrActorPlugin::renderGoalsOverviewStats(UiStatsWindow &window) {
             std::format("Selected goal at {:.2f}s; open a replay to seek", seekTime);
       }
     }
-    ImGui::Separator();
+    ImGui::Spacing();
     ImGui::PopID();
   }
   if (goalEventIndexes.empty()) {
-    ImGui::TextWrapped("No goals loaded.");
+    ImGui::Text("No goals loaded.");
   }
-  ImGui::EndChild();
 }
 
 void SubtrActorPlugin::renderAdHocStatsWindow(UiStatsWindow &window) {

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7373,6 +7373,13 @@ bool SubtrActorPlugin::renderModuleSummaryToggle(
   if (active) {
     ImGui::PopStyleColor(2);
   }
+  if (width <= 0.0f) {
+    const float itemRight = ImGui::GetItemRectMax().x;
+    const float contentRight = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
+    if (contentRight - itemRight > 112.0f) {
+      ImGui::SameLine();
+    }
+  }
   return clicked;
 }
 
@@ -7577,9 +7584,15 @@ void SubtrActorPlugin::renderModuleSummaryControls(
 
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "TIMELINE VISUALIZATIONS");
   renderTimelineControls();
+  if (toggleWidth <= 0.0f) {
+    ImGui::NewLine();
+  }
   ImGui::Spacing();
   ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "IN-GAME VISUALIZATIONS");
   renderInGameControls();
+  if (toggleWidth <= 0.0f) {
+    ImGui::NewLine();
+  }
 }
 
 void SubtrActorPlugin::renderModuleSettingsControls(

--- a/bakkesmod/SubtrActorPlugin.cpp
+++ b/bakkesmod/SubtrActorPlugin.cpp
@@ -7609,7 +7609,23 @@ void SubtrActorPlugin::renderLauncherToggleChrome() {
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.28f, 0.57f, 0.72f, 1.0f});
   }
 
-  if (ImGui::Button("Menu##subtr-actor-launcher-toggle", ImVec2{42.0f, 42.0f})) {
+  const bool launcherToggleClicked =
+      ImGui::Button("##subtr-actor-launcher-toggle", ImVec2{42.0f, 42.0f});
+  const ImVec2 toggleMin = ImGui::GetItemRectMin();
+  const ImVec2 toggleMax = ImGui::GetItemRectMax();
+  const float toggleCenterX = (toggleMin.x + toggleMax.x) * 0.5f;
+  const float toggleCenterY = (toggleMin.y + toggleMax.y) * 0.5f;
+  ImDrawList *drawList = ImGui::GetWindowDrawList();
+  const ImU32 barColor = ImGui::GetColorU32(ImVec4{0.93f, 0.96f, 0.98f, 1.0f});
+  for (const float yOffset : {-6.0f, 0.0f, 6.0f}) {
+    drawList->AddLine(
+        ImVec2{toggleCenterX - 9.5f, toggleCenterY + yOffset},
+        ImVec2{toggleCenterX + 9.5f, toggleCenterY + yOffset},
+        barColor,
+        2.0f);
+  }
+
+  if (launcherToggleClicked) {
     uiWindowOpen = true;
     if (uiLauncherOpen) {
       hideLauncherWindow();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -352,7 +352,7 @@ private:
   int cameraFreePreset = -1;
   uint32_t cameraSelectedPlayerIndex = 0;
   std::string cameraSelectedPlayerId;
-  float cameraDistanceScale = 1.0f;
+  float cameraDistanceScale = 2.25f;
   bool cameraCustomSettingsEnabled = false;
   bool cameraBallCamEnabled = false;
   float cameraCustomFov = 110.0f;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -442,12 +442,17 @@ private:
   void applyLauncherMenuPlacement();
   void renderLauncherWindow();
   void renderLauncherWorkspaceControls();
-  void renderWebWindowToggleControls(const char *idSuffix, bool closeLauncherOnToggle);
+  void renderWebWindowToggleControls(
+      const char *idSuffix,
+      bool closeLauncherOnToggle,
+      bool includeState = true,
+      bool fullWidth = false);
   void renderStatsWindowCreationControls(
       const char *idSuffix,
       bool closeLauncherOnCreate,
       bool includeHeading = true,
-      bool includeManager = true);
+      bool includeManager = true,
+      bool fullWidth = false);
   void renderSettingsWindowControls();
   void renderEmptyStateWindow();
   void renderFloatingWindowLayer();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -150,8 +150,8 @@ private:
     bool pending_apply_placement = false;
     float x = 0.0f;
     float y = 0.0f;
-    float width = 540.0f;
-    float height = 330.0f;
+    float width = 0.0f;
+    float height = 0.0f;
     float viewport_width = 0.0f;
     float viewport_height = 0.0f;
     int z_index = 0;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -449,6 +449,7 @@ private:
   void renderEventSourceControls();
   void renderStatusWindow();
   void renderCameraWindow();
+  void applyPlaybackConfigToReplay(std::string_view sourceLabel);
   void renderPlaybackControlsWindow();
   void renderRecordingWindow();
   void renderGraphInspectorWindow();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -435,7 +435,7 @@ private:
   void renderLauncherWorkspaceControls();
   void renderLauncherStatsWindowControls();
   void renderEmptyStateWindow();
-  void renderSingletonWindows();
+  void renderFloatingWindowLayer();
   void renderScoreboardWindow();
   void renderEventsWindow();
   void renderEventSourceControls();
@@ -508,7 +508,6 @@ private:
   bool renderSingletonWindowHeader(const char *label, bool &open);
   void applyStatsWindowPlacement(UiStatsWindow &window);
   void captureStatsWindowPlacement(UiStatsWindow &window);
-  void renderStatsWindows();
   void renderStatsWindow(UiStatsWindow &window, size_t stackIndex);
   void renderStatsWindowScopeSelector(UiStatsWindow &window);
   void renderStatsWindowAddControl(UiStatsWindow &window);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -494,6 +494,7 @@ private:
   void createStatsWindow(UiStatsWindowKind kind, bool initializeEntries = false);
   void createStatsModuleWindow(std::string moduleName, int moduleView = 0);
   std::pair<float, float> defaultStatsWindowSize(UiStatsWindowKind kind) const;
+  std::pair<float, float> defaultStatsWindowPosition(size_t stackIndex) const;
   void initializeStatsWindowPlacement(UiStatsWindow &window);
   void resetStatsWindowPlacement(UiStatsWindow &window, size_t stackIndex);
   void showStatsWindow(UiStatsWindow &window);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -335,7 +335,7 @@ private:
   bool renderEffectSpeedFlipEnabled = false;
   bool renderEffectTouchEnabled = false;
   int cameraViewMode = 0;
-  int cameraFreePreset = 0;
+  int cameraFreePreset = -1;
   uint32_t cameraSelectedPlayerIndex = 0;
   std::string cameraSelectedPlayerId;
   float cameraDistanceScale = 1.0f;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -583,6 +583,7 @@ private:
   void loadUiConfig();
   void saveUiConfig();
   void maybeAutosaveUiConfig();
+  void renderLayoutConfigControls(const char *idSuffix);
   int recentEventCountForActor(std::string_view actor) const;
   int recentEventCountForTeam(uint8_t isTeam0) const;
   int recentEventCountForType(std::string_view type) const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -321,7 +321,6 @@ private:
   bool eventPlaylistTeamEventsEnabled = true;
   bool eventPlaylistGoalContextEnabled = true;
   bool eventPlaylistAutoFollow = true;
-  std::string eventPlaylistStatus;
   bool timelineRangeBoostEnabled = false;
   bool timelineRangePossessionEnabled = false;
   bool timelineRangePressureEnabled = false;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -432,6 +432,7 @@ private:
   void renderLauncherToggleChrome();
   void applyLauncherMenuPlacement();
   void renderLauncherWindow();
+  void renderLauncherWorkspaceControls();
   void renderScoreboardWindow();
   void renderEventsWindow();
   void renderEventSourceControls();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -608,6 +608,7 @@ private:
       std::string_view lhsTargetId,
       std::string_view rhsTargetId) const;
   const std::vector<std::string> &statsModuleNames();
+  std::vector<std::string> availableStatsModuleNames();
   std::string playerStatValue(const SaPlayerFrame &player, std::string_view statId) const;
   std::string teamStatValue(uint8_t isTeam0, std::string_view statId) const;
   const std::string &currentStatsJson() const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -435,6 +435,7 @@ private:
   void renderLauncherWorkspaceControls();
   void renderLauncherStatsWindowControls();
   void renderEmptyStateWindow();
+  void renderSingletonWindows();
   void renderScoreboardWindow();
   void renderEventsWindow();
   void renderEventSourceControls();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -184,6 +184,7 @@ private:
     const char *label;
     const char *create_label;
     bool web_config;
+    bool default_window;
   };
 
   struct PlayerStatSnapshot {

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -599,9 +599,12 @@ private:
       const UiStatsWindow::Entry &entry) const;
   std::optional<uint32_t> playerIndexForTargetId(std::string_view targetId) const;
   std::string webPlayerIdForIndex(uint32_t playerIndex) const;
+  std::optional<std::string> webPlayerIdForIndexIfKnown(uint32_t playerIndex) const;
   std::string webPlayerIdForWindow(const UiStatsWindow &window) const;
+  std::optional<std::string> webPlayerIdForWindowConfig(const UiStatsWindow &window) const;
   void resolveStatsWindowPlayerSelection(UiStatsWindow &window);
   std::string webCameraPlayerId() const;
+  std::optional<std::string> webCameraPlayerIdConfig() const;
   void resolveCameraPlayerSelection();
   void renderAdHocTargetSelector(
       UiStatsWindow &window,

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -472,7 +472,11 @@ private:
   void renderModuleControlsWindow();
   void renderTouchControlsWindow();
   void renderBoostPickupControlsWindow();
-  bool renderModuleSummaryToggle(const char *label, bool active, const char *idSuffix);
+  bool renderModuleSummaryToggle(
+      const char *label,
+      bool active,
+      const char *idSuffix,
+      float width = 230.0f);
   void renderCvarModuleSummaryToggle(
       const char *label,
       const char *name,

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -382,6 +382,8 @@ private:
   bool boostPickupFieldOwn = true;
   bool boostPickupFieldOpponent = true;
   bool boostPickupFieldUnknown = true;
+  bool boostPickupPlayerFilterEnabled = false;
+  std::vector<std::string> boostPickupPlayerIds;
   int graphInspectorView = 0;
   int mechanicsReviewIndex = 0;
   float mechanicsReviewClipLeadSeconds = 2.0f;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -481,13 +481,22 @@ private:
       const char *label,
       const char *name,
       bool defaultValue,
-      const char *idSuffix);
+      const char *idSuffix,
+      float width = 230.0f);
   void renderEventFilterModuleSummaryToggle(
       const char *label,
       const char *token,
-      const char *idSuffix);
-  void renderBoolModuleSummaryToggle(const char *label, bool &active, const char *idSuffix);
-  void renderModuleSummaryControls(const char *idSuffix, bool collapsibleGroups = true);
+      const char *idSuffix,
+      float width = 230.0f);
+  void renderBoolModuleSummaryToggle(
+      const char *label,
+      bool &active,
+      const char *idSuffix,
+      float width = 230.0f);
+  void renderModuleSummaryControls(
+      const char *idSuffix,
+      bool collapsibleGroups = true,
+      float toggleWidth = 230.0f);
   void renderModuleSettingsControls(
       const char *idSuffix,
       bool includeOpenButtons,

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -441,7 +441,9 @@ private:
   void applyLauncherMenuPlacement();
   void renderLauncherWindow();
   void renderLauncherWorkspaceControls();
-  void renderLauncherStatsWindowControls();
+  void renderWebWindowToggleControls(const char *idSuffix, bool closeLauncherOnToggle);
+  void renderStatsWindowCreationControls(const char *idSuffix, bool closeLauncherOnCreate);
+  void renderSettingsWindowControls();
   void renderEmptyStateWindow();
   void renderFloatingWindowLayer();
   void renderScoreboardWindow();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -355,7 +355,6 @@ private:
   std::string playbackStatus = "Stopped";
   int recordingFps = 60;
   int recordingPlaybackRateIndex = 1;
-  bool recordingFinishBeforeDump = false;
   bool recordingActive = false;
   int recordingSnapshotCount = 0;
   size_t recordingLastBytes = 0;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -433,6 +433,7 @@ private:
   void applyLauncherMenuPlacement();
   void renderLauncherWindow();
   void renderLauncherWorkspaceControls();
+  void renderLauncherStatsWindowControls();
   void renderScoreboardWindow();
   void renderEventsWindow();
   void renderEventSourceControls();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -477,6 +477,7 @@ private:
       float y,
       float width,
       float height);
+  void applySingletonWindowPlacement(UiWindowPlacement &placement);
   void applyScoreboardWindowPlacement();
   void captureWindowPlacement(UiWindowPlacement &placement);
   bool renderSingletonWindowHeader(const char *label, bool &open);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -617,7 +617,7 @@ private:
   void scheduleUiConfigAutosave(
       std::chrono::milliseconds delay = std::chrono::milliseconds(150));
   void maybeAutosaveUiConfig();
-  void renderLayoutConfigControls(const char *idSuffix);
+  void renderLayoutConfigControls(const char *idSuffix, bool fullWidth = false);
   int recentEventCountForActor(std::string_view actor) const;
   int recentEventCountForTeam(uint8_t isTeam0) const;
   int recentEventCountForType(std::string_view type) const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -97,6 +97,8 @@ private:
   using ReplayAnnotationPlayerCount = size_t (*)(const SaReplayAnnotations *);
   using WriteReplayAnnotationPlayers =
       size_t (*)(const SaReplayAnnotations *, SaReplayPlayerInfo *, size_t);
+  using ReplayAnnotationScoreAtTime =
+      int32_t (*)(const SaReplayAnnotations *, float, SaReplayScore *);
   using PollReplayAnnotations =
       size_t (*)(SaReplayAnnotations *, float, SaMechanicEvent *, size_t);
 
@@ -254,6 +256,7 @@ private:
   ReplayAnnotationCount replayAnnotationCount = nullptr;
   ReplayAnnotationPlayerCount replayAnnotationPlayerCount = nullptr;
   WriteReplayAnnotationPlayers writeReplayAnnotationPlayers = nullptr;
+  ReplayAnnotationScoreAtTime replayAnnotationScoreAtTime = nullptr;
   PollReplayAnnotations pollReplayAnnotations = nullptr;
 
   uint64_t frameNumber = 0;
@@ -669,6 +672,7 @@ private:
   void pushTeamEventMessage(const SaTeamEvent &event);
   void pushGoalContextEventMessage(const SaGoalContextEvent &event);
   void pushPlayerStatEventMessage(const SaPlayerStatEvent &event);
+  std::optional<std::pair<int32_t, int32_t>> currentScoreboardScore() const;
   bool overlayCategoryEnabled(std::string_view category);
   bool overlayMechanicEnabled(SaMechanicKind kind);
   std::string playerLabel(uint32_t playerIndex, uint8_t isTeam0) const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -487,7 +487,7 @@ private:
       const char *token,
       const char *idSuffix);
   void renderBoolModuleSummaryToggle(const char *label, bool &active, const char *idSuffix);
-  void renderModuleSummaryControls(const char *idSuffix);
+  void renderModuleSummaryControls(const char *idSuffix, bool collapsibleGroups = true);
   void renderModuleSettingsControls(const char *idSuffix, bool includeOpenButtons);
   std::array<SingletonWindowControl, 13> singletonWindowControls();
   std::vector<SingletonWindowControl> webSingletonWindowControls();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -351,7 +351,7 @@ private:
   float playbackCurrentTime = 0.0f;
   bool playbackPlaying = false;
   float playbackRate = 1.0f;
-  bool playbackSkipPostGoalTransitions = false;
+  bool playbackSkipPostGoalTransitions = true;
   bool playbackSkipKickoffs = false;
   std::string playbackStatus = "Stopped";
   int recordingFps = 60;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -558,6 +558,7 @@ private:
   void renderStatsWindowScopeSelector(UiStatsWindow &window);
   void renderStatsWindowAddControl(UiStatsWindow &window);
   void renderStatsWindowEntries(UiStatsWindow &window);
+  void renderMissingStatsRows(UiStatsWindow &window);
   void renderPlayerStatsTable(UiStatsWindow &window, const SaPlayerFrame &player);
   void renderTeamStatsTable(UiStatsWindow &window, uint8_t isTeam0);
   void renderAllPlayersStatsTable(UiStatsWindow &window);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -666,6 +666,7 @@ private:
   void pushEventMessage(const SaMechanicEvent &event);
   void pushTeamEventMessage(const SaTeamEvent &event);
   void pushGoalContextEventMessage(const SaGoalContextEvent &event);
+  void pushPlayerStatEventMessage(const SaPlayerStatEvent &event);
   bool overlayCategoryEnabled(std::string_view category);
   bool overlayMechanicEnabled(SaMechanicKind kind);
   std::string playerLabel(uint32_t playerIndex, uint8_t isTeam0) const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -664,6 +664,7 @@ private:
   void dumpAnalysisNodeJson(std::vector<std::string> params);
   void verifyGraphRuntime(std::vector<std::string> params);
   void selfTestGraphRuntime(std::vector<std::string> params);
+  void pushGoalEventMessage(const SaGoalEvent &event);
   void pushEventMessage(const SaMechanicEvent &event);
   void pushTeamEventMessage(const SaTeamEvent &event);
   void pushGoalContextEventMessage(const SaGoalContextEvent &event);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -325,6 +325,7 @@ private:
   bool eventPlaylistGoalContextEnabled = true;
   bool eventPlaylistAutoFollow = true;
   std::string eventPlaylistSourceFilter = "default";
+  std::string eventPlaylistLastActiveKey;
   bool timelineRangeBoostEnabled = false;
   bool timelineRangePossessionEnabled = false;
   bool timelineRangePressureEnabled = false;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -503,7 +503,8 @@ private:
   void renderModuleSettingsControls(
       const char *idSuffix,
       bool includeOpenButtons,
-      bool webCardHeaders = false);
+      bool webCardHeaders = false,
+      bool onlyWebActivePanels = false);
   std::array<SingletonWindowControl, 13> singletonWindowControls();
   std::vector<SingletonWindowControl> webSingletonWindowControls();
   std::array<StatsWindowKindControl, 7> statsWindowKindControls() const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -316,6 +316,7 @@ private:
   bool uiModuleControlsOpen = false;
   bool uiTouchControlsOpen = false;
   bool uiBoostPickupControlsOpen = false;
+  bool uiLauncherToggleHovered = false;
   bool eventPlaylistMechanicsEnabled = true;
   bool eventPlaylistTeamEventsEnabled = true;
   bool eventPlaylistGoalContextEnabled = true;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -623,6 +623,7 @@ private:
   std::string uiConfigJson();
   std::optional<std::string> statsPlayerCfgFromJson(const std::string &json);
   std::optional<std::string> statsPlayerCfgJsonFromClipboard(std::string_view clipboardText);
+  void applyUiConfigParams(std::vector<std::string> params);
   void applyUiConfigJson(const std::string &json, std::string_view sourceLabel);
   void loadUiConfig();
   void saveUiConfig();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -188,6 +188,8 @@ private:
     const char *label;
     const char *create_label;
     uint8_t stat_scopes;
+    bool scope_selector;
+    bool stat_picker;
     bool web_config;
     bool default_window;
   };
@@ -515,6 +517,8 @@ private:
   const char *statsWindowKindConfigId(UiStatsWindowKind kind) const;
   const char *statsWindowKindLabel(UiStatsWindowKind kind) const;
   uint8_t statsWindowKindStatScopes(UiStatsWindowKind kind) const;
+  bool statsWindowKindHasScopeSelector(UiStatsWindowKind kind) const;
+  bool statsWindowKindHasStatPicker(UiStatsWindowKind kind) const;
   std::string statsWindowDisplayLabel(const UiStatsWindow &window) const;
   std::string statsWindowTitle(const UiStatsWindow &window) const;
   const SaPlayerFrame *sampledPlayerByIndex(uint32_t playerIndex) const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <chrono>
 #include <deque>
 #include <filesystem>
@@ -172,6 +173,14 @@ private:
     float y;
     float width;
     float height;
+  };
+
+  struct StatsWindowKindControl {
+    UiStatsWindowKind kind;
+    const char *config_id;
+    const char *label;
+    const char *create_label;
+    bool web_config;
   };
 
   struct PlayerStatSnapshot {
@@ -436,6 +445,7 @@ private:
   void renderModuleSummaryControls(const char *idSuffix);
   void renderModuleSettingsControls(const char *idSuffix, bool includeOpenButtons);
   std::array<SingletonWindowControl, 13> singletonWindowControls();
+  std::array<StatsWindowKindControl, 7> statsWindowKindControls() const;
   void renderSingletonWindowManager();
   void renderStatsWindowManager();
   void focusTopLoadedWindow();
@@ -488,6 +498,8 @@ private:
   void renderJsonInspectorPayload(const char *id, const std::string &label, const std::string &json);
   std::vector<std::string> graphOutputNames();
   std::vector<std::string> analysisNodeNames();
+  std::optional<UiStatsWindowKind> parseStatsWindowKind(std::string_view value) const;
+  const char *statsWindowKindConfigId(UiStatsWindowKind kind) const;
   const char *statsWindowKindLabel(UiStatsWindowKind kind) const;
   std::string statsWindowDisplayLabel(const UiStatsWindow &window) const;
   std::string statsWindowTitle(const UiStatsWindow &window) const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -97,6 +97,8 @@ private:
   using ReplayAnnotationPlayerCount = size_t (*)(const SaReplayAnnotations *);
   using WriteReplayAnnotationPlayers =
       size_t (*)(const SaReplayAnnotations *, SaReplayPlayerInfo *, size_t);
+  using WriteReplayAnnotationFramePlayers =
+      size_t (*)(const SaReplayAnnotations *, float, SaPlayerFrame *, size_t);
   using ReplayAnnotationScoreAtTime =
       int32_t (*)(const SaReplayAnnotations *, float, SaReplayScore *);
   using PollReplayAnnotations =
@@ -256,6 +258,7 @@ private:
   ReplayAnnotationCount replayAnnotationCount = nullptr;
   ReplayAnnotationPlayerCount replayAnnotationPlayerCount = nullptr;
   WriteReplayAnnotationPlayers writeReplayAnnotationPlayers = nullptr;
+  WriteReplayAnnotationFramePlayers writeReplayAnnotationFramePlayers = nullptr;
   ReplayAnnotationScoreAtTime replayAnnotationScoreAtTime = nullptr;
   PollReplayAnnotations pollReplayAnnotations = nullptr;
 
@@ -651,7 +654,7 @@ private:
   std::string mechanicsReviewKey(const UiEventRecord &event) const;
   const char *mechanicsReviewDecisionLabel(const UiEventRecord &event) const;
   void tickReplayAnnotations();
-  void importReplayAnnotationPlayers();
+  void importReplayAnnotationPlayers(float replayTime);
   void tickMechanicsReviewClipBoundary();
   void resetReplayAnnotations();
   std::optional<std::string> currentReplayPath(ReplayServerWrapper replayServer);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <deque>
 #include <filesystem>
+#include <initializer_list>
 #include <memory>
 #include <optional>
 #include <string>
@@ -453,6 +454,9 @@ private:
   void focusTopLoadedWindow();
   void resetWindowPlacements();
   void resetDefaultStatsWindows();
+  void applyWorkspaceWindowVisibility(
+      bool launcherOpen,
+      std::initializer_list<std::string_view> openWindowIds);
   void applyDefaultUiWorkspace();
   void applyReplayReviewUiWorkspace();
   void applyGraphDebugUiWorkspace();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -443,7 +443,11 @@ private:
   void renderLauncherWindow();
   void renderLauncherWorkspaceControls();
   void renderWebWindowToggleControls(const char *idSuffix, bool closeLauncherOnToggle);
-  void renderStatsWindowCreationControls(const char *idSuffix, bool closeLauncherOnCreate);
+  void renderStatsWindowCreationControls(
+      const char *idSuffix,
+      bool closeLauncherOnCreate,
+      bool includeHeading = true,
+      bool includeManager = true);
   void renderSettingsWindowControls();
   void renderEmptyStateWindow();
   void renderFloatingWindowLayer();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -509,6 +509,7 @@ private:
   void resetScoreboardWindowPlacement(bool focus = false);
   void showSingletonWindow(bool &open, UiWindowPlacement &placement);
   void hideSingletonWindow(bool &open);
+  void hideStatsWindow(UiStatsWindow &window);
   void focusSingletonWindow(UiWindowPlacement &placement);
   void hideLauncherWindow();
   void applyWindowPlacement(

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -122,6 +122,8 @@ private:
     LinearColor color;
     uint64_t frame_number = 0;
     float time = 0.0f;
+    uint8_t has_player = 0;
+    uint32_t player_index = 0;
   };
 
   enum class UiStatsWindowKind {

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -321,7 +321,7 @@ private:
   bool eventPlaylistTeamEventsEnabled = true;
   bool eventPlaylistGoalContextEnabled = true;
   bool eventPlaylistAutoFollow = true;
-  std::string eventPlaylistSourceFilter = "all";
+  std::string eventPlaylistSourceFilter = "default";
   bool timelineRangeBoostEnabled = false;
   bool timelineRangePossessionEnabled = false;
   bool timelineRangePressureEnabled = false;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -88,6 +88,9 @@ private:
   using WriteDecodedStatsPlayerConfigJson = size_t (*)(const char *, uint8_t *, size_t);
   using EncodedStatsPlayerConfigLen = size_t (*)(const char *);
   using WriteEncodedStatsPlayerConfig = size_t (*)(const char *, uint8_t *, size_t);
+  using ReplayAnnotationFrameJsonLen = size_t (*)(const SaReplayAnnotations *, float);
+  using WriteReplayAnnotationFrameJson =
+      size_t (*)(const SaReplayAnnotations *, float, uint8_t *, size_t);
   using DrainEvents = size_t (*)(SaEngine *, SaMechanicEvent *, size_t);
   using DrainTeamEvents = size_t (*)(SaEngine *, SaTeamEvent *, size_t);
   using DrainGoalContextEvents = size_t (*)(SaEngine *, SaGoalContextEvent *, size_t);
@@ -259,6 +262,8 @@ private:
   ReplayAnnotationPlayerCount replayAnnotationPlayerCount = nullptr;
   WriteReplayAnnotationPlayers writeReplayAnnotationPlayers = nullptr;
   WriteReplayAnnotationFramePlayers writeReplayAnnotationFramePlayers = nullptr;
+  ReplayAnnotationFrameJsonLen replayAnnotationFrameJsonLen = nullptr;
+  WriteReplayAnnotationFrameJson writeReplayAnnotationFrameJson = nullptr;
   ReplayAnnotationScoreAtTime replayAnnotationScoreAtTime = nullptr;
   PollReplayAnnotations pollReplayAnnotations = nullptr;
 
@@ -424,6 +429,8 @@ private:
       std::chrono::steady_clock::time_point{};
   mutable uint64_t cachedStatsJsonFrameNumber = std::numeric_limits<uint64_t>::max();
   mutable std::string cachedStatsJson;
+  mutable float cachedReplayFrameJsonTime = -1.0f;
+  mutable std::string cachedReplayFrameJson;
   std::chrono::steady_clock::time_point nextUiConfigAutosave =
       std::chrono::steady_clock::time_point{};
   std::string lastSavedUiConfigJson;
@@ -663,6 +670,7 @@ private:
       NamedJsonLen len,
       WriteNamedJson write,
       const std::string &name) const;
+  const std::string &currentReplayFrameJson() const;
   void dumpGraphJson(std::vector<std::string> params);
   void dumpStatsModuleJson(std::vector<std::string> params);
   void dumpStatsModuleFrameJson(std::vector<std::string> params);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -506,7 +506,7 @@ private:
   void applyStatsWindowPlacement(UiStatsWindow &window);
   void captureStatsWindowPlacement(UiStatsWindow &window);
   void renderStatsWindows();
-  void renderStatsWindow(UiStatsWindow &window);
+  void renderStatsWindow(UiStatsWindow &window, size_t stackIndex);
   void renderStatsWindowScopeSelector(UiStatsWindow &window);
   void renderStatsWindowAddControl(UiStatsWindow &window);
   void renderStatsWindowEntries(UiStatsWindow &window);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -5,6 +5,7 @@
 #include <deque>
 #include <filesystem>
 #include <initializer_list>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -404,6 +405,8 @@ private:
   std::vector<std::string> cachedStatsModuleNames;
   std::chrono::steady_clock::time_point nextStatsModuleNamesRefresh =
       std::chrono::steady_clock::time_point{};
+  mutable uint64_t cachedStatsJsonFrameNumber = std::numeric_limits<uint64_t>::max();
+  mutable std::string cachedStatsJson;
   std::chrono::steady_clock::time_point nextUiConfigAutosave =
       std::chrono::steady_clock::time_point{};
   std::string lastSavedUiConfigJson;
@@ -538,6 +541,11 @@ private:
   const std::vector<std::string> &statsModuleNames();
   std::string playerStatValue(const SaPlayerFrame &player, std::string_view statId) const;
   std::string teamStatValue(uint8_t isTeam0, std::string_view statId) const;
+  const std::string &currentStatsJson() const;
+  std::optional<std::string> graphPlayerStatValue(
+      const SaPlayerFrame &player,
+      std::string_view statId) const;
+  std::optional<std::string> graphTeamStatValue(uint8_t isTeam0, std::string_view statId) const;
   std::string defaultAdHocTargetId(std::string_view statId) const;
   std::string adHocStatValue(std::string_view statId, std::string_view targetId) const;
   std::string webUiStatIdForWindow(
@@ -579,11 +587,11 @@ private:
   void tickMechanicsReviewClipBoundary();
   void resetReplayAnnotations();
   std::optional<std::string> currentReplayPath(ReplayServerWrapper replayServer);
-  std::string readJsonBuffer(JsonLen len, WriteJson write);
+  std::string readJsonBuffer(JsonLen len, WriteJson write) const;
   std::string readNamedJsonBuffer(
       NamedJsonLen len,
       WriteNamedJson write,
-      const std::string &name);
+      const std::string &name) const;
   void dumpGraphJson(std::vector<std::string> params);
   void dumpStatsModuleJson(std::vector<std::string> params);
   void dumpStatsModuleFrameJson(std::vector<std::string> params);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -434,6 +434,7 @@ private:
   void renderLauncherWindow();
   void renderLauncherWorkspaceControls();
   void renderLauncherStatsWindowControls();
+  void renderEmptyStateWindow();
   void renderScoreboardWindow();
   void renderEventsWindow();
   void renderEventSourceControls();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -352,7 +352,6 @@ private:
   float playbackRate = 1.0f;
   bool playbackSkipPostGoalTransitions = true;
   bool playbackSkipKickoffs = false;
-  std::string playbackStatus = "Stopped";
   int recordingFps = 60;
   int recordingPlaybackRateIndex = 1;
   bool recordingActive = false;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -319,7 +319,7 @@ private:
   bool uiScoreboardOpen = true;
   bool uiEventsOpen = false;
   bool uiStatusOpen = false;
-  bool uiCameraOpen = true;
+  bool uiCameraOpen = false;
   bool uiPlaybackControlsOpen = false;
   bool uiRecordingOpen = false;
   bool uiGraphInspectorOpen = false;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -507,6 +507,7 @@ private:
       bool focus = false);
   void resetScoreboardWindowPlacement(bool focus = false);
   void showSingletonWindow(bool &open, UiWindowPlacement &placement);
+  void hideSingletonWindow(bool &open);
   void focusSingletonWindow(UiWindowPlacement &placement);
   void hideLauncherWindow();
   void applyWindowPlacement(

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -508,6 +508,7 @@ private:
   void resetScoreboardWindowPlacement(bool focus = false);
   void showSingletonWindow(bool &open, UiWindowPlacement &placement);
   void focusSingletonWindow(UiWindowPlacement &placement);
+  void hideLauncherWindow();
   void applyWindowPlacement(
       UiWindowPlacement &placement,
       float x,

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -321,6 +321,7 @@ private:
   bool eventPlaylistTeamEventsEnabled = true;
   bool eventPlaylistGoalContextEnabled = true;
   bool eventPlaylistAutoFollow = true;
+  std::string eventPlaylistSourceFilter = "all";
   bool timelineRangeBoostEnabled = false;
   bool timelineRangePossessionEnabled = false;
   bool timelineRangePressureEnabled = false;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -130,6 +130,7 @@ private:
     };
 
     uint32_t id = 0;
+    std::string config_id;
     UiStatsWindowKind kind = UiStatsWindowKind::Player;
     bool open = true;
     bool pending_focus = false;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -84,6 +84,8 @@ private:
   using WriteAnalysisNodeNamesJson = WriteJson;
   using GraphInfoJsonLen = JsonLen;
   using WriteGraphInfoJson = WriteJson;
+  using DecodedStatsPlayerConfigJsonLen = size_t (*)(const char *);
+  using WriteDecodedStatsPlayerConfigJson = size_t (*)(const char *, uint8_t *, size_t);
   using DrainEvents = size_t (*)(SaEngine *, SaMechanicEvent *, size_t);
   using DrainTeamEvents = size_t (*)(SaEngine *, SaTeamEvent *, size_t);
   using DrainGoalContextEvents = size_t (*)(SaEngine *, SaGoalContextEvent *, size_t);
@@ -238,6 +240,8 @@ private:
   WriteAnalysisNodeNamesJson writeAnalysisNodeNamesJson = nullptr;
   GraphInfoJsonLen graphInfoJsonLen = nullptr;
   WriteGraphInfoJson writeGraphInfoJson = nullptr;
+  DecodedStatsPlayerConfigJsonLen decodedStatsPlayerConfigJsonLen = nullptr;
+  WriteDecodedStatsPlayerConfigJson writeDecodedStatsPlayerConfigJson = nullptr;
   DrainEvents drainEvents = nullptr;
   DrainTeamEvents drainTeamEvents = nullptr;
   DrainGoalContextEvents drainGoalContextEvents = nullptr;
@@ -568,6 +572,7 @@ private:
       size_t index);
   std::filesystem::path uiConfigPath() const;
   std::string uiConfigJson();
+  std::optional<std::string> statsPlayerCfgJsonFromClipboard(std::string_view clipboardText);
   void applyUiConfigJson(const std::string &json, std::string_view sourceLabel);
   void loadUiConfig();
   void saveUiConfig();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -86,6 +86,8 @@ private:
   using WriteGraphInfoJson = WriteJson;
   using DecodedStatsPlayerConfigJsonLen = size_t (*)(const char *);
   using WriteDecodedStatsPlayerConfigJson = size_t (*)(const char *, uint8_t *, size_t);
+  using EncodedStatsPlayerConfigLen = size_t (*)(const char *);
+  using WriteEncodedStatsPlayerConfig = size_t (*)(const char *, uint8_t *, size_t);
   using DrainEvents = size_t (*)(SaEngine *, SaMechanicEvent *, size_t);
   using DrainTeamEvents = size_t (*)(SaEngine *, SaTeamEvent *, size_t);
   using DrainGoalContextEvents = size_t (*)(SaEngine *, SaGoalContextEvent *, size_t);
@@ -242,6 +244,8 @@ private:
   WriteGraphInfoJson writeGraphInfoJson = nullptr;
   DecodedStatsPlayerConfigJsonLen decodedStatsPlayerConfigJsonLen = nullptr;
   WriteDecodedStatsPlayerConfigJson writeDecodedStatsPlayerConfigJson = nullptr;
+  EncodedStatsPlayerConfigLen encodedStatsPlayerConfigLen = nullptr;
+  WriteEncodedStatsPlayerConfig writeEncodedStatsPlayerConfig = nullptr;
   DrainEvents drainEvents = nullptr;
   DrainTeamEvents drainTeamEvents = nullptr;
   DrainGoalContextEvents drainGoalContextEvents = nullptr;
@@ -572,6 +576,7 @@ private:
       size_t index);
   std::filesystem::path uiConfigPath() const;
   std::string uiConfigJson();
+  std::optional<std::string> statsPlayerCfgFromJson(const std::string &json);
   std::optional<std::string> statsPlayerCfgJsonFromClipboard(std::string_view clipboardText);
   void applyUiConfigJson(const std::string &json, std::string_view sourceLabel);
   void loadUiConfig();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -471,6 +471,7 @@ private:
   void applyRecordingUiWorkspace();
   void createStatsWindow(UiStatsWindowKind kind, bool initializeEntries = false);
   void createStatsModuleWindow(std::string moduleName, int moduleView = 0);
+  std::pair<float, float> defaultStatsWindowSize(UiStatsWindowKind kind) const;
   void initializeStatsWindowPlacement(UiStatsWindow &window);
   void resetStatsWindowPlacement(UiStatsWindow &window, size_t stackIndex);
   void showStatsWindow(UiStatsWindow &window);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -164,6 +164,10 @@ private:
     int z_index = 0;
   };
 
+  static constexpr uint8_t UI_STAT_SCOPE_PLAYER = static_cast<uint8_t>(1u << 0);
+  static constexpr uint8_t UI_STAT_SCOPE_TEAM = static_cast<uint8_t>(1u << 1);
+  static constexpr uint8_t UI_STAT_SCOPE_EVENT = static_cast<uint8_t>(1u << 2);
+
   struct SingletonWindowControl {
     const char *label;
     const char *config_id;
@@ -183,6 +187,7 @@ private:
     const char *config_id;
     const char *label;
     const char *create_label;
+    uint8_t stat_scopes;
     bool web_config;
     bool default_window;
   };
@@ -509,6 +514,7 @@ private:
   std::optional<UiStatsWindowKind> parseStatsWindowKind(std::string_view value) const;
   const char *statsWindowKindConfigId(UiStatsWindowKind kind) const;
   const char *statsWindowKindLabel(UiStatsWindowKind kind) const;
+  uint8_t statsWindowKindStatScopes(UiStatsWindowKind kind) const;
   std::string statsWindowDisplayLabel(const UiStatsWindow &window) const;
   std::string statsWindowTitle(const UiStatsWindow &window) const;
   const SaPlayerFrame *sampledPlayerByIndex(uint32_t playerIndex) const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -166,6 +166,8 @@ private:
   struct SingletonWindowControl {
     const char *label;
     const char *config_id;
+    const char *legacy_open_key;
+    const char *legacy_placement_key;
     bool web_config;
     bool *open;
     UiWindowPlacement *placement;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -174,6 +174,7 @@ private:
     const char *legacy_open_key;
     const char *legacy_placement_key;
     bool web_config;
+    int launcher_order;
     bool *open;
     UiWindowPlacement *placement;
     float x;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -488,7 +488,10 @@ private:
       const char *idSuffix);
   void renderBoolModuleSummaryToggle(const char *label, bool &active, const char *idSuffix);
   void renderModuleSummaryControls(const char *idSuffix, bool collapsibleGroups = true);
-  void renderModuleSettingsControls(const char *idSuffix, bool includeOpenButtons);
+  void renderModuleSettingsControls(
+      const char *idSuffix,
+      bool includeOpenButtons,
+      bool webCardHeaders = false);
   std::array<SingletonWindowControl, 13> singletonWindowControls();
   std::vector<SingletonWindowControl> webSingletonWindowControls();
   std::array<StatsWindowKindControl, 7> statsWindowKindControls() const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -584,6 +584,8 @@ private:
   void applyUiConfigJson(const std::string &json, std::string_view sourceLabel);
   void loadUiConfig();
   void saveUiConfig();
+  void scheduleUiConfigAutosave(
+      std::chrono::milliseconds delay = std::chrono::milliseconds(150));
   void maybeAutosaveUiConfig();
   void renderLayoutConfigControls(const char *idSuffix);
   int recentEventCountForActor(std::string_view actor) const;

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -457,6 +457,7 @@ private:
   void renderModuleSummaryControls(const char *idSuffix);
   void renderModuleSettingsControls(const char *idSuffix, bool includeOpenButtons);
   std::array<SingletonWindowControl, 13> singletonWindowControls();
+  std::vector<SingletonWindowControl> webSingletonWindowControls();
   std::array<StatsWindowKindControl, 7> statsWindowKindControls() const;
   void renderSingletonWindowManager();
   void renderStatsWindowManager();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -536,6 +536,7 @@ private:
   void hideSingletonWindow(bool &open);
   void hideStatsWindow(UiStatsWindow &window);
   void focusSingletonWindow(UiWindowPlacement &placement);
+  void showLauncherWindow();
   void hideLauncherWindow();
   void applyWindowPlacement(
       UiWindowPlacement &placement,

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -558,6 +558,12 @@ private:
   void renderStatsWindowScopeSelector(UiStatsWindow &window);
   void renderStatsWindowAddControl(UiStatsWindow &window);
   void renderStatsWindowEntries(UiStatsWindow &window);
+  bool renderStatsWindowValueRow(
+      UiStatsWindow &window,
+      size_t entryIndex,
+      std::string_view label,
+      std::string_view value,
+      std::string_view idSuffix = {});
   void renderMissingStatsRows(UiStatsWindow &window);
   void renderPlayerStatsTable(UiStatsWindow &window, const SaPlayerFrame &player);
   void renderTeamStatsTable(UiStatsWindow &window, uint8_t isTeam0);

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -164,6 +164,8 @@ private:
 
   struct SingletonWindowControl {
     const char *label;
+    const char *config_id;
+    bool web_config;
     bool *open;
     UiWindowPlacement *placement;
     float x;
@@ -520,7 +522,7 @@ private:
       std::string_view statId,
       size_t index);
   std::filesystem::path uiConfigPath() const;
-  std::string uiConfigJson() const;
+  std::string uiConfigJson();
   void applyUiConfigJson(const std::string &json, std::string_view sourceLabel);
   void loadUiConfig();
   void saveUiConfig();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -162,6 +162,16 @@ private:
     int z_index = 0;
   };
 
+  struct SingletonWindowControl {
+    const char *label;
+    bool *open;
+    UiWindowPlacement *placement;
+    float x;
+    float y;
+    float width;
+    float height;
+  };
+
   struct PlayerStatSnapshot {
     int shots = 0;
     int saves = 0;
@@ -423,6 +433,7 @@ private:
   void renderBoolModuleSummaryToggle(const char *label, bool &active, const char *idSuffix);
   void renderModuleSummaryControls(const char *idSuffix);
   void renderModuleSettingsControls(const char *idSuffix, bool includeOpenButtons);
+  std::array<SingletonWindowControl, 13> singletonWindowControls();
   void renderSingletonWindowManager();
   void renderStatsWindowManager();
   void focusTopLoadedWindow();

--- a/bakkesmod/SubtrActorPlugin.h
+++ b/bakkesmod/SubtrActorPlugin.h
@@ -498,7 +498,8 @@ private:
   void renderModuleSummaryControls(
       const char *idSuffix,
       bool collapsibleGroups = true,
-      float toggleWidth = 230.0f);
+      float toggleWidth = 230.0f,
+      bool includePluginControls = true);
   void renderModuleSettingsControls(
       const char *idSuffix,
       bool includeOpenButtons,

--- a/bakkesmod/verify-plugin-artifacts.ps1
+++ b/bakkesmod/verify-plugin-artifacts.ps1
@@ -165,6 +165,8 @@ $RustNeedles = @(
     "subtr_actor_bakkesmod_write_analysis_node_names_json",
     "subtr_actor_bakkesmod_decoded_stats_player_config_json_len",
     "subtr_actor_bakkesmod_write_decoded_stats_player_config_json",
+    "subtr_actor_bakkesmod_encoded_stats_player_config_len",
+    "subtr_actor_bakkesmod_write_encoded_stats_player_config",
     "subtr_actor_bakkesmod_replay_annotations_create",
     "subtr_actor_bakkesmod_replay_annotation_player_count",
     "subtr_actor_bakkesmod_write_replay_annotation_players",

--- a/bakkesmod/verify-plugin-artifacts.ps1
+++ b/bakkesmod/verify-plugin-artifacts.ps1
@@ -163,6 +163,8 @@ $RustNeedles = @(
     "subtr_actor_bakkesmod_write_analysis_node_json",
     "subtr_actor_bakkesmod_analysis_node_names_json_len",
     "subtr_actor_bakkesmod_write_analysis_node_names_json",
+    "subtr_actor_bakkesmod_decoded_stats_player_config_json_len",
+    "subtr_actor_bakkesmod_write_decoded_stats_player_config_json",
     "subtr_actor_bakkesmod_replay_annotations_create",
     "subtr_actor_bakkesmod_replay_annotation_player_count",
     "subtr_actor_bakkesmod_write_replay_annotation_players",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1187,6 +1187,18 @@ def main() -> int:
         "plugin recording exposes web-like detail grid",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        'if (bytes <= 0) {\n    return "--";\n  }\n  const units = ["B", "KB", "MB", "GB"];',
+        "stats evaluation player recording size formatter uses dash and decimal units",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'if (bytes == 0) {\n    return "--";\n  }\n\n  constexpr std::array<const char *, 4> units{{"B", "KB", "MB", "GB"}};',
+        "plugin recording size formatter mirrors web dash and decimal units",
+        errors,
+    )
     for plugin_only_recording_surface in (
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "RECORDING");',
         'ImGui::Checkbox("Finalize before dump"',
@@ -1194,6 +1206,9 @@ def main() -> int:
         '"recording_finish_before_dump"',
         'ImGui::Button("Snapshot")',
         'ImGui::Button("Log folder")',
+        'return std::format("{} B", bytes);',
+        'KiB',
+        'MiB',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1231,6 +1231,9 @@ def main() -> int:
         'renderModuleSummaryToggle("None", noSourcesEnabled, "event-playlist-sources")',
         'renderModuleSummaryToggle(label.c_str(), source.enabled, "event-playlist-sources")',
         'ImGui::Text("%zu selected / %zu recent", playlistEventIndexes.size(), recentUiEvents.size());',
+        'ImGui::TextWrapped("Status: %s", eventPlaylistStatus.c_str());',
+        "eventPlaylistStatus",
+        '"event_playlist_status"',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2365,8 +2365,9 @@ def main() -> int:
     require_contains(
         plugin_source,
         'ImGui::TextWrapped("%s", statusReadout.c_str());\n'
+        "  ImGui::Separator();\n"
         '  ImGui::Text("%d / %zu", current == nullptr ? 0 : mechanicsReviewIndex + 1, candidates.size());',
-        "plugin mechanics review status appears before current item like web",
+        "plugin mechanics review status is separated before current item like web",
         errors,
     )
     reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -896,8 +896,25 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::TextDisabled("%s", tags.empty() ? "Unlabeled" : joinStrings(tags, " · ").c_str());',
-        "plugin unlabeled goal tag fallback mirrors web",
+        'renderGoalTagChip("Unlabeled", true, 0);',
+        "plugin unlabeled goal tag chip mirrors web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const std::string label = std::format("{}##goal-tag-chip-{}", text, chipIndex);',
+        "plugin goal-label tags render as individual chips",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "for (size_t tagIndex = 0; tagIndex < tags.size(); tagIndex += 1) {\n"
+        "        if (tagIndex > 0) {\n"
+        "          ImGui::SameLine();\n"
+        "        }\n"
+        "        renderGoalTagChip(tags[tagIndex], false, tagIndex);\n"
+        "      }",
+        "plugin goal-label tag chips preserve separate labels",
         errors,
     )
     require_contains(
@@ -968,6 +985,7 @@ def main() -> int:
         'ImGui::TextDisabled("%.2fs - %s", event.time, event.actor.c_str());',
         'ImGui::TextWrapped("%s", event.label.c_str());',
         'ImGui::TextWrapped("No goals loaded.");',
+        'ImGui::TextDisabled("%s", tags.empty() ? "Unlabeled" : joinStrings(tags, " · ").c_str());',
         'ImGui::TextDisabled("%s", tags.empty() ? "Unlabeled" : joinStrings(tags, " · ").c_str());\n    if (ImGui::SmallButton("Watch"))',
     ):
         reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2242,6 +2242,64 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_styles_source,
+        ".module-summary-item {\n"
+        "  appearance: none;\n"
+        "  display: inline-flex;\n"
+        "  align-items: center;\n"
+        "  justify-content: space-between;\n"
+        "  gap: var(--ui-gap-sm);\n"
+        "  min-height: var(--ui-control-height);\n"
+        "  padding: var(--ui-control-padding-block) var(--ui-control-padding-inline);\n"
+        "  border-radius: var(--ui-radius-pill);\n"
+        "  border: 1px solid var(--ui-border-subtle);\n"
+        "  background: rgba(255, 255, 255, 0.03);",
+        "stats evaluation player module summary items use muted pill chrome",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".module-summary-item[data-active=\"true\"] {\n"
+        "  border-color: rgba(75, 148, 255, 0.22);\n"
+        "  background: rgba(75, 148, 255, 0.08);\n"
+        "  color: #dceafb;\n"
+        "}",
+        "stats evaluation player active module summary items use blue pill chrome",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2{10.0f, 5.0f});\n"
+        "  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 999.0f);\n"
+        "  ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);",
+        "plugin module summary toggles use web-like pill geometry",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "active ? ImVec4{0.29f, 0.58f, 1.0f, 0.08f} : ImVec4{1.0f, 1.0f, 1.0f, 0.03f}",
+        "plugin module summary toggles mirror web active/inactive backgrounds",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "active ? ImVec4{0.29f, 0.58f, 1.0f, 0.22f} : ImVec4{1.0f, 1.0f, 1.0f, 0.10f}",
+        "plugin module summary toggles mirror web active/inactive borders",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PopStyleColor(5);\n  ImGui::PopStyleVar(3);",
+        "plugin module summary toggles restore web-like style stack",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "ImVec4{0.16f, 0.35f, 0.28f, 1.0f}",
+        "plugin module summary toggles use old green active fill",
+        errors,
+    )
+    require_contains(
         plugin_header,
         "bool includePluginControls = true",
         "plugin module summary can hide plugin-only controls for web-like launcher",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -882,14 +882,35 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        "for (const group of tagsByGoalIndex.values()) {\n"
+        "    group.sort(\n"
+        "      (left, right) => left.kind.localeCompare(right.kind) || right.confidence - left.confidence,\n"
+        "    );\n"
+        "  }",
+        "stats evaluation player sorts goal tags by kind and confidence",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         "for (const index of tagsByGoalIndex.keys()) {\n    goalIndexes.add(index);\n  }",
         "stats evaluation player keeps tag-only goals in goal-label overview",
         errors,
     )
     require_contains(
         plugin_source,
-        "auto goalTagText = [](const UiEventRecord &event) {",
+        "auto goalTagChip = [](const UiEventRecord &event) {",
         "plugin goal-label window formats replay goal tags",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "std::sort(tags.begin(), tags.end(), [](const GoalTagChip &left, const GoalTagChip &right) {\n"
+        "      if (left.label == right.label) {\n"
+        "        return left.confidence > right.confidence;\n"
+        "      }\n"
+        "      return left.label < right.label;\n"
+        "    });",
+        "plugin sorts goal tags by label and descending confidence like web",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1379,6 +1379,18 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "item.sourceLabel,",
+        "stats evaluation player event playlist row meta uses source labels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const std::string sourceLabel = sourceLabelForEvent(event);",
+        "plugin event playlist row meta uses selected source labels",
+        errors,
+    )
+    require_contains(
         plugin_source,
         "std::string formatEventPlaylistTime(float seconds)",
         "plugin event playlist uses web-like minute time labels",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -526,6 +526,47 @@ def main() -> int:
             errors,
         )
     require_contains(
+        web_player_main_source,
+        "function renderAdHocStats(",
+        "stats evaluation player ad-hoc stats renderer",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'targetSelect.className = "stats-window-stat-target";',
+        "stats evaluation player ad-hoc rows expose target selector",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "void SubtrActorPlugin::renderAdHocStatsWindow(UiStatsWindow &window)",
+        "plugin ad-hoc stats renderer",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "renderAdHocTargetSelector(window, entry, statId, i);",
+        "plugin ad-hoc rows expose target selector",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const std::string statValue = adHocStatValue(statId, entry.target_id);",
+        "plugin ad-hoc rows render stat value inline like web",
+        errors,
+    )
+    for plugin_only_ad_hoc_surface in (
+        'ImGui::Columns(4, "ad-hoc-stat-rows", false);',
+        'ImGui::BeginChild("ad-hoc-events", ImVec2{0.0f, 0.0f}, true);',
+        'ImGui::TextColored(toImVec4(event.color), "%.2fs %s", event.time, event.actor.c_str());',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_ad_hoc_surface,
+            "plugin ad-hoc stats window plugin-only table/event surface",
+            errors,
+        )
+    require_contains(
         web_player_template_source,
         '<input id="skip-post-goal-transitions" type="checkbox" checked />',
         "stats evaluation player default skips post-goal resets",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1016,6 +1016,59 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        'row.className = "stats-window-stat-row";',
+        "stats evaluation player shared stat row class",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'name.className = "stats-window-stat-name";',
+        "stats evaluation player shared stat row label class",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'valueEl.className = "stats-window-stat-value";',
+        "stats evaluation player shared stat row value class",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'remove.className = "stats-window-stat-remove";',
+        "stats evaluation player shared stat row remove class",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".stats-window-stat-row {\n"
+        "  display: grid;\n"
+        "  grid-template-columns: minmax(0, 1fr) auto auto;\n"
+        "  gap: var(--ui-gap-sm);\n"
+        "  align-items: center;\n"
+        "  min-height: 1.45rem;",
+        "stats evaluation player shared stat row grid layout",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::AlignTextToFramePadding();\n"
+        "  ImGui::TextColored(ImVec4{0.62f, 0.71f, 0.78f, 1.0f}, \"%s\", labelString.c_str());\n"
+        "  ImGui::SameLine(valueX);\n"
+        "  ImGui::AlignTextToFramePadding();\n"
+        "  ImGui::TextColored(ImVec4{0.93f, 0.96f, 0.98f, 1.0f}, \"%s\", valueString.c_str());",
+        "plugin shared stat row uses muted label and bright value like web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2{5.0f, 2.0f});\n"
+        "  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 4.0f);\n"
+        "  if (ImGui::SmallButton(removeLabel.c_str())) {",
+        "plugin shared stat row uses compact rounded remove button",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'renderStatsWindowValueRow(\n                window, i, statLabel, statValue, std::format("player-{}", player.player_index))',
         "plugin all-player stats rows use shared row renderer",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1189,6 +1189,24 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        'case "recording":\n      return "Recording";\n    case "stopping":\n      return "Stopping";\n    case "ready":\n      return "Ready";',
+        "stats evaluation player recording status uses user-facing state labels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const std::string recordingStatusReadout =\n      recordingActive   ? "Recording"\n      : hasGraphSnapshot ? "Ready"\n      : !loaded || !engine ? "No replay"\n                           : recordingStatus;',
+        "plugin recording status readout uses web-like state labels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Text("%s", recordingStatusReadout.c_str());',
+        "plugin recording status renders the web-like readout",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         'if (bytes <= 0) {\n    return "--";\n  }\n  const units = ["B", "KB", "MB", "GB"];',
         "stats evaluation player recording size formatter uses dash and decimal units",
         errors,
@@ -1206,6 +1224,7 @@ def main() -> int:
         '"recording_finish_before_dump"',
         'ImGui::Button("Snapshot")',
         'ImGui::Button("Log folder")',
+        'ImGui::Text("%s", recordingStatus.c_str());',
         'return std::format("{} B", bytes);',
         'KiB',
         'MiB',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -825,12 +825,23 @@ def main() -> int:
         "plugin camera custom settings toggle mirrors web label",
         errors,
     )
+    require_contains(
+        web_player_template_source,
+        '<input id="ball-cam" type="checkbox" disabled />',
+        "stats evaluation player camera ball-cam toggle",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderCustomSlider(\n        "Transition speed",\n        cameraCustomTransitionSpeed,\n        0.5f,\n        2.0f,\n        "%.2f");\n  }\n\n  bool nextBallCamEnabled = cameraBallCamEnabled;\n  pushCameraDisabledStyle(!hasAttachedCamera);\n  const bool ballCamChanged = ImGui::Checkbox("Ball cam", &nextBallCamEnabled);',
+        "plugin camera ball-cam toggle follows custom settings controls like web",
+        errors,
+    )
     for plugin_only_camera_surface in (
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "CAMERA PROFILE");',
         'ImGui::BeginCombo("Target", selectedLabel.c_str())',
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "READOUT");',
         'ImGui::Button("Open player stats")',
-        'ImGui::Checkbox("Ball cam", &nextBallCamEnabled)',
         'ImGui::Checkbox("Custom settings", &nextCustomSettingsEnabled)',
     ):
         reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -967,6 +967,30 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        'createStatsWindow(button.dataset.createStatsWindow as StatsWindowKind);',
+        "stats evaluation player launcher creates stats windows",
+        errors,
+    )
+    if re.search(
+        r"data-create-stats-window.*?createStatsWindow\(button\.dataset\.createStatsWindow as StatsWindowKind\);.*?setLauncherOpen\(false\);",
+        web_player_main_source,
+        re.DOTALL,
+    ):
+        errors.append("stats evaluation player launcher closes after stats window creation")
+    require_contains(
+        plugin_source,
+        'renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);',
+        "plugin launcher keeps menu open after stats window creation like the web player",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'renderStatsWindowCreationControls("launcher-stats-windows", true, false, false, true);',
+        "plugin launcher closes after stats window creation",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         "if (panels.length === 0) {\n    moduleSettingsEl.hidden = true;",
         "stats evaluation player hides empty launcher module settings",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -445,6 +445,60 @@ def main() -> int:
         "launcher actions expose replay loading like the web player",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        "summary.textContent = `Filters ${selectedSourceIds.size}/${sources.length}`;",
+        "stats evaluation player event playlist filter count label",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Text("Filters %zu/%zu", selectedSourceCount, playlistSources.size());',
+        "plugin event playlist filter count label mirrors web spacing",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'allButton.textContent = "All";',
+        "stats evaluation player event playlist all action label",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderModuleSummaryToggle(\n          "All",\n          allSourcesEnabled,\n          "event-playlist-sources")',
+        "plugin event playlist all action label mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'button.className = "event-playlist-item";',
+        "stats evaluation player event playlist rows are clickable items",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Selectable(itemLabel.c_str(), active)',
+        "plugin event playlist rows are selectable items",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "std::string formatEventPlaylistTime(float seconds)",
+        "plugin event playlist uses web-like minute time labels",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'std::format("All ({})", recentUiEvents.size()).c_str()',
+        "plugin event playlist all action includes event count",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'std::format("{} {:.2f}s##event-playlist-cue", active ? ">" : "Cue", event.time)',
+        "plugin event playlist visible cue mini-button",
+        errors,
+    )
     for label, plugin_needle in (
         ("Possession", '"Possession",\n        timelineRangePossessionEnabled'),
         ("Half control", '"Half control",\n        timelineRangePressureEnabled'),

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -470,15 +470,39 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "if (panels.length === 0) {\n    moduleSettingsEl.hidden = true;",
+        "stats evaluation player hides empty launcher module settings",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (timelineRangePossessionEnabled) {\n    ImGui::Separator();\n    renderModuleSettingsControls(\"launcher-module-settings\", false, true, true);\n  }",
+        "launcher module settings only render active web panels",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'renderModuleSummaryControls("module-controls-summary");',
         "dedicated module controls keep plugin-only module controls",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderModuleSettingsControls("module-controls-settings", true);',
+        "dedicated module controls keep full module settings",
         errors,
     )
     reject_contains(
         plugin_source,
         'renderModuleSummaryControls("launcher-module-summary", false, 0.0f);',
         "launcher module summary includes plugin-only controls",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'renderModuleSettingsControls("launcher-module-settings", false, true);',
+        "launcher module settings render unconditionally",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1208,6 +1208,30 @@ def main() -> int:
         "plugin mechanics review current item uses web-like field grid",
         errors,
     )
+    require_contains(
+        web_player_template_source,
+        '<span id="mechanics-review-replay-load-summary">0 replays</span>',
+        "stats evaluation player mechanics review replay summary",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("%s", replayAnnotations ? "1 replay" : "0 replays");',
+        "plugin mechanics review replay summary mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'empty.textContent = "No review playlist loaded.";',
+        "stats evaluation player mechanics review empty playlist text",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("No review playlist loaded.");',
+        "plugin mechanics review empty playlist text mirrors web",
+        errors,
+    )
     for plugin_only_mechanics_review_current_surface in (
         'ImGui::Text("Decision: %s", mechanicsReviewDecisionLabel(current));',
         'ImGui::Text("Mechanic: %s", current.type.c_str());',
@@ -1215,6 +1239,7 @@ def main() -> int:
         'ImGui::Text("Clip: %.2fs to %.2fs", clipStart, clipEnd);',
         'ImGui::Text("Event: frame %llu", static_cast<unsigned long long>(current.frame_number));',
         'ImGui::TextWrapped("Reason: %s", current.details.c_str());',
+        'ImGui::TextWrapped("No candidate selected");\n    ImGui::End();\n    return;',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -3079,6 +3079,43 @@ def main() -> int:
         "visible team stats scope combo label",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        'const SINGLETON_WINDOW_IDS: SingletonWindowId[] = [',
+        "stats evaluation player has an explicit singleton window stacking order",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "for (const SingletonWindowControl &window : webSingletonWindowControls()) {\n"
+        "    resetSingletonPlacement(window);\n"
+        "  }\n"
+        "  for (const SingletonWindowControl &window : singletonWindowControls()) {\n"
+        "    if (window.web_config) {\n"
+        "      continue;\n"
+        "    }\n"
+        "    resetSingletonPlacement(window);\n"
+        "  }",
+        "plugin reset placement z-order follows web singleton order before plugin-only windows",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "for (const SingletonWindowControl &window : singletonWindowControls()) {\n"
+        "    if (window.placement == &scoreboardPlacement) {\n"
+        "      resetScoreboardWindowPlacement();\n"
+        "      continue;\n"
+        "    }\n"
+        "    resetSingletonWindowPlacement(\n"
+        "        *window.placement,\n"
+        "        window.x,\n"
+        "        window.y,\n"
+        "        window.width,\n"
+        "        window.height);\n"
+        "  }",
+        "plugin reset placement z-order uses raw singleton declaration order",
+        errors,
+    )
 
     require_contains(
         plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -608,6 +608,54 @@ def main() -> int:
             errors,
         )
     require_contains(
+        web_player_main_source,
+        'list.className = "goal-label-list";',
+        "stats evaluation player goal-label list",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'item.className = "goal-label-item";',
+        "stats evaluation player goal-label items",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'meta.textContent = `${formatTime(time)} · ${scorerName}`;',
+        "stats evaluation player goal-label meta format",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled(\n        "%s · %s",',
+        "plugin goal-label meta format mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'empty.textContent = "Unlabeled";',
+        "stats evaluation player unlabeled goal chip",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("%s", event.details.empty() ? "Unlabeled" : event.details.c_str());',
+        "plugin unlabeled goal tag fallback mirrors web",
+        errors,
+    )
+    for plugin_only_goal_labels_surface in (
+        'ImGui::BeginChild("goal-labels", ImVec2{0.0f, 0.0f}, true);',
+        'ImGui::TextDisabled("%.2fs - %s", event.time, event.actor.c_str());',
+        'ImGui::TextWrapped("%s", event.label.c_str());',
+        'ImGui::TextWrapped("No goals loaded.");',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_goal_labels_surface,
+            "plugin goal labels plugin-only log surface",
+            errors,
+        )
+    require_contains(
         web_player_template_source,
         '<input id="skip-post-goal-transitions" type="checkbox" checked />',
         "stats evaluation player default skips post-goal resets",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -585,6 +585,18 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        'if (jsonPropertyExists(*overlays, "renderEffects")) {',
+        "web renderEffects import uses JSON parser",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'overlays->find("\\"renderEffects\\"")',
+        "web renderEffects import uses exact substring",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         'std::string statId = statsWindowObjectsFromWeb\n                               ? parseJsonStringProperty(entryObject, "statId").value_or("")\n                               : parseJsonStringProperty(entryObject, "stat_id").value_or("");',
         "web selected stat import only reads statId",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2102,20 +2102,50 @@ def main() -> int:
             f"stats evaluation player touch controls setting {touch_settings_label}",
             errors,
         )
+    require_contains(
+        web_player_styles_source,
+        ".module-settings-card {\n"
+        "  display: grid;\n"
+        "  gap: 0.75rem;\n"
+        "  padding: 0.85rem 0.9rem;\n"
+        "  border-radius: 1rem;\n"
+        "  border: 1px solid rgba(255, 255, 255, 0.08);\n"
+        "  background: rgba(255, 255, 255, 0.035);",
+        "stats evaluation player touch controls use module settings card chrome",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".module-settings-subgroup {\n"
+        "  display: grid;\n"
+        "  gap: 0.65rem;\n"
+        "  padding-top: 0.15rem;\n"
+        "  border-top: 1px solid rgba(255, 255, 255, 0.06);",
+        "stats evaluation player touch controls use settings subgroups",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".module-settings-header {\n"
+        "  display: flex;\n"
+        "  align-items: start;\n"
+        "  justify-content: space-between;",
+        "stats evaluation player touch controls use header/readout rows",
+        errors,
+    )
     for plugin_touch_surface in (
-        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Touch markers");',
-        'ImGui::Text("Touch decay");',
+        'ImGui::BeginChild("touch-settings-card", ImVec2{0.0f, 0.0f}, true);',
+        'auto renderTouchSettingsHeader = [](const char *eyebrow,\n                                      const char *title,\n                                      const std::string &readout)',
+        'renderTouchSettingsHeader(\n      "Touch markers",\n      "Touch decay",\n      std::format("{:.1f}s", touchMarkerDecaySeconds));',
         'ImGui::TextDisabled("Keep each marker visible after the touch");',
         '"##touch-marker-decay-seconds", &touchMarkerDecaySeconds, 1.0f, 10.0f, "%.1fs"',
-        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Overlay");',
-        'ImGui::Text("Touch mode");',
-        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Stat display");',
-        'ImGui::Text("Touch breakdown");',
+        'renderTouchSettingsHeader(\n      "Overlay",\n      "Touch mode",\n      touchControlsMode == 1 ? "Advancement" : "Markers");',
+        'renderTouchSettingsHeader("Stat display", "Touch breakdown", touchBreakdownReadout());',
     ):
         require_contains(
             plugin_source,
             plugin_touch_surface,
-            "plugin touch controls mirror stats evaluation player settings",
+            "plugin touch controls mirror stats evaluation player settings card",
             errors,
         )
     for plugin_only_touch_surface in (
@@ -2128,6 +2158,12 @@ def main() -> int:
         'ImGui::Button("Open touch stats")',
         'ImGui::Button("Inspect touch nodes")',
         '"Marker decay seconds", &touchMarkerDecaySeconds',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Touch markers");',
+        'ImGui::Text("Touch decay");',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Overlay");',
+        'ImGui::Text("Touch mode");',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Stat display");',
+        'ImGui::Text("Touch breakdown");',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -465,6 +465,36 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        'const bool hasLegacyStatsWindows = jsonPropertyExists(json, "stats_windows");',
+        "stats window import checks legacy property presence",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const bool hasWebStatsWindows = jsonPropertyExists(json, "statsWindows");',
+        "stats window import checks web property presence",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'hasLegacyStatsWindows\n          ? parseJsonObjectArrayProperty(json, "stats_windows")',
+        "stats window import prefers present legacy plugin config",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'hasWebStatsWindows ? parseJsonObjectArrayProperty(json, "statsWindows")',
+        "stats window import falls back to present web config",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'if (statsWindowObjects.empty()) {\n    statsWindowObjects = parseJsonObjectArrayProperty(json, "statsWindows");\n  }',
+        "stats window import falls back based on parsed legacy emptiness",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         "auto writeStatsPlayerPlacement = [](",
         "dedicated web placement writer",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2192,8 +2192,8 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'std::format(\n        "{}  {}##mechanics-review-item",\n        formatEventPlaylistTime(event.time),\n        title)',
-        "plugin mechanics review rows use web-like title labels",
+        'std::format(\n        "{}##mechanics-review-item",\n        title)',
+        "plugin mechanics review rows use web-like title labels without time prefix",
         errors,
     )
     require_contains(
@@ -2503,6 +2503,12 @@ def main() -> int:
         plugin_source,
         'std::format(\n        "{} {:.2f}s {} ({})",',
         "plugin mechanics review rows use prefix/raw-seconds/status-in-title shape",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'std::format(\n        "{}  {}##mechanics-review-item",\n        formatEventPlaylistTime(event.time),',
+        "plugin mechanics review rows prefix event time before item title",
         errors,
     )
     for plugin_only_mechanics_review_queue_surface in (

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -550,6 +550,42 @@ def main() -> int:
             errors,
         )
     require_contains(
+        web_player_template_source,
+        '<span class="label">Camera profile</span>',
+        "stats evaluation player camera profile label",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("Camera profile");\n  ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);\n  if (ImGui::BeginCombo("##attached-player", selectedLabel.c_str()))',
+        "plugin camera profile selector mirrors web label and hidden control id",
+        errors,
+    )
+    require_contains(
+        web_player_template_source,
+        '<dl class="detail-grid">',
+        "stats evaluation player camera detail grid",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Columns(2, "camera-detail-grid", false);',
+        "plugin camera uses web-like detail grid",
+        errors,
+    )
+    for plugin_only_camera_surface in (
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "CAMERA PROFILE");',
+        'ImGui::BeginCombo("Target", selectedLabel.c_str())',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "READOUT");',
+        'ImGui::Button("Open player stats")',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_camera_surface,
+            "plugin camera window plugin-only surface",
+            errors,
+        )
+    require_contains(
         plugin_source,
         '"Load Replay...", ImVec2{actionButtonWidth, 0.0f}',
         "launcher actions expose replay loading like the web player",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1732,6 +1732,18 @@ def main() -> int:
         "plugin replay loading source row uses web-like dot-separated metadata",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        'progress.className = "mechanics-review-replay-load-progress";',
+        "stats evaluation player replay loading rows include progress bars",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::ProgressBar(replayLoadProgress, ImVec2{-1.0f, 0.0f}, "");',
+        "plugin replay loading source row includes web-like progress bar",
+        errors,
+    )
     reject_contains(
         plugin_source,
         'ImGui::Text("Summary: %s", replayPath ? "1 replay candidate" : "0 replay candidates");',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -483,6 +483,12 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        'const auto idString = parseJsonStringProperty(object, "id");\n    if (statsWindowObjectsFromWeb && !idString) {\n      continue;\n    }',
+        "web stats window import rejects entries without string ids",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         'hasLegacyStatsWindows\n          ? parseJsonObjectArrayProperty(json, "stats_windows")',
         "stats window import prefers present legacy plugin config",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1752,7 +1752,7 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'if (jsonPropertyExists(*overlays, "renderEffects")) {',
+        'const bool hasRenderEffects = jsonPropertyExists(*overlays, "renderEffects");',
         "web renderEffects import uses JSON parser",
         errors,
     )
@@ -1760,6 +1760,12 @@ def main() -> int:
         plugin_source,
         'jsonPropertyExists(*overlays, "pluginRenderEffects")',
         "plugin-only render effects import uses separate plugin config field",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'parseJsonBoolProperty(*overlays, "pluginHudOverlay")',
+        "plugin-only HUD overlay master imports from separate plugin config field",
         errors,
     )
     require_contains(
@@ -1836,6 +1842,12 @@ def main() -> int:
         plugin_source,
         'file << "    \\"pluginRenderEffects\\": [";',
         "plugin-only render effects export uses separate plugin config field",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'file << "    \\"pluginHudOverlay\\": " << (hudOverlayEnabled ? "true" : "false") << ",\\n";',
+        "plugin-only HUD overlay master exports separate plugin config field",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -838,8 +838,31 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::BeginCombo(\n          "##recording-playback-rate",',
+        'const bool recordingPlaybackRateOpen = ImGui::BeginCombo(\n      "##recording-playback-rate",',
         "plugin recording playback rate uses hidden-label web-like selector",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "recordingPlaybackRate.disabled = isRecording;",
+        "stats evaluation player disables recording playback rate while recording",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool recordingPlaybackRateDisabled = recordingSettingsLocked;\n"
+        "  pushRecordingDisabledStyle(recordingPlaybackRateDisabled);\n"
+        "  ImGui::SetNextItemWidth(96.0f);\n"
+        "  const bool recordingPlaybackRateOpen = ImGui::BeginCombo(",
+        "plugin recording playback rate selector is disabled while recording",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (recordingPlaybackRateDisabled) {\n"
+        "      ImGui::CloseCurrentPopup();\n"
+        "      ImGui::EndCombo();",
+        "plugin recording playback rate disabled selector cannot remain open",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -893,6 +893,18 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "cameraViewSideButton.disabled = !hasReplay;",
+        "stats evaluation player disables side camera without replay",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "cameraDistance.disabled = !hasAttachedCamera;",
+        "stats evaluation player updates camera settings availability from active camera state",
+        errors,
+    )
+    require_contains(
         plugin_source,
         "const bool hasCameraContext = !sampledPlayers.empty();",
         "plugin camera derives replay context for disabled controls",
@@ -908,6 +920,18 @@ def main() -> int:
         plugin_source,
         'cameraViewButton("Overhead##camera-view", 2, !hasCameraContext)',
         "plugin disables preset camera modes without replay context",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'cameraViewButton("Diagonal##camera-view", 3, !hasCameraContext)',
+        "plugin disables side camera mode without replay context",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "targetPlayer = cameraViewMode == 1 ? sampledPlayerByIndex(cameraSelectedPlayerIndex) : nullptr;\n  const std::string activeCameraLabel =\n      targetPlayer == nullptr",
+        "plugin camera settings availability uses updated camera mode",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -475,6 +475,30 @@ def main() -> int:
         "camera customSettings null import uses JSON parser",
         errors,
     )
+    require_contains(
+        plugin_header,
+        "int cameraFreePreset = -1;",
+        "camera free preset has nullable native state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'std::clamp(parseJsonNumberProperty(json, "camera_free_preset").value_or(-1.0), -1.0, 1.0)',
+        "legacy camera free preset import preserves null state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'jsonPropertyIsNull(*camera, "freePreset")',
+        "web camera freePreset null import uses JSON parser",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'cameraFreePreset = -1;',
+        "plain camera modes clear free preset",
+        errors,
+    )
     reject_contains(
         plugin_source,
         'camera->find("\\"customSettings\\":null")',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -870,8 +870,38 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::TextDisabled("%s", event.details.empty() ? "Unlabeled" : event.details.c_str());',
+        'ImGui::TextDisabled("%s", tags.empty() ? "Unlabeled" : joinStrings(tags, " · ").c_str());',
         "plugin unlabeled goal tag fallback mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "chip.textContent = `${formatMechanicKind(tag.kind)} ${Math.round(tag.confidence * 100)}%`;",
+        "stats evaluation player goal-label tag confidence chips",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "auto goalTagText = [](const UiEventRecord &event) {",
+        "plugin goal-label window formats replay goal tags",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool samePlayer = goalEvent.has_player == 0 || candidate.has_player == 0 ||",
+        "plugin goal-label tags match scorer like web goal tags",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool nearbyTime = std::fabs(candidate.time - goalEvent.time) <= 0.25f;",
+        "plugin goal-label tags associate with nearby goal context",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'ImGui::TextDisabled("%s", event.details.empty() ? "Unlabeled" : event.details.c_str());',
+        "plugin goal labels use event details instead of goal tag chips",
         errors,
     )
     for plugin_only_goal_labels_surface in (

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1259,6 +1259,18 @@ def main() -> int:
         "plugin replay loading summary uses web-like replay count",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        '.join(" · ");',
+        "stats evaluation player replay loading rows use dot-separated metadata",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'joinStrings(replayMeta, " · ")',
+        "plugin replay loading source row uses web-like dot-separated metadata",
+        errors,
+    )
     reject_contains(
         plugin_source,
         'ImGui::Text("Summary: %s", replayPath ? "1 replay candidate" : "0 replay candidates");',
@@ -1271,6 +1283,26 @@ def main() -> int:
         "plugin replay loading active status label",
         errors,
     )
+    for plugin_only_replay_loading_surface in (
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REPLAY LOADING");',
+        'ImGui::Text("In replay: %s", inReplay ? "yes" : "no");',
+        'ImGui::Text("Replay time: %.2fs", replayServer.GetReplayTimeElapsed());',
+        'ImGui::Text("Annotations: %zu", annotationCount);',
+        'ImGui::Text("Players: %zu", annotationPlayers.size());',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REPLAY SOURCES");',
+        'ImGui::BeginChild("replay-loading-players", ImVec2{0.0f, 96.0f}, true);',
+        'ImGui::Checkbox("Replay annotations", &annotationsValue)',
+        'ImGui::Button("Retry load")',
+        'ImGui::Button("Clear load")',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "CURRENT REPLAY");',
+        'metaText += " | ";',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_replay_loading_surface,
+            "plugin replay loading plugin-only management surface",
+            errors,
+        )
     for label, plugin_needle in (
         ("Possession", '"Possession",\n        timelineRangePossessionEnabled'),
         ("Half control", '"Half control",\n        timelineRangePressureEnabled'),

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1016,6 +1016,18 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_template_source,
+        '<dd id="duration-readout">0.00s</dd>',
+        "stats evaluation player playback duration starts with a numeric readout",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("Duration");\n  ImGui::Text("%.2fs", durationSeconds);',
+        "plugin playback duration always renders a numeric readout",
+        errors,
+    )
+    require_contains(
         web_player_main_source,
         "function getPlaybackConfigSnapshot(): PlayerPlaybackConfig {\n"
         "  const state = replayPlayer?.getState();\n"
@@ -1080,6 +1092,12 @@ def main() -> int:
             "plugin playback window plugin-only surface",
             errors,
         )
+    reject_contains(
+        plugin_source,
+        'ImGui::TextDisabled("Duration");\n  if (durationSeconds > 0.0f) {',
+        "plugin playback duration renders a dash fallback",
+        errors,
+    )
     require_contains(
         web_player_template_source,
         '<input id="recording-fps" type="number" min="1" max="120" step="1" value="60" />',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -19,28 +19,8 @@ RUST_SOURCE = REPO_ROOT / "crates/subtr-actor-bakkesmod/src/lib.rs"
 PLUGIN_SOURCE = REPO_ROOT / "bakkesmod/SubtrActorPlugin.cpp"
 PLUGIN_HEADER = REPO_ROOT / "bakkesmod/SubtrActorPlugin.h"
 ABI_HEADER = REPO_ROOT / "crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h"
-
-WEB_SINGLETON_WINDOW_IDS = (
-    "camera",
-    "scoreboard",
-    "playback",
-    "recording",
-    "mechanics",
-    "event-playlist",
-    "mechanics-review",
-    "replay-loading",
-    "boost-pickups",
-    "touch-controls",
-)
-
-WEB_STATS_WINDOW_KIND_IDS = (
-    "player",
-    "team",
-    "all-players",
-    "all-teams",
-    "goals-overview",
-    "ad-hoc",
-)
+WEB_PLAYER_CONFIG_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/playerConfig.ts"
+WEB_PLAYER_MAIN_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/main.ts"
 
 
 @dataclass(frozen=True)
@@ -208,6 +188,28 @@ def cpp_array(source: str, name: str) -> list[str]:
     return quoted_strings(match.group(1))
 
 
+def ts_array(source: str, name: str) -> list[str]:
+    match = re.search(
+        rf"const\s+{re.escape(name)}\s*:[^=]+=\s*\[(.*?)\];",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(f"missing TypeScript array {name}")
+    return quoted_strings(match.group(1))
+
+
+def ts_type_alias_strings(source: str, name: str) -> list[str]:
+    match = re.search(
+        rf"export\s+type\s+{re.escape(name)}\s*=\s*(.*?);",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(f"missing TypeScript type alias {name}")
+    return quoted_strings(match.group(1))
+
+
 def require_contains(source: str, needle: str, label: str, errors: list[str]) -> None:
     if needle not in source:
         errors.append(f"missing {label}: {needle}")
@@ -278,6 +280,8 @@ def main() -> int:
     plugin_source = PLUGIN_SOURCE.read_text(encoding="utf-8")
     plugin_header = PLUGIN_HEADER.read_text(encoding="utf-8")
     abi_header = ABI_HEADER.read_text(encoding="utf-8")
+    web_player_config_source = WEB_PLAYER_CONFIG_SOURCE.read_text(encoding="utf-8")
+    web_player_main_source = WEB_PLAYER_MAIN_SOURCE.read_text(encoding="utf-8")
     cpp_combined = plugin_header + "\n" + plugin_source
     errors: list[str] = []
 
@@ -297,6 +301,19 @@ def main() -> int:
                 f"Rust={rust_values!r} C++={cpp_values!r}"
             )
 
+    web_singleton_type_ids = tuple(
+        ts_type_alias_strings(web_player_config_source, "SingletonWindowId")
+    )
+    web_singleton_window_ids = tuple(ts_array(web_player_main_source, "SINGLETON_WINDOW_IDS"))
+    if web_singleton_window_ids != web_singleton_type_ids:
+        errors.append(
+            "stats evaluation player singleton window order differs from its config type: "
+            f"type={web_singleton_type_ids!r} array={web_singleton_window_ids!r}"
+        )
+    web_stats_window_kind_ids = tuple(
+        ts_type_alias_strings(web_player_config_source, "StatsWindowKind")
+    )
+
     web_window_ids = tuple(
         window_id
         for window_id, web_config, _ in sorted(
@@ -305,19 +322,19 @@ def main() -> int:
         )
         if web_config
     )
-    if web_window_ids != WEB_SINGLETON_WINDOW_IDS:
+    if web_window_ids != web_singleton_window_ids:
         errors.append(
             "web singleton window order drifted from stats evaluation player: "
-            f"expected={WEB_SINGLETON_WINDOW_IDS!r} actual={web_window_ids!r}"
+            f"expected={web_singleton_window_ids!r} actual={web_window_ids!r}"
         )
 
-    web_stats_window_kind_ids = tuple(
+    plugin_web_stats_window_kind_ids = tuple(
         kind_id for kind_id, web_config in stats_window_kind_controls(plugin_source) if web_config
     )
-    if web_stats_window_kind_ids != WEB_STATS_WINDOW_KIND_IDS:
+    if plugin_web_stats_window_kind_ids != web_stats_window_kind_ids:
         errors.append(
             "web stats window kind order drifted from stats evaluation player: "
-            f"expected={WEB_STATS_WINDOW_KIND_IDS!r} actual={web_stats_window_kind_ids!r}"
+            f"expected={web_stats_window_kind_ids!r} actual={plugin_web_stats_window_kind_ids!r}"
         )
     require_contains(
         plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -513,6 +513,20 @@ def main() -> int:
             "stats evaluation player singleton window order differs from its config type: "
             f"type={web_singleton_type_ids!r} array={web_singleton_window_ids!r}"
         )
+    # Rocket League already provides camera and playback controls in-game, and the
+    # plugin does not support a real multi-replay queue. Keep those replay-player
+    # surfaces out of the BakkesMod launcher even though the web player retains them.
+    plugin_excluded_web_window_ids = (
+        "camera",
+        "playback",
+        "mechanics-review",
+        "replay-loading",
+    )
+    plugin_expected_web_singleton_window_ids = tuple(
+        window_id
+        for window_id in web_singleton_window_ids
+        if window_id not in plugin_excluded_web_window_ids
+    )
     web_stats_window_kind_ids = tuple(
         ts_type_alias_strings(web_player_config_source, "StatsWindowKind")
     )
@@ -537,19 +551,29 @@ def main() -> int:
         if web_config
     )
     web_window_ids = tuple(window_id for window_id, _ in plugin_web_window_controls)
-    if web_window_ids != web_singleton_window_ids:
+    if web_window_ids != plugin_expected_web_singleton_window_ids:
         errors.append(
             "web singleton window order drifted from stats evaluation player: "
-            f"expected={web_singleton_window_ids!r} actual={web_window_ids!r}"
+            f"expected={plugin_expected_web_singleton_window_ids!r} actual={web_window_ids!r}"
         )
     web_launcher_window_buttons = tuple(
-        web_launcher_buttons(web_player_template_source, "data-window-toggle")
+        (window_id, label)
+        for window_id, label in web_launcher_buttons(
+            web_player_template_source,
+            "data-window-toggle",
+        )
+        if window_id not in plugin_excluded_web_window_ids
     )
     if plugin_web_window_controls != web_launcher_window_buttons:
         errors.append(
             "web singleton launcher labels drifted from stats evaluation player: "
             f"expected={web_launcher_window_buttons!r} actual={plugin_web_window_controls!r}"
         )
+    for excluded_window_id in plugin_excluded_web_window_ids:
+        if any(window_id == excluded_window_id for window_id, _ in plugin_web_window_controls):
+            errors.append(
+                f"plugin launcher still exposes replay-player-only window {excluded_window_id!r}"
+            )
     plugin_window_open_variables = singleton_window_open_variables(plugin_source)
     plugin_bool_defaults = cpp_bool_defaults(plugin_header)
     web_initial_window_visibility = web_initial_singleton_visibility(web_player_template_source)
@@ -2171,27 +2195,19 @@ def main() -> int:
             "plugin touch controls window plugin-only surface",
             errors,
         )
-    require_contains(
+    reject_contains(
         plugin_source,
         '"Load Replay...", ImVec2{actionButtonWidth, 0.0f}',
-        "launcher actions expose replay loading like the web player",
+        "launcher exposes web replay-file loading action in-game",
         errors,
     )
-    require_contains(
-        web_player_main_source,
-        "function openReplayFilePicker(): void {\n  fileInput.click();\n  setLauncherOpen(false);\n}",
-        "stats evaluation player closes launcher after Load Replay action",
-        errors,
-    )
-    require_contains(
+    reject_contains(
         plugin_source,
-        'if (ImGui::Button("Load Replay...", ImVec2{actionButtonWidth, 0.0f})) {\n'
-        "    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);\n"
+        "showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);\n"
         "    resetReplayAnnotations();\n"
         "    tickReplayAnnotations();\n"
-        "    hideLauncherWindow();\n"
-        "  }",
-        "plugin launcher closes after Load Replay action like web",
+        "    hideLauncherWindow();",
+        "launcher opens replay-loading queue surface",
         errors,
     )
     reject_contains(
@@ -2201,21 +2217,14 @@ def main() -> int:
         errors,
     )
     require_contains(
-        web_player_template_source,
-        "<p>Load a replay to start.</p>\n          <button id=\"empty-load-replay\" type=\"button\">Load Replay...</button>",
-        "stats evaluation player empty state exposes only replay loading",
-        errors,
-    )
-    require_contains(
         plugin_source,
-        'ImGui::TextUnformatted("Load a replay to start.");\n'
-        '  if (ImGui::Button("Load Replay...", ImVec2{150.0f, 0.0f})) {\n'
-        "    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);\n"
+        'ImGui::TextUnformatted("Open a replay in Rocket League to start.");\n'
+        '  if (gameWrapper->IsInReplay() && ImGui::Button("Refresh current replay", ImVec2{190.0f, 0.0f})) {\n'
         "    resetReplayAnnotations();\n"
         "    tickReplayAnnotations();\n"
         "  }\n\n"
         "  ImGui::End();",
-        "plugin empty state mirrors web replay-loading-only card",
+        "plugin empty state uses current Rocket League replay instead of a replay queue",
         errors,
     )
     for plugin_only_empty_state_surface in (

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -864,6 +864,32 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        "actions.append(watch, jump);\n\n    item.append(header, labels, actions);",
+        "stats evaluation player goal-label actions are part of each card header layout",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const float actionsX = std::max(\n'
+        "        ImGui::GetCursorPosX(),\n"
+        "        ImGui::GetWindowContentRegionMax().x - watchWidth - cueWidth -\n"
+        "            ImGui::GetStyle().ItemSpacing.x);\n"
+        '    ImGui::TextColored(toImVec4(event.color), "Goal %zu", ordinal + 1);\n'
+        "    ImGui::SameLine(actionsX);",
+        "plugin goal-label actions align with goal header like web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const bool watchClicked = ImGui::SmallButton("Watch");\n'
+        "    ImGui::SameLine();\n"
+        '    const bool cueClicked = ImGui::SmallButton("Cue");\n'
+        "    ImGui::TextDisabled(",
+        "plugin goal-label actions render before metadata like web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         'empty.textContent = "Unlabeled";',
         "stats evaluation player unlabeled goal chip",
         errors,
@@ -942,6 +968,7 @@ def main() -> int:
         'ImGui::TextDisabled("%.2fs - %s", event.time, event.actor.c_str());',
         'ImGui::TextWrapped("%s", event.label.c_str());',
         'ImGui::TextWrapped("No goals loaded.");',
+        'ImGui::TextDisabled("%s", tags.empty() ? "Unlabeled" : joinStrings(tags, " · ").c_str());\n    if (ImGui::SmallButton("Watch"))',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1420,9 +1420,36 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_styles_source,
+        ".transport-row {\n"
+        "  display: flex;\n"
+        "  gap: var(--ui-gap-sm);\n"
+        "}\n\n"
+        ".transport-row > * {\n"
+        "  flex: 1 1 auto;\n"
+        "}",
+        "stats evaluation player transport rows distribute controls",
+        errors,
+    )
+    require_contains(
         plugin_source,
-        'if (playbackButton(playbackPlaying ? "Pause" : "Play", !transportEnabled))',
-        "plugin playback transport uses web-like play button",
+        "const float playbackTransportWidth = ImGui::GetContentRegionAvail().x;\n"
+        "  const float playbackTransportGap = ImGui::GetStyle().ItemSpacing.x;\n"
+        "  const float playbackTransportItemWidth =\n"
+        "      std::max(72.0f, (playbackTransportWidth - playbackTransportGap) * 0.5f);",
+        "plugin playback transport row distributes controls like web flex row",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Button(label, ImVec2{width, 0.0f})',
+        "plugin playback transport uses full-row button sizing",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::SameLine(0.0f, playbackTransportGap);",
+        "plugin playback transport uses explicit web-like gap",
         errors,
     )
     require_contains(
@@ -1486,10 +1513,10 @@ def main() -> int:
         plugin_source,
         "const bool playbackRateDisabled = !transportEnabled;\n"
         "  pushPlaybackDisabledStyle(playbackRateDisabled);\n"
-        "  ImGui::SetNextItemWidth(96.0f);\n"
+        "  ImGui::SetNextItemWidth(playbackTransportItemWidth);\n"
         "  const bool playbackRateOpen =\n"
         '      ImGui::BeginCombo("##playback-rate", playbackRateLabels[playbackRateIndex]);',
-        "plugin playback rate selector is disabled with transport",
+        "plugin playback rate selector is disabled and flex-sized with transport",
         errors,
     )
     require_contains(
@@ -1545,8 +1572,18 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_styles_source,
+        ".recording-controls {\n"
+        "  display: grid;\n"
+        "  grid-template-columns: repeat(2, minmax(0, 1fr));\n"
+        "  gap: var(--ui-gap-sm);\n"
+        "}",
+        "stats evaluation player recording controls use two-column grid",
+        errors,
+    )
+    require_contains(
         plugin_source,
-        'ImGui::InputInt(\n      "##recording-fps",',
+        'ImGui::InputInt(\n          "##recording-fps",',
         "plugin recording FPS uses web-like numeric input",
         errors,
     )
@@ -1584,9 +1621,30 @@ def main() -> int:
         plugin_source,
         "const bool recordingPlaybackRateDisabled = recordingSettingsLocked;\n"
         "  pushRecordingDisabledStyle(recordingPlaybackRateDisabled);\n"
-        "  ImGui::SetNextItemWidth(96.0f);\n"
+        "  ImGui::SetNextItemWidth(recordingControlWidth);\n"
         "  const bool recordingPlaybackRateOpen = ImGui::BeginCombo(",
-        "plugin recording playback rate selector is disabled while recording",
+        "plugin recording playback rate selector is disabled and grid-sized while recording",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const float recordingControlWidth =\n"
+        "      std::max(96.0f, (ImGui::GetContentRegionAvail().x - recordingControlGap) * 0.5f);",
+        "plugin recording controls use two-column grid sizing",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const float recordingPrimaryButtonWidth =\n"
+        "      std::max(68.0f, (recordingPrimaryRowWidth - recordingControlGap * 2.0f) / 3.0f);",
+        "plugin recording primary transport row distributes three buttons",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const float recordingSecondaryButtonWidth =\n"
+        "      std::max(88.0f, (recordingSecondaryRowWidth - recordingControlGap) * 0.5f);",
+        "plugin recording secondary transport row distributes two buttons",
         errors,
     )
     require_contains(
@@ -1611,13 +1669,13 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'recordingButton("Start", recordingActive || !loaded || !engine)',
+        'recordingButton(\n          "Start",\n          recordingActive || !loaded || !engine,',
         "plugin recording start waits for analysis engine and idle state",
         errors,
     )
     require_contains(
         plugin_source,
-        'recordingButton("Download", recordingActive || !hasGraphSnapshot)',
+        'recordingButton(\n          "Download",\n          recordingActive || !hasGraphSnapshot,',
         "plugin recording exposes web-like download action",
         errors,
     )

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -3116,6 +3116,32 @@ def main() -> int:
         "plugin reset placement z-order uses raw singleton declaration order",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        'Boolean(target.closest("button, input, select, textarea, option, label, a, [data-no-drag]"))',
+        "stats evaluation player window dragging ignores interactive controls",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "bringWindowToFront(windowEl);\n      const startX = event.clientX;",
+        "stats evaluation player brings windows forward from non-interactive pointer down",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows) &&\n"
+        "      ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !ImGui::IsAnyItemActive()",
+        "plugin window z-order bumps ignore active controls like web dragging",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows) &&\n"
+        "      ImGui::IsMouseClicked(ImGuiMouseButton_Left))",
+        "plugin window z-order bumps on interactive control clicks",
+        errors,
+    )
 
     require_contains(
         plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1337,6 +1337,24 @@ def main() -> int:
             "plugin event playlist filter module-summary button surface",
             errors,
         )
+    require_contains(
+        plugin_source,
+        "const std::string currentFilter = eventPlaylistSourceFilter;",
+        "plugin event playlist uses independent filter state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "eventPlaylistSourceFilter = eventFilterFromSelectedSources(selectedSources);",
+        "plugin event playlist filter changes do not mutate overlay event filters",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'setCvarString(\n            "subtr_actor_overlay_event_types",\n            eventFilterFromSelectedSources(selectedSources));',
+        "plugin event playlist filter mutates overlay event filters",
+        errors,
+    )
     reject_contains(
         plugin_source,
         'std::format("{} {:.2f}s##event-playlist-cue", active ? ">" : "Cue", event.time)',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -477,6 +477,12 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        "const bool statsWindowObjectsFromWeb = !hasLegacyStatsWindows && hasWebStatsWindows;",
+        "stats window import tracks web source",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         'hasLegacyStatsWindows\n          ? parseJsonObjectArrayProperty(json, "stats_windows")',
         "stats window import prefers present legacy plugin config",
         errors,
@@ -497,6 +503,18 @@ def main() -> int:
         plugin_source,
         'if (!webConfig) {\n          continue;\n        }\n        placement = R"({"x":8,"y":8,"viewport":{"width":1,"height":1},"visible":true})";',
         "web singleton window import mirrors normalizePlacement defaults",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (!placement && statsWindowObjectsFromWeb) {\n      placement = R\"({\"x\":8,\"y\":8,\"viewport\":{\"width\":1,\"height\":1},\"visible\":true})\";\n    }",
+        "web stats window import mirrors normalizePlacement defaults",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (!statsWindowObjectsFromWeb && !hasEntriesProperty && window.entries.empty() &&",
+        "web stats window import preserves missing entries as empty",
         errors,
     )
     reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2634,6 +2634,24 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        'row.append(main, status, progress);',
+        "stats evaluation player replay loading row places title/status/progress together",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const float statusX =\n        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - statusWidth);",
+        "plugin replay loading aligns status with row title",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::SameLine(statusX);\n    ImGui::TextColored(statusColor, "%s", status);',
+        "plugin replay loading renders status on title row",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'joinStrings(replayMeta, " · ")',
         "plugin replay loading source row uses web-like dot-separated metadata",
@@ -2679,6 +2697,12 @@ def main() -> int:
         plugin_source,
         'const std::string title = replayPath ? *replayPath\n                              : !rawReplayPath.empty() ? rawReplayPath\n                                                       : replayAnnotationPath;',
         "plugin replay loading row title uses the full replay path",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'ImGui::TextWrapped("%s", title.c_str());',
+        "plugin replay loading stacks title before status",
         errors,
     )
     for plugin_only_replay_loading_surface in (

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -496,6 +496,60 @@ def main() -> int:
             errors,
         )
     require_contains(
+        web_player_template_source,
+        '<input id="recording-fps" type="number" min="1" max="120" step="1" value="60" />',
+        "stats evaluation player recording FPS input",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::InputInt("##recording-fps", &nextRecordingFps, 1, 10)',
+        "plugin recording FPS uses web-like numeric input",
+        errors,
+    )
+    require_contains(
+        web_player_template_source,
+        '<select id="recording-playback-rate">',
+        "stats evaluation player recording playback rate selector",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::BeginCombo(\n          "##recording-playback-rate",',
+        "plugin recording playback rate uses hidden-label web-like selector",
+        errors,
+    )
+    require_contains(
+        web_player_template_source,
+        '<button id="recording-download" type="button" disabled>Download</button>',
+        "stats evaluation player recording download action",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'recordingButton("Download", recordingActive || !hasGraphSnapshot)',
+        "plugin recording exposes web-like download action",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Columns(2, "recording-detail-grid", false);',
+        "plugin recording exposes web-like detail grid",
+        errors,
+    )
+    for plugin_only_recording_surface in (
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "RECORDING");',
+        'ImGui::Checkbox("Finalize before dump"',
+        'ImGui::Button("Snapshot")',
+        'ImGui::Button("Log folder")',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_recording_surface,
+            "plugin recording window plugin-only surface",
+            errors,
+        )
+    require_contains(
         plugin_source,
         '"Load Replay...", ImVec2{actionButtonWidth, 0.0f}',
         "launcher actions expose replay loading like the web player",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -428,6 +428,61 @@ def main() -> int:
             f"expected={web_launcher_stats_buttons!r} actual={plugin_web_stats_window_controls!r}"
         )
     require_contains(
+        web_player_main_source,
+        'queryInput.placeholder = "Search stats";',
+        "stats evaluation player stats picker search placeholder",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("Search stats");',
+        "plugin stats picker shows web-like search prompt",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'std::format("##stats-window-search-{}", window.id).c_str()',
+        "plugin stats picker search input uses hidden label",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'addGroup.innerHTML = `<span>Add all ${category}</span><strong>${group.length}</strong>`;',
+        "stats evaluation player stats picker category row",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'std::format("Add all {}   {}##{}-{}", category, count, window.id, category);',
+        "plugin stats picker category row mirrors web count layout",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'item.innerHTML = `<span>${definition.label}</span><strong>${definition.scope}</strong>`;',
+        "stats evaluation player stats picker stat row",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'std::format(\n        "{}   {}##{}-{}",',
+        "plugin stats picker stat row mirrors web label/scope layout",
+        errors,
+    )
+    for plugin_only_stats_picker_surface in (
+        'std::format("Search stats##{}", window.id).c_str()',
+        'ImGui::SmallButton(std::format("Clear##stat-search-{}", window.id).c_str())',
+        'std::format("Add all {} ({})##{}-{}", category, count, window.id, category)',
+        'std::format(\n        "{}  [{}]##{}-{}",',
+        'ImGui::TextDisabled(\n          "%s  [%s selected]",',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_stats_picker_surface,
+            "plugin stats picker plugin-only row/search surface",
+            errors,
+        )
+    require_contains(
         web_player_template_source,
         '<input id="skip-post-goal-transitions" type="checkbox" checked />',
         "stats evaluation player default skips post-goal resets",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -484,12 +484,25 @@ def main() -> int:
         "plugin stats picker stat row mirrors web label/scope layout",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        'empty.textContent = statRegistry.length === 0 ? "No stats available." : "No matching stats.";',
+        "stats evaluation player stats picker no-results empty state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderStatsWindowEmpty("No matching stats.");',
+        "plugin stats picker no-results empty state mirrors web",
+        errors,
+    )
     for plugin_only_stats_picker_surface in (
         'std::format("Search stats##{}", window.id).c_str()',
         'ImGui::SmallButton(std::format("Clear##stat-search-{}", window.id).c_str())',
         'std::format("Add all {} ({})##{}-{}", category, count, window.id, category)',
         'std::format(\n        "{}  [{}]##{}-{}",',
         'ImGui::TextDisabled(\n          "%s  [%s selected]",',
+        'ImGui::Text("No matching stats.");',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1127,6 +1127,24 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "const DEFAULT_CAMERA_DISTANCE_SCALE = 2.25;",
+        "stats evaluation player default camera distance scale",
+        errors,
+    )
+    require_contains(
+        plugin_header,
+        "float cameraDistanceScale = 2.25f;",
+        "plugin default camera distance scale mirrors stats evaluation player",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'parseJsonNumberProperty(json, "camera_distance_scale").value_or(cameraDistanceScale)',
+        "legacy camera distance config preserves plugin/web default when unset",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'ImGui::TextDisabled("Camera profile");\n  ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);\n  const bool profileDisabled = !hasCameraContext;\n  pushCameraDisabledStyle(profileDisabled);\n  const bool profileOpen = ImGui::BeginCombo("##attached-player", selectedLabel.c_str());',
         "plugin camera profile selector mirrors web label and hidden control id",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1991,10 +1991,62 @@ def main() -> int:
         )
         require_contains(
             plugin_source,
-            f'ImGui::TextColored(ImVec4{{0.53f, 0.69f, 0.83f, 1.0f}}, "{boost_filter_label}");',
+            f'renderBoostFilterGroupTitle("{boost_filter_label}");',
             f"plugin boost pickup filter label {boost_filter_label}",
             errors,
         )
+    require_contains(
+        web_player_boost_pickup_filters_source,
+        'settingsEl.className = "boost-pickup-filter-panel";',
+        "stats evaluation player boost pickup filters render a settings panel",
+        errors,
+    )
+    require_contains(
+        web_player_boost_pickup_filters_source,
+        'header.className = "boost-pickup-filter-summary";',
+        "stats evaluation player boost pickup filters render a summary row",
+        errors,
+    )
+    require_contains(
+        web_player_boost_pickup_filters_source,
+        'grid.className = "boost-pickup-filter-grid";',
+        "stats evaluation player boost pickup filters render a grid",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".boost-pickup-filter-grid {\n"
+        "  display: grid;\n"
+        "  grid-template-columns: repeat(2, minmax(0, 1fr));\n"
+        "  gap: 0.75rem 1rem;\n"
+        "}",
+        "stats evaluation player boost pickup filter grid is two columns",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Columns(2, "boost-pickup-filter-grid", false);',
+        "plugin boost pickup filter groups use web-like two-column grid",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const std::string pickupReadout =\n      pickupsHidden ? "Hidden"\n                    : constrainedGroups == 0 ? "All labels"',
+        "plugin boost pickup filters render web-like summary readout",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::SetCursorPosX(std::max(\n      ImGui::GetCursorPosX(),\n      ImGui::GetWindowContentRegionMax().x - pickupReadoutWidth));',
+        "plugin boost pickup summary is right-aligned like web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "auto renderBoostFilterCheckbox = [&](const char *label, bool &value, bool sameLine)",
+        "plugin boost pickup filter options share web-like option renderer",
+        errors,
+    )
     require_contains(
         web_player_boost_pickup_filters_source,
         'optionText.textContent = `${player.name} (${player.isTeamZero ? "Blue" : "Orange"})`;',
@@ -2026,6 +2078,8 @@ def main() -> int:
         'ImGui::Button("Hide pickups")',
         'ImGui::Button("All players")',
         'ImGui::Button("No players")',
+        'ImGui::Separator();\n  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Activity");',
+        'ImGui::Separator();\n  ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Field half");',
     ):
         reject_contains(
             plugin_source,
@@ -3869,7 +3923,7 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Player");',
+        'renderBoostFilterGroupTitle("Player");',
         "boost pickup filters expose web player filter group",
         errors,
     )

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -878,6 +878,10 @@ def main() -> int:
         'ImGui::Button("Open boost stats")',
         'ImGui::Button("Inspect boost nodes")',
         'ImGui::Button("Boost output")',
+        'ImGui::Button("All filters")',
+        'ImGui::Button("Hide pickups")',
+        'ImGui::Button("All players")',
+        'ImGui::Button("No players")',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -881,6 +881,12 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "for (const index of tagsByGoalIndex.keys()) {\n    goalIndexes.add(index);\n  }",
+        "stats evaluation player keeps tag-only goals in goal-label overview",
+        errors,
+    )
+    require_contains(
         plugin_source,
         "auto goalTagText = [](const UiEventRecord &event) {",
         "plugin goal-label window formats replay goal tags",
@@ -896,6 +902,12 @@ def main() -> int:
         plugin_source,
         "const bool nearbyTime = std::fabs(candidate.time - goalEvent.time) <= 0.25f;",
         "plugin goal-label tags associate with nearby goal context",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (!hasMatchingGoalEvent) {\n      goalEventIndexes.push_back(index);\n    }",
+        "plugin keeps tag-only goals in goal-label overview",
         errors,
     )
     reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -917,6 +917,26 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "const teamClass = getStatTargetTeamClass(definition, entry.targetId);\n"
+        "    if (teamClass) {\n"
+        "      targetSelect.classList.add(teamClass);\n"
+        "    }",
+        "stats evaluation player ad-hoc target selector applies team accent class",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".stats-window-stat-target {\n"
+        "  max-width: 7rem;\n"
+        "  margin-left: 0.35rem;\n"
+        "  padding: 0.16rem 0.3rem;\n"
+        "  border-radius: var(--ui-radius-sm);\n"
+        "  font-size: 0.7rem;",
+        "stats evaluation player ad-hoc target selector compact sizing",
+        errors,
+    )
+    require_contains(
         plugin_source,
         "void SubtrActorPlugin::renderAdHocStatsWindow(UiStatsWindow &window)",
         "plugin ad-hoc stats renderer",
@@ -926,6 +946,30 @@ def main() -> int:
         plugin_source,
         "renderAdHocTargetSelector(window, entry, statId, i);",
         "plugin ad-hoc rows expose target selector",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "auto pushAdHocTargetSelectorStyle = [](std::optional<LinearColor> teamColor) {\n"
+        "    ImGui::SetNextItemWidth(std::min(112.0f, ImGui::GetContentRegionAvail().x));",
+        "plugin ad-hoc target selector uses compact web-like width",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const int selectorStyleColors = pushAdHocTargetSelectorStyle(selectedColor);\n"
+        "    const bool comboOpen = ImGui::BeginCombo(\n"
+        "        std::format(\"##ad-hoc-target-{}-{}\", window.id, index).c_str(),",
+        "plugin ad-hoc target selector wraps combo in team accent style",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PushStyleColor(ImGuiCol_Border, accent);\n"
+        "    ImGui::PushStyleColor(\n"
+        "        ImGuiCol_FrameBg,\n"
+        "        ImVec4{accent.x * 0.18f, accent.y * 0.18f, accent.z * 0.18f, 0.58f});",
+        "plugin ad-hoc target selector applies team accent frame",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -505,7 +505,7 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::Text("Load a replay to show stats.");',
+        'renderStatsWindowEmpty("Load a replay to show stats.");',
         "plugin stats windows no-data empty state mirrors web",
         errors,
     )
@@ -2231,6 +2231,18 @@ def main() -> int:
         plugin_source,
         "json += \",\\\"name\\\":\";",
         "plugin replay module frame player stats preserve player names for in-game cards",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "renderStatsWindowEmpty(\"No stats added.\");",
+        "plugin stats windows show the web-player no-stats empty state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "renderStatsWindowEmpty(\"Load a replay to show goal labels.\");",
+        "plugin goal-label stats windows show the web-player replay empty state",
         errors,
     )
     reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -941,7 +941,13 @@ def main() -> int:
         "launcher actions expose replay loading like the web player",
         errors,
     )
-    reject_contains(
+    require_contains(
+        web_player_main_source,
+        "function openReplayFilePicker(): void {\n  fileInput.click();\n  setLauncherOpen(false);\n}",
+        "stats evaluation player closes launcher after Load Replay action",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'if (ImGui::Button("Load Replay...", ImVec2{actionButtonWidth, 0.0f})) {\n'
         "    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);\n"
@@ -949,7 +955,7 @@ def main() -> int:
         "    tickReplayAnnotations();\n"
         "    hideLauncherWindow();\n"
         "  }",
-        "plugin launcher closes after Load Replay action",
+        "plugin launcher closes after Load Replay action like web",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -170,6 +170,14 @@ REQUIRED_PLUGIN_ABI_EXPORTS = (
         "subtr_actor_bakkesmod_write_replay_annotation_frame_players",
         "writeReplayAnnotationFramePlayers",
     ),
+    (
+        "subtr_actor_bakkesmod_replay_annotation_frame_json_len",
+        "replayAnnotationFrameJsonLen",
+    ),
+    (
+        "subtr_actor_bakkesmod_write_replay_annotation_frame_json",
+        "writeReplayAnnotationFrameJson",
+    ),
     ("subtr_actor_bakkesmod_replay_annotation_score_at_time", "replayAnnotationScoreAtTime"),
     ("subtr_actor_bakkesmod_poll_replay_annotations", "pollReplayAnnotations"),
 )

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -842,9 +842,36 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        'empty.className = "stat-window-empty";',
+        "stats evaluation player stats empty state class",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".stat-window-empty {\n"
+        "  margin: 0;\n"
+        "  color: #9eb4c6;\n"
+        "  font-size: 0.88rem;\n"
+        "}",
+        "stats evaluation player stats empty state styling",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'renderStatsWindowEmpty("No matching stats.");',
         "plugin stats picker no-results empty state mirrors web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "void renderStatsWindowEmpty(std::string_view message) {\n"
+        "  const std::string messageString{message};\n"
+        "  ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{0.62f, 0.71f, 0.78f, 1.0f});\n"
+        "  ImGui::TextWrapped(\"%s\", messageString.c_str());\n"
+        "  ImGui::PopStyleColor();\n"
+        "}",
+        "plugin stats empty state uses web-like muted body text",
         errors,
     )
     for plugin_only_stats_picker_surface in (
@@ -854,6 +881,7 @@ def main() -> int:
         'std::format(\n        "{}  [{}]##{}-{}",',
         'ImGui::TextDisabled(\n          "%s  [%s selected]",',
         'ImGui::Text("No matching stats.");',
+        'void renderStatsWindowEmpty(std::string_view message) {\n  ImGui::Spacing();\n  ImGui::TextDisabled("%s", std::string{message}.c_str());\n}',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -721,6 +721,33 @@ def main() -> int:
         "plugin playback exposes web-like detail grid",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        "function getPlaybackConfigSnapshot(): PlayerPlaybackConfig {\n"
+        "  const state = replayPlayer?.getState();\n"
+        "  return {\n"
+        "    currentTime: state?.currentTime,",
+        "stats evaluation player playback config snapshot is explicit",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "playbackStatus",
+        "plugin playback persists hidden status state",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'parseJsonStringProperty(*playback, "status")',
+        "plugin playback imports hidden status field",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        ',\\"status\\":',
+        "plugin playback exports hidden status field",
+        errors,
+    )
     for plugin_only_playback_surface in (
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WEB PLAYBACK CONFIG");',
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ANALYSIS");',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -440,6 +440,62 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_template_source,
+        '<button id="toggle-playback" disabled>Play</button>',
+        "stats evaluation player playback transport button",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'if (playbackButton(playbackPlaying ? "Pause" : "Play", !transportEnabled))',
+        "plugin playback transport uses web-like play button",
+        errors,
+    )
+    require_contains(
+        web_player_template_source,
+        '<select id="playback-rate" disabled>',
+        "stats evaluation player playback rate select",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::BeginCombo("##playback-rate", playbackRateLabels[playbackRateIndex])',
+        "plugin playback rate uses hidden-label web-like selector",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Checkbox("Skip post-goal resets", &nextSkipPostGoalTransitions)',
+        "plugin playback skip post-goal label mirrors web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Checkbox("Skip kickoff countdowns", &nextSkipKickoffs)',
+        "plugin playback skip kickoff label mirrors web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Columns(2, "playback-detail-grid", false);',
+        "plugin playback exposes web-like detail grid",
+        errors,
+    )
+    for plugin_only_playback_surface in (
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "WEB PLAYBACK CONFIG");',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "ANALYSIS");',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "TIMING");',
+        'playbackButton("Seek", !transportEnabled)',
+        'ImGui::Checkbox("Playing", &nextPlaying)',
+        'ImGui::InputFloat("Current time"',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_playback_surface,
+            "plugin playback window plugin-only surface",
+            errors,
+        )
+    require_contains(
         plugin_source,
         '"Load Replay...", ImVec2{actionButtonWidth, 0.0f}',
         "launcher actions expose replay loading like the web player",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2381,6 +2381,24 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        'if (state.status === "idle") {\n    return "Pending";\n  }\n  if (state.status === "loading") {\n    return formatReplayLoadStateProgress(state.progress) || "Loading";\n  }',
+        "stats evaluation player replay loading row uses pending/loading status labels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        ': !inReplay       ? "Pending"\n                           : replayAnnotations ? "Loaded"',
+        "plugin replay loading pending status mirrors web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        ': "Loading";',
+        "plugin replay loading active row status mirrors web loading label",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         '.join(" · ");',
         "stats evaluation player replay loading rows use dot-separated metadata",
         errors,
@@ -2431,6 +2449,18 @@ def main() -> int:
         plugin_source,
         'ImGui::Text("Active: %s", status);',
         "plugin replay loading active status label",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        '"Waiting for replay"',
+        "plugin replay loading uses plugin-only waiting status label",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        '"Scanning"',
+        "plugin replay loading uses plugin-only scanning status label",
         errors,
     )
     reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1130,6 +1130,18 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        '.join(" · ");',
+        "stats evaluation player event playlist row meta uses dot separator",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'joinStrings(metaParts, " · ")',
+        "plugin event playlist row meta uses web-like dot separator",
+        errors,
+    )
+    require_contains(
         plugin_source,
         "std::string formatEventPlaylistTime(float seconds)",
         "plugin event playlist uses web-like minute time labels",
@@ -1158,6 +1170,16 @@ def main() -> int:
         "plugin event playlist visible cue mini-button",
         errors,
     )
+    for plugin_only_event_playlist_row_meta in (
+        'joinStrings(metaParts, " / ").c_str());\n    }\n    if (!event.details.empty())',
+        'ImGui::TextDisabled("%s", event.category.c_str());',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_event_playlist_row_meta,
+            "plugin event playlist row plugin-only metadata surface",
+            errors,
+        )
     require_contains(
         web_player_main_source,
         'button.className = "mechanics-review-item";',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1557,6 +1557,7 @@ def main() -> int:
             errors,
         )
     for label, plugin_needle in (
+        ("Shots, saves, assists", '{"core", "Shots, saves, assists", "Replay"}'),
         ("Possession", '"Possession",\n        timelineRangePossessionEnabled'),
         ("Half control", '"Half control",\n        timelineRangePressureEnabled'),
         ("Rush", '"Rush", timelineRangeRushEnabled'),
@@ -1574,6 +1575,24 @@ def main() -> int:
             f"plugin module summary label {label}",
             errors,
         )
+    require_contains(
+        plugin_source,
+        'appendUiEvent(UiEventRecord{\n      "core",',
+        "plugin sends shot/save/assist events to the web core event source",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'pushPlayerStatEventMessage(event);\n      pendingPlayerStatEvents.push_back(event);',
+        "plugin surfaces inferred player stat events before graph submission",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'pushPlayerStatEventMessage(event);\n  pendingPlayerStatEvents.push_back(event);',
+        "plugin surfaces explicit player stat events before graph submission",
+        errors,
+    )
     for stale_label in (
         '"Possession timeline"',
         '"Half control timeline"',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1586,6 +1586,42 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "mechanicsReviewPrev.disabled = !review || review.loading || review.currentIndex <= 0;",
+        "stats evaluation player mechanics review disables unavailable previous action",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool prevDisabled = current == nullptr || mechanicsReviewIndex <= 0;",
+        "plugin mechanics review disables unavailable previous action",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "mechanicsReviewReplay.disabled = !review || review.loading || !review.currentClip;",
+        "stats evaluation player mechanics review disables unavailable replay action",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool replayDisabled = current == nullptr;",
+        "plugin mechanics review disables unavailable replay action",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "mechanicsReviewConfirm.disabled = decisionDisabled;",
+        "stats evaluation player mechanics review disables unavailable decisions",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool decisionDisabled = current == nullptr;",
+        "plugin mechanics review disables unavailable decisions",
+        errors,
+    )
+    require_contains(
         web_player_template_source,
         '<span id="mechanics-review-replay-load-summary">0 replays</span>',
         "stats evaluation player mechanics review replay summary",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -896,8 +896,60 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        'teamHeader.className = "stats-window-team-header";',
+        "stats evaluation player all-player stats team headers",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".stats-window-team-header {\n"
+        "  display: flex;\n"
+        "  align-items: center;\n"
+        "  justify-content: space-between;",
+        "stats evaluation player all-player stats header layout",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const std::string teamTitle = std::format("{} team", teamLabel(isTeam0));\n'
+        "    const std::string teamMeta =\n"
+        '        std::format("{} player{}", playerCount, playerCount == 1 ? "" : "s");',
+        "plugin all-player stats team header title/meta mirrors web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::SameLine(metaX);\n"
+        "    ImGui::TextColored(teamColor, \"%s\", teamMeta.c_str());\n"
+        "    ImGui::PushStyleColor(ImGuiCol_Separator, teamColor);\n"
+        "    ImGui::Separator();",
+        "plugin all-player stats team header aligns meta and divider",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         'section.className = `stats-window-entity ${getTeamClass(player.is_team_0)}`;',
         "stats evaluation player all-player stats entity sections",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".stats-window-entity {\n"
+        "  display: grid;\n"
+        "  gap: var(--ui-gap-xs);\n"
+        "  padding-left: 0.5rem;\n"
+        "  border-left: 2px solid rgba(255, 255, 255, 0.12);",
+        "stats evaluation player grouped stats entity accent rail",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "drawList->AddRectFilled(\n"
+        "          ImVec2{entityStart.x, entityStart.y + 2.0f},\n"
+        "          ImVec2{entityStart.x + 2.0f, entityStart.y + ImGui::GetTextLineHeight() + 2.0f},\n"
+        "          ImGui::GetColorU32(teamColor));\n"
+        "      ImGui::Indent(8.0f);",
+        "plugin all-player entity rows use web-like accent rail",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1267,6 +1267,24 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "if (activeKey === eventPlaylistLastActiveKey && !options.forceScroll) {\n    return;\n  }",
+        "stats evaluation player event playlist avoids repeated auto-follow scroll",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "active && eventPlaylistAutoFollow && activeEventKey != eventPlaylistLastActiveKey",
+        "plugin event playlist avoids repeated auto-follow scroll",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "eventPlaylistLastActiveKey = activeEventKey;",
+        "plugin event playlist remembers active auto-follow item",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'std::format(\n'
         '      "Filters {}/{}##event-playlist-filter",\n'

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1241,12 +1241,43 @@ def main() -> int:
         "plugin mechanics review rows expose review status",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        "formatMechanicsReviewStatus(candidate.meta?.reviewStatus),\n    ].join(\" · \");",
+        "stats evaluation player mechanics review row meta uses dot separator",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'joinStrings(metaParts, " · ")',
+        "plugin mechanics review row meta uses web-like dot separator",
+        errors,
+    )
     reject_contains(
         plugin_source,
         'std::format(\n        "{} {:.2f}s {} ({})",',
         "plugin mechanics review rows use prefix/raw-seconds/status-in-title shape",
         errors,
     )
+    for plugin_only_mechanics_review_queue_surface in (
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REVIEW QUEUE");',
+        'ImGui::Checkbox("Mechanics", &eventPlaylistMechanicsEnabled)',
+        'ImGui::Checkbox("Team", &eventPlaylistTeamEventsEnabled)',
+        'ImGui::Checkbox("Goal context", &eventPlaylistGoalContextEnabled)',
+        'ImGui::SliderFloat("Clip lead", &mechanicsReviewClipLeadSeconds, 0.0f, 10.0f, "%.1fs")',
+        '"Clip trail", &mechanicsReviewClipTrailSeconds, 0.0f, 10.0f, "%.1fs"',
+        'ImGui::Button("Open events")',
+        'ImGui::Button("Open playlist")',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REPLAY");',
+        'ImGui::Text(\n      "Replay annotations: %s",',
+        'joinStrings(metaParts, " / ").c_str());\n    ImGui::PopID();',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_mechanics_review_queue_surface,
+            "plugin mechanics review plugin-only queue/filter surface",
+            errors,
+        )
     require_contains(
         web_player_template_source,
         '<span id="replay-loading-summary">0 replays</span>',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -3294,19 +3294,35 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        "const float statusX =\n        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - statusWidth);",
-        "plugin replay loading aligns status with row title",
+        "ImGui::Dummy(ImVec2{rowWidth, rowHeight});\n"
+        "    const ImVec2 rowMin = ImGui::GetItemRectMin();\n"
+        "    const ImVec2 rowMax = ImGui::GetItemRectMax();",
+        "plugin replay loading row reserves a web-like source card",
         errors,
     )
     require_contains(
         plugin_source,
-        'ImGui::SameLine(statusX);\n    ImGui::TextColored(statusColor, "%s", status);',
-        "plugin replay loading renders status on title row",
+        "drawList->AddRectFilled(\n"
+        "        rowMin,\n"
+        "        rowMax,\n"
+        "        ImGui::ColorConvertFloat4ToU32(ImVec4{1.0f, 1.0f, 1.0f, 0.035f}),\n"
+        "        6.0f);\n"
+        "    drawList->AddRect(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(rowBorder), 6.0f);",
+        "plugin replay loading row draws web-like card chrome",
         errors,
     )
     require_contains(
         plugin_source,
-        'joinStrings(replayMeta, " · ")',
+        "drawList->AddText(\n"
+        "        ImVec2{statusX, titleY},\n"
+        "        ImGui::ColorConvertFloat4ToU32(statusColor),\n"
+        "        status);",
+        "plugin replay loading renders status on the title row",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const std::string meta = joinStrings(replayMeta, " · ");',
         "plugin replay loading source row uses web-like dot-separated metadata",
         errors,
     )
@@ -3318,8 +3334,10 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::ProgressBar(replayLoadProgress, ImVec2{-1.0f, 0.0f}, "");',
-        "plugin replay loading source row includes web-like progress bar",
+        "drawList->AddRectFilled(\n"
+        "        ImVec2{progressMinX, progressY},\n"
+        "        ImVec2{progressMinX + (progressMaxX - progressMinX) * replayLoadProgress, progressY + 4.0f},",
+        "plugin replay loading source row draws web-like embedded progress bar",
         errors,
     )
     reject_contains(
@@ -3358,6 +3376,17 @@ def main() -> int:
         "plugin replay loading stacks title before status",
         errors,
     )
+    for plugin_only_replay_loading_row_surface in (
+        "const float statusX =\n        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - statusWidth);",
+        'ImGui::SameLine(statusX);\n    ImGui::TextColored(statusColor, "%s", status);',
+        'ImGui::ProgressBar(replayLoadProgress, ImVec2{-1.0f, 0.0f}, "");',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_replay_loading_row_surface,
+            "plugin replay loading plugin-only stacked row surface",
+            errors,
+        )
     for plugin_only_replay_loading_surface in (
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "REPLAY LOADING");',
         'ImGui::Text("In replay: %s", inReplay ? "yes" : "no");',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -465,6 +465,24 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        "bool jsonPropertyIsNull(const std::string &json, const std::string &propertyName)",
+        "JSON null property helper",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'jsonPropertyIsNull(*camera, "customSettings")',
+        "camera customSettings null import uses JSON parser",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'camera->find("\\"customSettings\\":null")',
+        "camera customSettings null import uses exact substring",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         'file << "null";',
         "web config can emit null values",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -417,6 +417,24 @@ def main() -> int:
         )
     require_contains(
         plugin_source,
+        '"Load Replay...", ImVec2{actionButtonWidth, 0.0f}',
+        "launcher actions expose replay loading like the web player",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        '"Live analysis graph",\n            liveAnalysis,\n            "launcher-plugin-tools"',
+        "plugin-specific live analysis toggle lives under launcher plugin tools",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        '"Live analysis graph",\n          liveAnalysis,\n          "launcher-actions"',
+        "plugin-specific live analysis toggle in web-like launcher actions",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         "std::optional<std::string> SubtrActorPlugin::webPlayerIdForWindowConfig(",
         "nullable web stats window playerId helper",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -705,6 +705,56 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_styles_source,
+        ".stats-window-toolbar {\n  justify-content: end;\n}",
+        "stats evaluation player right-aligns non-scoped stats add toolbar",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const float addButtonX =\n"
+        "        std::max(ImGui::GetCursorPosX(), ImGui::GetWindowContentRegionMax().x - addButtonSize);\n"
+        "    ImGui::SetCursorPosX(addButtonX);",
+        "plugin right-aligns non-scoped stats add toolbar",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".stats-window-add-button {\n"
+        "  width: var(--ui-control-height);\n"
+        "  min-width: var(--ui-control-height);\n"
+        "  padding: 0;",
+        "stats evaluation player stats add button is a square control",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const float addButtonSize = ImGui::GetFrameHeight();",
+        "plugin stats add button uses square control sizing",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".stats-window-picker {\n"
+        "  display: grid;\n"
+        "  gap: var(--ui-gap-sm);\n"
+        "  padding: var(--ui-panel-padding);\n"
+        "  border-radius: var(--ui-radius-md);\n"
+        "  border: 1px solid rgba(255, 255, 255, 0.08);\n"
+        "  background: rgba(255, 255, 255, 0.04);",
+        "stats evaluation player stats picker is a bordered panel",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 6.0f);\n"
+        "  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{12.0f, 10.0f});\n"
+        "  ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4{1.0f, 1.0f, 1.0f, 0.04f});\n"
+        "  ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{1.0f, 1.0f, 1.0f, 0.08f});",
+        "plugin stats picker uses web-like bordered panel chrome",
+        errors,
+    )
+    require_contains(
         web_player_main_source,
         'addGroup.innerHTML = `<span>Add all ${category}</span><strong>${group.length}</strong>`;',
         "stats evaluation player stats picker category row",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2912,6 +2912,56 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_styles_source,
+        ".mechanics-review-fields dt {\n"
+        "  color: var(--muted);\n"
+        "  font-size: 0.68rem;\n"
+        "  text-transform: uppercase;\n"
+        "}",
+        "stats evaluation player mechanics review fields use muted labels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderWebDetailGridCell("Mechanic", mechanicReadout);',
+        "plugin mechanics review mechanic field uses shared detail grid styling",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderWebDetailGridCell("Clip", clipReadout);',
+        "plugin mechanics review clip field uses shared detail grid styling",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderWebDetailGridCell("Event", eventReadout);',
+        "plugin mechanics review event field uses shared detail grid styling",
+        errors,
+    )
+    require_contains(
+        web_player_template_source,
+        '<div class="mechanics-review-wide">\n                    <dt>Reason</dt>',
+        "stats evaluation player mechanics review reason spans the field grid",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Columns(1);\n'
+        '  ImGui::Spacing();\n'
+        '  ImGui::TextColored(ImVec4{0.54f, 0.64f, 0.73f, 1.0f}, "Reason");',
+        "plugin mechanics review reason is rendered as a full-width field",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{0.93f, 0.96f, 0.98f, 1.0f});\n"
+        '  ImGui::TextWrapped("%s", reasonReadout.c_str());\n'
+        "  ImGui::PopStyleColor();",
+        "plugin mechanics review reason uses web-like value color while wrapping",
+        errors,
+    )
+    require_contains(
         web_player_main_source,
         'parts.push(`${Math.max(0, clipEnd - clipStart).toFixed(1)}s clip`);',
         "stats evaluation player mechanics review clip field includes duration",
@@ -2947,6 +2997,17 @@ def main() -> int:
         "plugin mechanics review event field omits event time",
         errors,
     )
+    for plugin_only_mechanics_review_field_surface in (
+        'ImGui::TextDisabled("Mechanic");\n  const std::string mechanicReadout =',
+        'ImGui::TextDisabled("Clip");\n  ImGui::Text("%s", clipReadout.c_str());',
+        'ImGui::TextDisabled("Reason");\n  ImGui::TextWrapped("%s", reasonReadout.c_str());',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_mechanics_review_field_surface,
+            "plugin mechanics review plugin-only raw field surface",
+            errors,
+        )
     require_contains(
         web_player_main_source,
         'return typeof item.meta?.mechanic === "string" ? formatMechanicKind(item.meta.mechanic) : "--";',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2386,6 +2386,24 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "const fileName = rawPath\n    .replace(/^path:/, \"\")\n    .split(\"/\")\n    .filter(Boolean)\n    .pop();",
+        "stats evaluation player replay loading row title derives a file label",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "std::string replaySourceDisplayLabel(std::string_view path) {",
+        "plugin replay loading has a web-like replay source label helper",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const std::string title = replaySourceDisplayLabel(titlePath);',
+        "plugin replay loading row title uses a file label",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'joinStrings(replayMeta, " · ")',
         "plugin replay loading source row uses web-like dot-separated metadata",
@@ -2413,6 +2431,12 @@ def main() -> int:
         plugin_source,
         'ImGui::Text("Active: %s", status);',
         "plugin replay loading active status label",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'const std::string title = replayPath ? *replayPath\n                              : !rawReplayPath.empty() ? rawReplayPath\n                                                       : replayAnnotationPath;',
+        "plugin replay loading row title uses the full replay path",
         errors,
     )
     for plugin_only_replay_loading_surface in (

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -331,6 +331,30 @@ def main() -> int:
         "web stats window config always emits team",
         errors,
     )
+    require_contains(
+        plugin_source,
+        'std::format("##stats-window-player-scope-{}", window.id).c_str()',
+        "player stats scope combo uses hidden label",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'std::format("##stats-window-team-scope-{}", window.id).c_str()',
+        "team stats scope combo uses hidden label",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'ImGui::BeginCombo("Player", selectedLabel.c_str())',
+        "visible player stats scope combo label",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'ImGui::BeginCombo("Team", selectedTeam)',
+        "visible team stats scope combo label",
+        errors,
+    )
 
     require_contains(
         plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -523,6 +523,24 @@ def main() -> int:
         "web stats window import preserves missing entries as empty",
         errors,
     )
+    require_contains(
+        plugin_source,
+        'std::string statId = statsWindowObjectsFromWeb\n                               ? parseJsonStringProperty(entryObject, "statId").value_or("")\n                               : parseJsonStringProperty(entryObject, "stat_id").value_or("");',
+        "web selected stat import only reads statId",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'std::string targetId = statsWindowObjectsFromWeb\n                                 ? parseJsonStringProperty(entryObject, "targetId").value_or("")\n                                 : parseJsonStringProperty(entryObject, "target_id").value_or("");',
+        "web selected stat import only reads targetId",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (statsWindowObjectsFromWeb) {\n        continue;\n      }",
+        "web selected stat import rejects string-array entries",
+        errors,
+    )
     reject_contains(
         plugin_source,
         'if (statsWindowObjects.empty()) {\n    statsWindowObjects = parseJsonObjectArrayProperty(json, "statsWindows");\n  }',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2544,8 +2544,35 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::Selectable(itemLabel.c_str(), active)',
-        "plugin event playlist rows are selectable items",
+        "auto renderEventPlaylistItem = [&](const std::string &timeLabel,\n"
+        "                                     const std::string &eventLabel,\n"
+        "                                     const std::string &metaLabel,\n"
+        "                                     const ImVec4 &eventColor,\n"
+        "                                     bool active)",
+        "plugin event playlist rows use a web-like card renderer",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const bool clicked = ImGui::InvisibleButton(buttonId.c_str(), ImVec2{rowWidth, rowHeight});',
+        "plugin event playlist card rows keep button click behavior",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "drawList->AddRectFilled(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(rowBg), 6.0f);\n"
+        "    drawList->AddRect(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(border), 6.0f);",
+        "plugin event playlist rows draw bordered card chrome",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "drawList->AddRectFilled(\n"
+        "        rowMin,\n"
+        "        ImVec2{rowMin.x + colorRailWidth, rowMax.y},\n"
+        "        eventColorU32,\n"
+        "        6.0f);",
+        "plugin event playlist rows draw the web-like colored left rail",
         errors,
     )
     require_contains(
@@ -2586,20 +2613,29 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'const std::string itemLabel = std::format("{}##event-playlist-item", eventLabel);',
-        "plugin event playlist row title excludes time like web title column",
+        "const std::string metaLabel = joinStrings(metaParts, \" · \");",
+        "plugin event playlist row metadata mirrors web joined meta text",
         errors,
     )
     require_contains(
         plugin_source,
-        'ImGui::TextDisabled("%s", timeLabel.c_str());\n    ImGui::SameLine(64.0f);',
-        "plugin event playlist renders time as a separate column",
+        "drawList->AddText(\n"
+        "        ImVec2{timeX, titleY},\n"
+        "        IM_COL32(137, 164, 186, 255),\n"
+        "        timeLabel.c_str());",
+        "plugin event playlist renders time as a separate muted column",
         errors,
     )
     require_contains(
         plugin_source,
-        'ImGui::SetCursorPosX(64.0f);\n      ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());',
-        "plugin event playlist metadata aligns under title column",
+        "drawList->AddText(ImVec2{mainX, titleY}, IM_COL32(237, 245, 250, 255), eventLabel.c_str());",
+        "plugin event playlist title draws in the main title column",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "drawList->AddText(ImVec2{mainX, metaY}, IM_COL32(137, 164, 186, 255), metaLabel.c_str());",
+        "plugin event playlist metadata draws below the title column",
         errors,
     )
     reject_contains(
@@ -2608,6 +2644,19 @@ def main() -> int:
         "plugin event playlist row title falls back to raw event type",
         errors,
     )
+    for plugin_only_event_playlist_row_surface in (
+        'ImGui::Selectable(itemLabel.c_str(), active)',
+        'const std::string itemLabel = std::format("{}##event-playlist-item", eventLabel);',
+        'ImGui::TextDisabled("%s", timeLabel.c_str());\n    ImGui::SameLine(64.0f);',
+        'ImGui::SetCursorPosX(64.0f);\n      ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());',
+        "ImGui::Separator();\n    ImGui::PopID();",
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_event_playlist_row_surface,
+            "plugin event playlist plugin-only flat row surface",
+            errors,
+        )
     require_contains(
         web_player_timeline_markers_source,
         'label: `${playerName} speed flip ${qualityPercent}%`,',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 RUST_SOURCE = REPO_ROOT / "crates/subtr-actor-bakkesmod/src/lib.rs"
 PLUGIN_SOURCE = REPO_ROOT / "bakkesmod/SubtrActorPlugin.cpp"
 PLUGIN_HEADER = REPO_ROOT / "bakkesmod/SubtrActorPlugin.h"
+PLUGIN_README = REPO_ROOT / "bakkesmod/README.md"
 ABI_HEADER = REPO_ROOT / "crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h"
 WEB_PLAYER_CONFIG_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/playerConfig.ts"
 WEB_PLAYER_MAIN_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/main.ts"
@@ -330,6 +331,7 @@ def main() -> int:
     rust_source = RUST_SOURCE.read_text(encoding="utf-8")
     plugin_source = PLUGIN_SOURCE.read_text(encoding="utf-8")
     plugin_header = PLUGIN_HEADER.read_text(encoding="utf-8")
+    plugin_readme_source = PLUGIN_README.read_text(encoding="utf-8")
     abi_header = ABI_HEADER.read_text(encoding="utf-8")
     web_player_config_source = WEB_PLAYER_CONFIG_SOURCE.read_text(encoding="utf-8")
     web_player_main_source = WEB_PLAYER_MAIN_SOURCE.read_text(encoding="utf-8")
@@ -1964,6 +1966,24 @@ def main() -> int:
         "    window.z_index = nextUiWindowZIndex++;\n"
         "    window.pending_focus = false;",
         "stats pending-focus render path bumps z-index",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'cvarManager->registerNotifier(\n      "subtr_actor_apply_ui_config",',
+        "plugin exposes console UI config import",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "statsPlayerCfgJsonFromClipboard(configText)",
+        "console UI config import accepts stats-player cfg values",
+        errors,
+    )
+    require_contains(
+        plugin_readme_source,
+        "`subtr_actor_apply_ui_config <json|cfg|url>`",
+        "BakkesMod README documents console UI config import",
         errors,
     )
 

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -990,6 +990,12 @@ def main() -> int:
         "plugin launcher closes after Load Replay action like web",
         errors,
     )
+    reject_contains(
+        plugin_source,
+        'std::format("{}   {}", window.label, isOpen ? "Hide" : "Show")',
+        "plugin launcher web window toggles append show/hide state text",
+        errors,
+    )
     require_contains(
         web_player_template_source,
         "<p>Load a replay to start.</p>\n          <button id=\"empty-load-replay\" type=\"button\">Load Replay...</button>",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1028,9 +1028,15 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        'state.textContent = `${source.active ? "On" : "Off"} ${source.count}`;',
+        "stats evaluation player Events window source rows expose state count readout",
+        errors,
+    )
+    require_contains(
         plugin_source,
-        'renderModuleSummaryToggle(label.c_str(), enabled, "event-sources")',
-        "plugin Events window source rows are module summary toggles",
+        'std::format(\n        "{}   {} {}##event-sources-{}",\n        option.label,\n        enabled ? "On" : "Off",\n        count,\n        option.value)',
+        "plugin Events window source rows expose web-like state count readout",
         errors,
     )
     require_contains(
@@ -1055,6 +1061,7 @@ def main() -> int:
         'ImGui::SmallButton("No events##event-sources")',
         'renderModuleSummaryToggle(\n          "All events",\n          allSelected,\n          "event-sources-actions")',
         'renderModuleSummaryToggle(\n          "No events",\n          selected.empty(),\n          "event-sources-actions")',
+        'renderModuleSummaryToggle(label.c_str(), enabled, "event-sources")',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -780,6 +780,8 @@ def main() -> int:
     for plugin_only_recording_surface in (
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "RECORDING");',
         'ImGui::Checkbox("Finalize before dump"',
+        "recordingFinishBeforeDump",
+        '"recording_finish_before_dump"',
         'ImGui::Button("Snapshot")',
         'ImGui::Button("Log folder")',
     ):

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -622,6 +622,50 @@ def main() -> int:
         "plugin leaves scoreboard pill separate from shared floating chrome",
         errors,
     )
+    require_contains(
+        web_player_styles_source,
+        ".floating-window-header h2,\n"
+        ".stats-window-header h2 {\n"
+        "  margin: 0;\n"
+        "  color: #87afd4;\n"
+        "  font-size: 0.68rem;\n"
+        "  font-weight: 800;\n"
+        "  letter-spacing: 0.14em;\n"
+        "  text-transform: uppercase;",
+        "stats evaluation player window headers render as uppercase labels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "std::string uppercaseHeaderLabel(std::string_view value) {\n"
+        "  std::string label;\n"
+        "  label.reserve(value.size());\n"
+        "  for (char ch : value) {\n"
+        "    label.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));\n"
+        "  }\n"
+        "  return label;\n"
+        "}",
+        "plugin window headers render as uppercase labels",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".floating-window-hide,\n"
+        ".stats-window-action {\n"
+        "  flex-shrink: 0;\n"
+        "  padding: var(--ui-control-padding-block) var(--ui-control-padding-inline);\n"
+        "  border-radius: var(--ui-radius-md);",
+        "stats evaluation player window hide buttons share action chrome",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);\n"
+        "  const bool hideClicked = ImGui::Button(hideLabel.c_str());\n"
+        "  ImGui::PopStyleVar();",
+        "plugin window hide buttons use shared rounded action chrome",
+        errors,
+    )
 
     plugin_web_stats_window_controls = tuple(
         (kind_id, label)

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2059,6 +2059,12 @@ def main() -> int:
         "plugin event playlist renders time as a separate column",
         errors,
     )
+    require_contains(
+        plugin_source,
+        'ImGui::SetCursorPosX(64.0f);\n      ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());',
+        "plugin event playlist metadata aligns under title column",
+        errors,
+    )
     reject_contains(
         plugin_source,
         "const std::string eventLabel = event.label.empty() ? event.type : event.label;",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -416,6 +416,30 @@ def main() -> int:
             f"expected={web_launcher_stats_buttons!r} actual={plugin_web_stats_window_controls!r}"
         )
     require_contains(
+        web_player_template_source,
+        '<input id="skip-post-goal-transitions" type="checkbox" checked />',
+        "stats evaluation player default skips post-goal resets",
+        errors,
+    )
+    require_contains(
+        plugin_header,
+        "bool playbackSkipPostGoalTransitions = true;",
+        "plugin playback default skips post-goal resets like web player",
+        errors,
+    )
+    require_contains(
+        web_player_template_source,
+        '<input id="skip-kickoffs" type="checkbox" />',
+        "stats evaluation player default does not skip kickoffs",
+        errors,
+    )
+    require_contains(
+        plugin_header,
+        "bool playbackSkipKickoffs = false;",
+        "plugin playback default does not skip kickoffs like web player",
+        errors,
+    )
+    require_contains(
         plugin_source,
         '"Load Replay...", ImVec2{actionButtonWidth, 0.0f}',
         "launcher actions expose replay loading like the web player",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2024,6 +2024,30 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        'return typeof item.meta?.mechanic === "string" ? formatMechanicKind(item.meta.mechanic) : "--";',
+        "stats evaluation player mechanics review formats mechanic ids",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "std::string eventTypeDisplayLabel(std::string_view value) {",
+        "plugin has web-like event type display labels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "eventTypeDisplayLabel(current->type)",
+        "plugin mechanics review current item formats mechanic ids",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "metaParts.push_back(eventTypeDisplayLabel(event.type));",
+        "plugin mechanics review rows format mechanic ids",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         "mechanicsReviewPrev.disabled = !review || review.loading || review.currentIndex <= 0;",
         "stats evaluation player mechanics review disables unavailable previous action",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1875,6 +1875,18 @@ def main() -> int:
         errors,
     )
     require_contains(
+        plugin_source,
+        "const std::string eventLabel = event.label.empty() ? sourceLabel : event.label;",
+        "plugin event playlist row title falls back to source label like web",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "const std::string eventLabel = event.label.empty() ? event.type : event.label;",
+        "plugin event playlist row title falls back to raw event type",
+        errors,
+    )
+    require_contains(
         web_player_timeline_markers_source,
         'label: `${playerName} speed flip ${qualityPercent}%`,',
         "stats evaluation player player mechanics include player names in titles",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1683,6 +1683,18 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        "replayPlayer.setAttachedPlayer(playerId);\n      replayPlayer.setCameraViewMode(\"follow\");\n      lastFreeCameraPreset = null;",
+        "stats evaluation player follows the reviewed player when activating a clip",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "cameraSelectedPlayerIndex = current->player_index;\n      cameraSelectedPlayerId = webPlayerIdForIndex(cameraSelectedPlayerIndex);\n      cameraViewMode = 1;\n      cameraFreePreset = -1;",
+        "plugin mechanics review replay follows the reviewed player",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         "mechanicsReviewConfirm.disabled = decisionDisabled;",
         "stats evaluation player mechanics review disables unavailable decisions",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1355,6 +1355,18 @@ def main() -> int:
         "plugin mechanics review row meta uses web-like dot separator",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        "function getStatsPlayerConfigSnapshot(): StatsPlayerConfig",
+        "stats evaluation player has an explicit persisted config snapshot",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        '"mechanics_review_status"',
+        "plugin persists transient mechanics review status",
+        errors,
+    )
     reject_contains(
         plugin_source,
         'std::format(\n        "{} {:.2f}s {} ({})",',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -447,6 +447,42 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        'renderModuleSummaryGroup("Timeline visualizations", timelineToggles)',
+        "stats evaluation player launcher module summary timeline group",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'renderModuleSummaryGroup("In-game visualizations", inGameVisualizationToggles)',
+        "stats evaluation player launcher module summary in-game group",
+        errors,
+    )
+    require_contains(
+        plugin_header,
+        "bool includePluginControls = true",
+        "plugin module summary can hide plugin-only controls for web-like launcher",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderModuleSummaryControls("launcher-module-summary", false, 0.0f, false);',
+        "launcher module summary excludes plugin-only controls like the web player",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderModuleSummaryControls("module-controls-summary");',
+        "dedicated module controls keep plugin-only module controls",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'renderModuleSummaryControls("launcher-module-summary", false, 0.0f);',
+        "launcher module summary includes plugin-only controls",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         "summary.textContent = `Filters ${selectedSourceIds.size}/${sources.length}`;",
         "stats evaluation player event playlist filter count label",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -990,22 +990,22 @@ def main() -> int:
         "stats evaluation player launcher creates stats windows",
         errors,
     )
-    if re.search(
-        r"data-create-stats-window.*?createStatsWindow\(button\.dataset\.createStatsWindow as StatsWindowKind\);.*?setLauncherOpen\(false\);",
+    require_contains(
         web_player_main_source,
-        re.DOTALL,
-    ):
-        errors.append("stats evaluation player launcher closes after stats window creation")
+        "setLauncherOpen(false);\n  renderStatsWindow(state);",
+        "stats evaluation player closes launcher after stats window creation",
+        errors,
+    )
     require_contains(
         plugin_source,
-        'renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);',
-        "plugin launcher keeps menu open after stats window creation like the web player",
+        'renderStatsWindowCreationControls("launcher-stats-windows", true, false, false, true);',
+        "plugin launcher closes after stats window creation like the web player",
         errors,
     )
     reject_contains(
         plugin_source,
-        'renderStatsWindowCreationControls("launcher-stats-windows", true, false, false, true);',
-        "plugin launcher closes after stats window creation",
+        'renderStatsWindowCreationControls("launcher-stats-windows", false, false, false, true);',
+        "plugin launcher keeps menu open after stats window creation",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2221,6 +2221,18 @@ def main() -> int:
         "plugin stats module selectors use live and replay module names",
         errors,
     )
+    require_contains(
+        plugin_source,
+        "renderStatsModuleFrameOverview(json, std::format(\"module-frame-{}\", window.id));",
+        "plugin stats module frame windows render structured team and player sections",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "json += \",\\\"name\\\":\";",
+        "plugin replay module frame player stats preserve player names for in-game cards",
+        errors,
+    )
     reject_contains(
         plugin_source,
         "ImGui::SetNextWindowFocus();\n"

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2074,6 +2074,42 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        'parts.push(`${Math.max(0, clipEnd - clipStart).toFixed(1)}s clip`);',
+        "stats evaluation player mechanics review clip field includes duration",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        '"{:.2f}s to {:.2f}s · {:.1f}s clip · {:.1f}s preroll · {:.1f}s postroll"',
+        "plugin mechanics review clip field includes duration and padding details",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "return [time, frame].filter((part) => part && part !== \"--\").join(\" · \") || \"--\";",
+        "stats evaluation player mechanics review event field combines time and frame",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        '"{:.2f}s · frame {}"',
+        "plugin mechanics review event field combines time and frame",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'const std::string clipReadout =\n      current == nullptr ? "--" : std::format("{:.2f}s to {:.2f}s", clipStart, clipEnd);',
+        "plugin mechanics review clip field omits web-like duration details",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'std::format("frame {}", static_cast<unsigned long long>(current->frame_number))',
+        "plugin mechanics review event field omits event time",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         'return typeof item.meta?.mechanic === "string" ? formatMechanicKind(item.meta.mechanic) : "--";',
         "stats evaluation player mechanics review formats mechanic ids",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2185,6 +2185,12 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        "return lastTeamScores;\n}\n\nvoid SubtrActorPlugin::renderScoreboardWindow()",
+        "plugin scoreboard falls back to live scores after replay annotation scores",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         "writeReplayAnnotationFramePlayers(\n        replayAnnotations,\n        replayTime,",
         "plugin replay annotations update sampled players from current replay stats frame",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -508,7 +508,7 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::Text("--");',
+        'renderStatsWindowValueRow(window, i, uiStatLabel(statId), "--")',
         "plugin scoped stats missing target value mirrors web dash",
         errors,
     )
@@ -564,6 +564,47 @@ def main() -> int:
             plugin_source,
             plugin_only_ad_hoc_surface,
             "plugin ad-hoc stats window plugin-only table/event surface",
+            errors,
+        )
+    require_contains(
+        web_player_main_source,
+        'teamSection.className = `stats-window-team-group ${getTeamScopeClass(team)}`;',
+        "stats evaluation player all-player stats team groups",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'section.className = `stats-window-entity ${getTeamClass(player.is_team_0)}`;',
+        "stats evaluation player all-player stats entity sections",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "bool SubtrActorPlugin::renderStatsWindowValueRow(",
+        "plugin shared stats row renderer",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderStatsWindowValueRow(\n                window, i, statLabel, statValue, std::format("player-{}", player.player_index))',
+        "plugin all-player stats rows use shared row renderer",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderStatsWindowValueRow(\n              window, i, statLabel, statValue, std::format("team-{}", isTeam0))',
+        "plugin all-team stats rows use shared row renderer",
+        errors,
+    )
+    for plugin_only_grouped_stats_surface in (
+        'ImGui::TreeNodeEx(playerName.c_str(), ImGuiTreeNodeFlags_DefaultOpen)',
+        'std::format("all-player-stat-rows-{}", player.player_index).c_str()',
+        'std::format("all-team-stat-rows-{}", isTeam0).c_str()',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_grouped_stats_surface,
+            "plugin grouped stats table/tree surface",
             errors,
         )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1457,6 +1457,18 @@ def main() -> int:
         "stats evaluation player has an explicit persisted config snapshot",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        "pluginRenderEffects: [...initialUrlConfig.overlays.pluginRenderEffects]",
+        "stats evaluation player preserves plugin-only render effect config",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "pluginHudOverlay: initialUrlConfig.overlays.pluginHudOverlay",
+        "stats evaluation player preserves plugin-only HUD overlay config",
+        errors,
+    )
     reject_contains(
         plugin_source,
         '"mechanics_review_status"',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -23,6 +23,7 @@ ABI_HEADER = REPO_ROOT / "crates/subtr-actor-bakkesmod/include/subtr_actor_bakke
 WEB_PLAYER_CONFIG_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/playerConfig.ts"
 WEB_PLAYER_MAIN_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/main.ts"
 WEB_PLAYER_TEMPLATE_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/appTemplate.ts"
+WEB_PLAYER_TIMELINE_MARKERS_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/timelineMarkers.ts"
 WEB_PLAYER_BOOST_PICKUP_FILTERS_SOURCE = (
     REPO_ROOT / "js/stat-evaluation-player/src/boostPickupFilters.ts"
 )
@@ -349,6 +350,9 @@ def main() -> int:
     web_player_config_source = WEB_PLAYER_CONFIG_SOURCE.read_text(encoding="utf-8")
     web_player_main_source = WEB_PLAYER_MAIN_SOURCE.read_text(encoding="utf-8")
     web_player_template_source = WEB_PLAYER_TEMPLATE_SOURCE.read_text(encoding="utf-8")
+    web_player_timeline_markers_source = WEB_PLAYER_TIMELINE_MARKERS_SOURCE.read_text(
+        encoding="utf-8"
+    )
     web_player_boost_pickup_filters_source = WEB_PLAYER_BOOST_PICKUP_FILTERS_SOURCE.read_text(
         encoding="utf-8"
     )
@@ -1393,6 +1397,48 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        "label.textContent = item.event.label ?? item.sourceLabel;",
+        "stats evaluation player event playlist row title uses event label",
+        errors,
+    )
+    require_contains(
+        web_player_timeline_markers_source,
+        'label: `${playerName} speed flip ${qualityPercent}%`,',
+        "stats evaluation player player mechanics include player names in titles",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'std::format("{} {}", playerLabel(event.player_index, event.is_team_0), action);',
+        "plugin player mechanics include player names in event titles",
+        errors,
+    )
+    require_contains(
+        web_player_timeline_markers_source,
+        "label: `${teamName} rush ${matchupLabel}`,",
+        "stats evaluation player team events include team names in titles",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        '"{} rush {}v{}"',
+        "plugin team events include team names in event titles",
+        errors,
+    )
+    require_contains(
+        web_player_timeline_markers_source,
+        'label: scorerName ? `${scorerName} goal context` : "Goal context",',
+        "stats evaluation player goal context includes scorer names in titles",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'std::format("{} {}", actor, goalContextLabel(event))',
+        "plugin goal context includes scorer names in event titles",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         '.join(" · ");',
         "stats evaluation player event playlist row meta uses dot separator",
         errors,
@@ -1469,6 +1515,8 @@ def main() -> int:
     for plugin_only_event_playlist_row_meta in (
         'joinStrings(metaParts, " / ").c_str());\n    }\n    if (!event.details.empty())',
         'ImGui::TextDisabled("%s", event.category.c_str());',
+        "playerLabel(event.player_index, event.is_team_0),\n      mechanicLabel(event.kind),",
+        "teamEventLabel(event),\n      std::format",
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1812,6 +1812,24 @@ def main() -> int:
         "web timelineEvents exports plugin-only broad mechanics id",
         errors,
     )
+    reject_contains(
+        plugin_source,
+        'writeOverlayId("team", eventPlaylistTeamEventsEnabled);',
+        "web timelineEvents exports plugin-only broad team id",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'writeOverlayId("goal_context", eventPlaylistGoalContextEnabled);',
+        "web timelineEvents exports plugin-only broad goal-context id",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "webTimelineEventSourceIdForFilterToken(token)",
+        "web timelineEvents exports normalized web source ids from plugin filters",
+        errors,
+    )
     require_contains(
         plugin_source,
         "for (const char *token : MECHANIC_FILTER_TOKENS) {\n"

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1089,8 +1089,32 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'renderModuleSummaryToggle(\n          "All",\n          allSourcesEnabled,\n          "event-playlist-sources")',
+        'ImGui::Button("All##event-playlist-sources-all")',
         "plugin event playlist all action label mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'noneButton.textContent = "None";',
+        "stats evaluation player event playlist none action label",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Button("None##event-playlist-sources-none")',
+        "plugin event playlist none action label mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'label.className = "toggle event-playlist-filter-option";',
+        "stats evaluation player event playlist filter options are checkbox toggles",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Checkbox(label.c_str(), &enabled)',
+        "plugin event playlist filter options are checkbox toggles",
         errors,
     )
     require_contains(
@@ -1117,6 +1141,17 @@ def main() -> int:
         "plugin event playlist all action includes event count",
         errors,
     )
+    for plugin_only_event_playlist_filter_surface in (
+        'renderModuleSummaryToggle(\n          "All",\n          allSourcesEnabled,\n          "event-playlist-sources")',
+        'renderModuleSummaryToggle("None", noSourcesEnabled, "event-playlist-sources")',
+        'renderModuleSummaryToggle(label.c_str(), source.enabled, "event-playlist-sources")',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_event_playlist_filter_surface,
+            "plugin event playlist filter module-summary button surface",
+            errors,
+        )
     reject_contains(
         plugin_source,
         'std::format("{} {:.2f}s##event-playlist-cue", active ? ">" : "Cue", event.time)',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -22,6 +22,12 @@ ABI_HEADER = REPO_ROOT / "crates/subtr-actor-bakkesmod/include/subtr_actor_bakke
 WEB_PLAYER_CONFIG_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/playerConfig.ts"
 WEB_PLAYER_MAIN_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/main.ts"
 WEB_PLAYER_TEMPLATE_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/appTemplate.ts"
+WEB_PLAYER_BOOST_PICKUP_FILTERS_SOURCE = (
+    REPO_ROOT / "js/stat-evaluation-player/src/boostPickupFilters.ts"
+)
+WEB_PLAYER_PLAYER_MODULES_SOURCE = (
+    REPO_ROOT / "js/stat-evaluation-player/src/stat-modules/playerModules.ts"
+)
 
 
 @dataclass(frozen=True)
@@ -328,6 +334,12 @@ def main() -> int:
     web_player_config_source = WEB_PLAYER_CONFIG_SOURCE.read_text(encoding="utf-8")
     web_player_main_source = WEB_PLAYER_MAIN_SOURCE.read_text(encoding="utf-8")
     web_player_template_source = WEB_PLAYER_TEMPLATE_SOURCE.read_text(encoding="utf-8")
+    web_player_boost_pickup_filters_source = WEB_PLAYER_BOOST_PICKUP_FILTERS_SOURCE.read_text(
+        encoding="utf-8"
+    )
+    web_player_player_modules_source = WEB_PLAYER_PLAYER_MODULES_SOURCE.read_text(
+        encoding="utf-8"
+    )
     cpp_combined = plugin_header + "\n" + plugin_source
     errors: list[str] = []
 
@@ -583,6 +595,87 @@ def main() -> int:
             plugin_source,
             plugin_only_camera_surface,
             "plugin camera window plugin-only surface",
+            errors,
+        )
+    for boost_filter_label in ("Pad type", "Activity", "Field half", "Player"):
+        web_boost_label_needles = {
+            "Pad type": 'createFilterGroup("Pad type",',
+            "Activity": '"Activity",\n            BOOST_PICKUP_ACTIVITY_OPTIONS',
+            "Field half": '"Field half",\n            BOOST_PICKUP_FIELD_HALF_OPTIONS',
+            "Player": 'groupTitle.textContent = "Player";',
+        }
+        require_contains(
+            web_player_boost_pickup_filters_source,
+            web_boost_label_needles[boost_filter_label],
+            f"stats evaluation player boost pickup filter label {boost_filter_label}",
+            errors,
+        )
+        require_contains(
+            plugin_source,
+            f'ImGui::TextColored(ImVec4{{0.53f, 0.69f, 0.83f, 1.0f}}, "{boost_filter_label}");',
+            f"plugin boost pickup filter label {boost_filter_label}",
+            errors,
+        )
+    for plugin_only_boost_surface in (
+        'ImGui::Text("Pickup labels: %s", pickupReadout.c_str());',
+        'ImGui::Text("Known pads: %zu", boostPadIds.size());',
+        'ImGui::Text("Pending pad events: %zu", pendingBoostPadEvents.size());',
+        'ImGui::Text("Recent boost pickups: %d", recentEventCountForType("boost_pickup"));',
+        'ImGui::Button("Show boost pickups")',
+        'ImGui::Button("Open boost stats")',
+        'ImGui::Button("Inspect boost nodes")',
+        'ImGui::Button("Boost output")',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_boost_surface,
+            "plugin boost pickup filters window plugin-only surface",
+            errors,
+        )
+    for touch_settings_label in (
+        'eyebrow.textContent = "Touch markers";',
+        'title.textContent = "Touch decay";',
+        'labelText.textContent = "Keep each marker visible after the touch";',
+        'modeEyebrow.textContent = "Overlay";',
+        'modeTitle.textContent = "Touch mode";',
+        'breakdownEyebrow.textContent = "Stat display";',
+        'breakdownTitle.textContent = "Touch breakdown";',
+    ):
+        require_contains(
+            web_player_player_modules_source,
+            touch_settings_label,
+            f"stats evaluation player touch controls setting {touch_settings_label}",
+            errors,
+        )
+    for plugin_touch_surface in (
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Touch markers");',
+        'ImGui::Text("Touch decay");',
+        'ImGui::TextDisabled("Keep each marker visible after the touch");',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Overlay");',
+        'ImGui::Text("Touch mode");',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Stat display");',
+        'ImGui::Text("Touch breakdown");',
+    ):
+        require_contains(
+            plugin_source,
+            plugin_touch_surface,
+            "plugin touch controls mirror stats evaluation player settings",
+            errors,
+        )
+    for plugin_only_touch_surface in (
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "LIVE TOUCH STATE");',
+        'ImGui::Text("Pending touches: %zu", pendingTouches.size());',
+        'ImGui::Text("Pending dodge refreshes: %zu", pendingDodgeRefreshes.size());',
+        'ImGui::Text("Recent touch events: %d", recentEventCountForType("touch"));',
+        'ImGui::Button("Show touches")',
+        'ImGui::Button("Show movement")',
+        'ImGui::Button("Open touch stats")',
+        'ImGui::Button("Inspect touch nodes")',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_touch_surface,
+            "plugin touch controls window plugin-only surface",
             errors,
         )
     require_contains(
@@ -977,7 +1070,7 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PLAYER");',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Player");',
         "boost pickup filters expose web player filter group",
         errors,
     )

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -4261,6 +4261,48 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_styles_source,
+        ".floating-window,\n"
+        ".stats-window,\n"
+        ".scoreboard-window {\n"
+        "  position: absolute;\n"
+        "  left: clamp(0.8rem, var(--window-x, 1rem), calc(100vw - 18rem));",
+        "stats evaluation player scoreboard shares overlay chrome base",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        "  border: 1px solid rgba(255, 255, 255, 0.12);\n"
+        "  border-radius: var(--ui-radius-lg);\n"
+        "  background: var(--ui-overlay-bg);",
+        "stats evaluation player scoreboard shares overlay border/background",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".scoreboard-window {\n"
+        "  left: 50%;\n"
+        "  top: 0.7rem;\n"
+        "  width: auto;",
+        "stats evaluation player scoreboard is a centered pill",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 999.0f);\n"
+        "  ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 1.0f);\n"
+        "  ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4{0.03f, 0.07f, 0.10f, 0.88f});\n"
+        "  ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{1.0f, 1.0f, 1.0f, 0.12f});",
+        "plugin scoreboard uses web-like pill background and border",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PopStyleColor(2);\n  ImGui::PopStyleVar(3);",
+        "plugin scoreboard restores pill chrome style stack",
+        errors,
+    )
+    require_contains(
         web_player_main_source,
         "renderScoreboard(state.frameIndex);",
         "stats evaluation player scoreboard follows current replay frame",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -417,8 +417,44 @@ def main() -> int:
         )
     require_contains(
         plugin_source,
+        "std::optional<std::string> SubtrActorPlugin::webPlayerIdForWindowConfig(",
+        "nullable web stats window playerId helper",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "std::optional<std::string> SubtrActorPlugin::webCameraPlayerIdConfig() const",
+        "nullable web camera attachedPlayerId helper",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (const auto playerId = webPlayerIdForWindowConfig(window))",
+        "web stats window config uses nullable playerId helper",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (const auto playerId = webPlayerIdForIndexIfKnown(window.selected_player_index))",
+        "stats window player selection only synthesizes known player ids",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (const auto attachedPlayerId = webCameraPlayerIdConfig())",
+        "web camera config uses nullable attachedPlayerId helper",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'file << "null";',
+        "web config can emit null values",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
         'file << ",\\"playerId\\":\\"" << escapeJsonString(webPlayerIdForWindow(window)) << "\\""',
-        "web stats window config always emits playerId",
+        "web stats window config always serializes playerId as string",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2363,6 +2363,19 @@ def main() -> int:
         errors,
     )
     require_contains(
+        plugin_source,
+        'ImGui::TextWrapped("%s", statusReadout.c_str());\n'
+        '  ImGui::Text("%d / %zu", current == nullptr ? 0 : mechanicsReviewIndex + 1, candidates.size());',
+        "plugin mechanics review status appears before current item like web",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'ImGui::TextWrapped("%s", currentTitle.c_str());\n  const std::string statusReadout =',
+        "plugin mechanics review renders current item before status",
+        errors,
+    )
+    require_contains(
         web_player_main_source,
         "mechanicsReviewPrev.disabled = !review || review.loading || review.currentIndex <= 0;",
         "stats evaluation player mechanics review disables unavailable previous action",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2443,6 +2443,18 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "getMechanicsReviewPlayerName(candidate),",
+        "stats evaluation player mechanics review rows expose player attribution",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (!event.actor.empty()) {\n      metaParts.push_back(event.actor);\n    }",
+        "plugin mechanics review rows expose player attribution",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'metaParts.push_back(mechanicsReviewDecisionLabel(event));',
         "plugin mechanics review rows expose review status",
@@ -2450,7 +2462,10 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
-        "formatMechanicsReviewStatus(candidate.meta?.reviewStatus),\n    ].join(\" · \");",
+        "formatMechanicsReviewStatus(candidate.meta?.reviewStatus),\n"
+        "      ]\n"
+        "        .filter((part) => part && part !== \"--\")\n"
+        "        .join(\" · \") || \"--\";",
         "stats evaluation player mechanics review row meta uses dot separator",
         errors,
     )

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1769,9 +1769,51 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "const panels = activeModules\n"
+        '    .filter((mod) => mod.id !== "boost" && mod.id !== TOUCH_MODULE_ID)\n'
+        "    .map((mod) => mod.renderSettings?.(ctx) ?? null)",
+        "stats evaluation player module settings are active-module panels",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".module-settings-card {\n"
+        "  display: grid;\n"
+        "  gap: 0.75rem;\n"
+        "  padding: 0.85rem 0.9rem;\n"
+        "  border-radius: 1rem;\n"
+        "  border: 1px solid rgba(255, 255, 255, 0.08);\n"
+        "  background: rgba(255, 255, 255, 0.035);",
+        "stats evaluation player module settings render card panels",
+        errors,
+    )
+    require_contains(
         plugin_source,
         "if (timelineRangePossessionEnabled) {\n    ImGui::Separator();\n    renderModuleSettingsControls(\"launcher-module-settings\", false, true, true);\n  }",
         "launcher module settings only render active web panels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::BeginChild(cardId, ImVec2{0.0f, height}, true);',
+        "plugin launcher module settings render web-like card panels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const bool possessionCard = beginModuleSettingsCard(\n'
+        '        "module-settings-card-possession",\n'
+        "        includeOpenButtons ? 116.0f : 84.0f);",
+        "plugin active possession settings use module-settings card",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::SameLine(std::max(\n"
+        "          ImGui::GetCursorPosX(),\n"
+        "          ImGui::GetWindowContentRegionMax().x - ImGui::CalcTextSize(readout.c_str()).x));",
+        "plugin module settings card aligns readout like web header",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -589,6 +589,30 @@ def main() -> int:
         "web renderEffects import uses JSON parser",
         errors,
     )
+    require_contains(
+        plugin_source,
+        'if (jsonPropertyExists(*boostConfig, "playerIds")) {',
+        "web boost playerIds import uses JSON parser",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'boostPickupPlayerFilterEnabled = !jsonPropertyIsNull(*boostConfig, "playerIds");',
+        "web boost playerIds null preserves all-player filter",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "writeStringArray(file, boostPickupPlayerIds);",
+        "web boost playerIds config emits selected players",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "PLAYER");',
+        "boost pickup filters expose web player filter group",
+        errors,
+    )
     reject_contains(
         plugin_source,
         'overlays->find("\\"renderEffects\\"")',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -529,6 +529,30 @@ def main() -> int:
         "plugin mechanics review rows use prefix/raw-seconds/status-in-title shape",
         errors,
     )
+    require_contains(
+        web_player_template_source,
+        '<span id="replay-loading-summary">0 replays</span>',
+        "stats evaluation player replay loading summary starts as replay count",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const std::string replaySummary = replayPath ? "1 replay" : "0 replays";',
+        "plugin replay loading summary uses web-like replay count",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'ImGui::Text("Summary: %s", replayPath ? "1 replay candidate" : "0 replay candidates");',
+        "plugin replay loading summary label/candidate wording",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'ImGui::Text("Active: %s", status);',
+        "plugin replay loading active status label",
+        errors,
+    )
     for label, plugin_needle in (
         ("Possession", '"Possession",\n        timelineRangePossessionEnabled'),
         ("Half control", '"Half control",\n        timelineRangePressureEnabled'),

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -870,8 +870,44 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::TextDisabled("Camera profile");\n  ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);\n  if (ImGui::BeginCombo("##attached-player", selectedLabel.c_str()))',
+        'ImGui::TextDisabled("Camera profile");\n  ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);\n  const bool profileDisabled = !hasCameraContext;\n  pushCameraDisabledStyle(profileDisabled);\n  const bool profileOpen = ImGui::BeginCombo("##attached-player", selectedLabel.c_str());',
         "plugin camera profile selector mirrors web label and hidden control id",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "attachedPlayer.disabled = !enabled;",
+        "stats evaluation player disables attached player selector with transport",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'button.disabled = !hasReplay || (mode === "follow" && !canFollow);',
+        "stats evaluation player disables unavailable camera modes",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "cameraViewOverheadButton.disabled = !hasReplay;",
+        "stats evaluation player disables overhead camera without replay",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool hasCameraContext = !sampledPlayers.empty();",
+        "plugin camera derives replay context for disabled controls",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'cameraViewButton("Follow##camera-view", 1, !hasCameraContext || selectedPlayer == nullptr)',
+        "plugin disables follow camera without replay player context",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'cameraViewButton("Overhead##camera-view", 2, !hasCameraContext)',
+        "plugin disables preset camera modes without replay context",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -746,6 +746,69 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        'allName.textContent = "All events";',
+        "stats evaluation player Events window all-events action",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderModuleSummaryToggle(\n          "All events",\n          allSelected,\n          "event-sources-actions")',
+        "plugin Events window all-events action mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'noneName.textContent = "No events";',
+        "stats evaluation player Events window no-events action",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderModuleSummaryToggle(\n          "No events",\n          selected.empty(),\n          "event-sources-actions")',
+        "plugin Events window no-events action mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'item.className = "module-summary-item";',
+        "stats evaluation player Events window source rows are module summary items",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderModuleSummaryToggle(label.c_str(), enabled, "event-sources")',
+        "plugin Events window source rows are module summary toggles",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'empty.textContent = "No events loaded.";',
+        "stats evaluation player Events window empty state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("No events loaded.");',
+        "plugin Events window empty state mirrors web",
+        errors,
+    )
+    for plugin_only_events_surface in (
+        'renderEventFilterCombo("Filter");',
+        'ImGui::Button("Clear")',
+        'ImGui::Text("%zu visible / %zu recent", visibleCount, recentUiEvents.size());',
+        'ImGui::Columns(4, "event-columns", true);',
+        'ImGui::TreeNode("Event sources##event-source-controls")',
+        'ImGui::SmallButton("All events##event-sources")',
+        'ImGui::SmallButton("No events##event-sources")',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_events_surface,
+            "plugin Events window plugin-only log/table surface",
+            errors,
+        )
+    require_contains(
+        web_player_main_source,
         "summary.textContent = `Filters ${selectedSourceIds.size}/${sources.length}`;",
         "stats evaluation player event playlist filter count label",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -312,6 +312,50 @@ def singleton_window_controls(source: str) -> list[tuple[str, str, bool, int]]:
     return controls
 
 
+def singleton_window_open_variables(source: str) -> dict[str, str]:
+    match = re.search(
+        r"return\s+\{\{(.*?)\}\};\s*\}\s*\n\s*std::vector<SubtrActorPlugin::SingletonWindowControl>",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError("missing singletonWindowControls return block")
+
+    variables: dict[str, str] = {}
+    for control in re.finditer(
+        r'\{\s*"[^"]+",\s*"(?P<id>[^"]+)",\s*"[^"]+",\s*"[^"]+",\s*'
+        r"(?:true|false),\s*\d+,\s*&(?P<open_var>ui[A-Za-z0-9_]+Open),",
+        match.group(1),
+        re.DOTALL,
+    ):
+        variables[control.group("id")] = control.group("open_var")
+    if not variables:
+        raise AssertionError("could not parse singletonWindowControls open variables")
+    return variables
+
+
+def cpp_bool_defaults(source: str) -> dict[str, bool]:
+    return {
+        match.group("name"): match.group("value") == "true"
+        for match in re.finditer(
+            r"\bbool\s+(?P<name>[A-Za-z0-9_]+)\s*=\s*(?P<value>true|false)\s*;",
+            source,
+        )
+    }
+
+
+def web_initial_singleton_visibility(source: str) -> dict[str, bool]:
+    visibility: dict[str, bool] = {}
+    for section in re.finditer(r"<section\b(?P<tag>[^>]*)>", source, re.DOTALL):
+        tag = section.group("tag")
+        window_id = re.search(r'\bdata-window-id="(?P<id>[^"]+)"', tag)
+        if window_id:
+            visibility[window_id.group("id")] = not re.search(r"\bhidden\b", tag)
+    if not visibility:
+        raise AssertionError("could not parse web singleton window visibility")
+    return visibility
+
+
 def stats_window_kind_controls(source: str) -> list[tuple[str, str, bool]]:
     match = re.search(
         r"SubtrActorPlugin::statsWindowKindControls\(\)\s+const\s+\{\s+return\s+\{\{"
@@ -423,6 +467,39 @@ def main() -> int:
         errors.append(
             "web singleton launcher labels drifted from stats evaluation player: "
             f"expected={web_launcher_window_buttons!r} actual={plugin_web_window_controls!r}"
+        )
+    plugin_window_open_variables = singleton_window_open_variables(plugin_source)
+    plugin_bool_defaults = cpp_bool_defaults(plugin_header)
+    web_initial_window_visibility = web_initial_singleton_visibility(web_player_template_source)
+    plugin_initial_window_visibility: list[tuple[str, bool]] = []
+    web_initial_window_visibility_ordered: list[tuple[str, bool]] = []
+    for window_id in web_window_ids:
+        open_variable = plugin_window_open_variables.get(window_id)
+        if open_variable is None:
+            errors.append(f"plugin singleton window {window_id!r} is missing an open bool pointer")
+            continue
+        if open_variable not in plugin_bool_defaults:
+            errors.append(
+                f"plugin singleton window {window_id!r} points at {open_variable}, "
+                "but the header has no default bool value for it"
+            )
+            continue
+        if window_id not in web_initial_window_visibility:
+            errors.append(
+                f"stats evaluation player template has no initial visibility for {window_id!r}"
+            )
+            continue
+        plugin_initial_window_visibility.append(
+            (window_id, plugin_bool_defaults[open_variable])
+        )
+        web_initial_window_visibility_ordered.append(
+            (window_id, web_initial_window_visibility[window_id])
+        )
+    if plugin_initial_window_visibility != web_initial_window_visibility_ordered:
+        errors.append(
+            "plugin singleton default visibility drifted from stats evaluation player: "
+            f"expected={web_initial_window_visibility_ordered!r} "
+            f"actual={plugin_initial_window_visibility!r}"
         )
 
     plugin_web_stats_window_controls = tuple(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -118,6 +118,14 @@ REQUIRED_PLUGIN_ABI_EXPORTS = (
         "subtr_actor_bakkesmod_write_decoded_stats_player_config_json",
         "writeDecodedStatsPlayerConfigJson",
     ),
+    (
+        "subtr_actor_bakkesmod_encoded_stats_player_config_len",
+        "encodedStatsPlayerConfigLen",
+    ),
+    (
+        "subtr_actor_bakkesmod_write_encoded_stats_player_config",
+        "writeEncodedStatsPlayerConfig",
+    ),
     ("subtr_actor_bakkesmod_events_json_len", "eventsJsonLen"),
     ("subtr_actor_bakkesmod_write_events_json", "writeEventsJson"),
     ("subtr_actor_bakkesmod_frame_json_len", "frameJsonLen"),

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1895,8 +1895,33 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'const std::string replaySummary = replayPath ? "1 replay" : "0 replays";',
+        'const std::string replaySummary = hasReplaySource ? "1 replay" : "0 replays";',
         "plugin replay loading summary uses web-like replay count",
+        errors,
+    )
+    require_contains(
+        web_player_template_source,
+        '<span id="replay-loading-active">Idle</span>',
+        "stats evaluation player replay loading active summary exists",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'loaded === states.length\n              ? "Complete"',
+        "stats evaluation player replay loading active summary reports completion",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const char *activeSummary = !hasReplaySource         ? "No playlist"\n'
+        '                              : replayAnnotations      ? "Complete"',
+        "plugin replay loading active summary mirrors web completion state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("%s", activeSummary);',
+        "plugin replay loading renders active summary separately from replay count",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -333,6 +333,24 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        "auto writeStatsPlayerPlacement = [](",
+        "dedicated web placement writer",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "writeStatsPlayerPlacement(file, *window.placement, visible);",
+        "singletonWindows use web placement shape",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "writePlacement(file, *window.placement, visible);",
+        "plugin windows keep plugin placement shape",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         'std::format("##stats-window-player-scope-{}", window.id).c_str()',
         "player stats scope combo uses hidden label",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1397,6 +1397,30 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        "const EVENT_PLAYLIST_PLAYER_COLORS = [",
+        "stats evaluation player event playlist has player color palette",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "return EVENT_PLAYLIST_PLAYER_COLORS[playerIndex % EVENT_PLAYLIST_PLAYER_COLORS.length]!",
+        "stats evaluation player event playlist colors rows by player",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "LinearColor eventPlaylistPlayerColor(uint32_t playerIndex)",
+        "plugin event playlist has player color palette",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "event.has_player != 0 ? eventPlaylistPlayerColor(event.player_index)",
+        "plugin event playlist colors player rows by player",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         "label.textContent = item.event.label ?? item.sourceLabel;",
         "stats evaluation player event playlist row title uses event label",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1116,8 +1116,36 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        'std::format(\n'
+        '      "Filters {}/{}##event-playlist-filter",\n'
+        "      selectedSourceCount,\n"
+        "      playlistSources.size())",
+        "plugin event playlist filter disclosure mirrors web summary",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool filtersOpen = ImGui::TreeNode(filterSummary.c_str());",
+        "plugin event playlist filter panel is collapsed like web details",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
         'ImGui::Text("Filters %zu/%zu", selectedSourceCount, playlistSources.size());',
-        "plugin event playlist filter count label mirrors web spacing",
+        "plugin event playlist renders filter summary as static text",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'empty.textContent = replayPlayer ? "No events loaded." : "Load a replay to see events.";',
+        "stats evaluation player event playlist empty state distinguishes no replay",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'recentUiEvents.empty() && replayAnnotations == nullptr ? "Load a replay to see events."\n'
+        '                                                               : "No events loaded."',
+        "plugin event playlist empty state distinguishes no replay",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -499,6 +499,36 @@ def main() -> int:
         "plugin event playlist visible cue mini-button",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        'button.className = "mechanics-review-item";',
+        "stats evaluation player mechanics review rows are clickable items",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'std::format(\n        "{}  {}##mechanics-review-item",\n        formatEventPlaylistTime(event.time),\n        title)',
+        "plugin mechanics review rows use web-like title labels",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "formatMechanicsReviewStatus(candidate.meta?.reviewStatus)",
+        "stats evaluation player mechanics review rows expose review status",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'metaParts.push_back(mechanicsReviewDecisionLabel(event));',
+        "plugin mechanics review rows expose review status",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'std::format(\n        "{} {:.2f}s {} ({})",',
+        "plugin mechanics review rows use prefix/raw-seconds/status-in-title shape",
+        errors,
+    )
     for label, plugin_needle in (
         ("Possession", '"Possession",\n        timelineRangePossessionEnabled'),
         ("Half control", '"Half control",\n        timelineRangePressureEnabled'),

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1127,6 +1127,32 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_template_source,
+        '<dl class="mechanics-review-fields">',
+        "stats evaluation player mechanics review current item field grid",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Columns(2, "mechanics-review-fields", false);',
+        "plugin mechanics review current item uses web-like field grid",
+        errors,
+    )
+    for plugin_only_mechanics_review_current_surface in (
+        'ImGui::Text("Decision: %s", mechanicsReviewDecisionLabel(current));',
+        'ImGui::Text("Mechanic: %s", current.type.c_str());',
+        'ImGui::Text("Player: %s", current.actor.c_str());',
+        'ImGui::Text("Clip: %.2fs to %.2fs", clipStart, clipEnd);',
+        'ImGui::Text("Event: frame %llu", static_cast<unsigned long long>(current.frame_number));',
+        'ImGui::TextWrapped("Reason: %s", current.details.c_str());',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_mechanics_review_current_surface,
+            "plugin mechanics review current item debug-style rows",
+            errors,
+        )
+    require_contains(
         web_player_main_source,
         "formatMechanicsReviewStatus(candidate.meta?.reviewStatus)",
         "stats evaluation player mechanics review rows expose review status",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -110,6 +110,14 @@ REQUIRED_PLUGIN_ABI_EXPORTS = (
     ("subtr_actor_bakkesmod_engine_reset", "engineReset"),
     ("subtr_actor_bakkesmod_finish", "engineFinish"),
     ("subtr_actor_bakkesmod_process_frame", "processFrame"),
+    (
+        "subtr_actor_bakkesmod_decoded_stats_player_config_json_len",
+        "decodedStatsPlayerConfigJsonLen",
+    ),
+    (
+        "subtr_actor_bakkesmod_write_decoded_stats_player_config_json",
+        "writeDecodedStatsPlayerConfigJson",
+    ),
     ("subtr_actor_bakkesmod_events_json_len", "eventsJsonLen"),
     ("subtr_actor_bakkesmod_write_events_json", "writeEventsJson"),
     ("subtr_actor_bakkesmod_frame_json_len", "frameJsonLen"),

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -813,11 +813,25 @@ def main() -> int:
         "plugin camera uses web-like detail grid",
         errors,
     )
+    require_contains(
+        web_player_template_source,
+        "<span>Custom camera settings</span>",
+        "stats evaluation player camera custom settings toggle",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Checkbox("Custom camera settings", &nextCustomSettingsEnabled)',
+        "plugin camera custom settings toggle mirrors web label",
+        errors,
+    )
     for plugin_only_camera_surface in (
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "CAMERA PROFILE");',
         'ImGui::BeginCombo("Target", selectedLabel.c_str())',
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "READOUT");',
         'ImGui::Button("Open player stats")',
+        'ImGui::Checkbox("Ball cam", &nextBallCamEnabled)',
+        'ImGui::Checkbox("Custom settings", &nextCustomSettingsEnabled)',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -22,6 +22,7 @@ PLUGIN_README = REPO_ROOT / "bakkesmod/README.md"
 ABI_HEADER = REPO_ROOT / "crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h"
 WEB_PLAYER_CONFIG_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/playerConfig.ts"
 WEB_PLAYER_MAIN_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/main.ts"
+WEB_PLAYER_STYLES_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/styles.css"
 WEB_PLAYER_TEMPLATE_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/appTemplate.ts"
 WEB_PLAYER_TIMELINE_MARKERS_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/timelineMarkers.ts"
 WEB_PLAYER_BOOST_PICKUP_FILTERS_SOURCE = (
@@ -473,6 +474,7 @@ def main() -> int:
     abi_header = ABI_HEADER.read_text(encoding="utf-8")
     web_player_config_source = WEB_PLAYER_CONFIG_SOURCE.read_text(encoding="utf-8")
     web_player_main_source = WEB_PLAYER_MAIN_SOURCE.read_text(encoding="utf-8")
+    web_player_styles_source = WEB_PLAYER_STYLES_SOURCE.read_text(encoding="utf-8")
     web_player_template_source = WEB_PLAYER_TEMPLATE_SOURCE.read_text(encoding="utf-8")
     web_player_timeline_markers_source = WEB_PLAYER_TIMELINE_MARKERS_SOURCE.read_text(
         encoding="utf-8"
@@ -581,6 +583,45 @@ def main() -> int:
             f"expected={web_initial_window_visibility_ordered!r} "
             f"actual={plugin_initial_window_visibility!r}"
         )
+    require_contains(
+        web_player_styles_source,
+        ".floating-window,\n.stats-window,\n.scoreboard-window {\n"
+        "  position: absolute;\n"
+        "  left: clamp(0.8rem, var(--window-x, 1rem), calc(100vw - 18rem));",
+        "stats evaluation player floating windows share overlay chrome",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "void pushWebFloatingWindowStyle() {\n"
+        "  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{14.0f, 12.0f});\n"
+        "  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f);\n"
+        "  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);\n"
+        "  ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2{8.0f, 8.0f});\n"
+        "  ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4{0.03f, 0.07f, 0.10f, 0.88f});\n"
+        "  ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{1.0f, 1.0f, 1.0f, 0.12f});\n"
+        "}",
+        "plugin floating windows share web-like overlay chrome",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (entry.kind == RenderEntryKind::Stats) {\n"
+        "      renderWithFloatingWindowStyle([&]() {\n"
+        "        renderStatsWindow(uiStatsWindows[entry.stats_index], entry.stats_index);\n"
+        "      });",
+        "plugin stats windows use shared web-like overlay chrome",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'if (id == "scoreboard") {\n'
+        "      renderScoreboardWindow();\n"
+        '    } else if (id == "mechanics") {\n'
+        "      renderWithFloatingWindowStyle([&]() { renderEventsWindow(); });",
+        "plugin leaves scoreboard pill separate from shared floating chrome",
+        errors,
+    )
 
     plugin_web_stats_window_controls = tuple(
         (kind_id, label)

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -3017,6 +3017,41 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_styles_source,
+        ".mechanics-review-actions,\n"
+        ".mechanics-review-decision-actions,\n"
+        ".mechanics-review-list-header {\n"
+        "  display: flex;\n"
+        "  align-items: center;\n"
+        "  justify-content: space-between;\n"
+        "  gap: var(--ui-gap-sm);\n"
+        "}",
+        "stats evaluation player mechanics review action rows use flex layout",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".mechanics-review-actions button,\n"
+        ".mechanics-review-decision-actions button {\n"
+        "  flex: 1 1 0;\n"
+        "}",
+        "stats evaluation player mechanics review action buttons distribute equally",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const float actionButtonWidth =\n"
+        "      std::max(72.0f, (ImGui::GetContentRegionAvail().x - actionGap * 2.0f) / 3.0f);",
+        "plugin mechanics review action buttons distribute equally",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::SameLine(0.0f, actionGap);",
+        "plugin mechanics review action rows use explicit web-like gaps",
+        errors,
+    )
+    require_contains(
         web_player_main_source,
         "mechanicsReviewReplay.disabled = !review || review.loading || !review.currentClip;",
         "stats evaluation player mechanics review disables unavailable replay action",
@@ -3047,11 +3082,50 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_styles_source,
+        "#mechanics-review-confirm {\n"
+        "  border-color: rgba(76, 175, 120, 0.52);\n"
+        "}",
+        "stats evaluation player mechanics review confirm action is green-accented",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        "#mechanics-review-reject {\n"
+        "  border-color: rgba(220, 95, 95, 0.58);\n"
+        "}",
+        "stats evaluation player mechanics review reject action is red-accented",
+        errors,
+    )
+    require_contains(
         plugin_source,
         "const bool decisionDisabled = current == nullptr;",
         "plugin mechanics review disables unavailable decisions",
         errors,
     )
+    require_contains(
+        plugin_source,
+        "ImVec4{0.30f, 0.69f, 0.47f, 0.52f}",
+        "plugin mechanics review confirm action uses green border accent",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImVec4{0.86f, 0.37f, 0.37f, 0.58f}",
+        "plugin mechanics review reject action uses red border accent",
+        errors,
+    )
+    for plugin_only_mechanics_review_action_surface in (
+        'const bool clicked = ImGui::Button(label);',
+        'ImGui::SameLine();\n  if (mechanicsReviewButton("Replay clip", replayDisabled))',
+        'ImGui::SameLine();\n  if (mechanicsReviewButton("Reject", decisionDisabled))',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_mechanics_review_action_surface,
+            "plugin mechanics review plugin-only natural-width action surface",
+            errors,
+        )
     require_contains(
         web_player_template_source,
         '<span id="mechanics-review-replay-load-summary">0 replays</span>',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1936,6 +1936,12 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        "return eventTypeDisplayLabel(event.type);",
+        "plugin event playlist fallback source labels use web-like event display labels",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         "std::string formatEventPlaylistTime(float seconds)",
         "plugin event playlist uses web-like minute time labels",
         errors,
@@ -1991,6 +1997,7 @@ def main() -> int:
         'ImGui::TextDisabled("%s", event.category.c_str());',
         "playerLabel(event.player_index, event.is_team_0),\n      mechanicLabel(event.kind),",
         "teamEventLabel(event),\n      std::format",
+        'if (!event.details.empty()) {\n      ImGui::TextDisabled("%s", event.details.c_str());',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -314,6 +314,18 @@ def main() -> int:
             "web stats window kind order drifted from stats evaluation player: "
             f"expected={WEB_STATS_WINDOW_KIND_IDS!r} actual={web_stats_window_kind_ids!r}"
         )
+    require_contains(
+        plugin_source,
+        'file << ",\\"playerId\\":\\"" << escapeJsonString(webPlayerIdForWindow(window)) << "\\""',
+        "web stats window config always emits playerId",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'file << ",\\"team\\":\\"" << (window.selected_team_is_team_0 != 0 ? "blue" : "orange") << "\\""',
+        "web stats window config always emits team",
+        errors,
+    )
 
     require_contains(
         plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -385,6 +385,86 @@ def stats_window_kind_controls(source: str) -> list[tuple[str, str, bool]]:
     return controls
 
 
+def stats_window_kind_details(source: str) -> dict[str, tuple[str, bool, bool, bool]]:
+    match = re.search(
+        r"SubtrActorPlugin::statsWindowKindControls\(\)\s+const\s+\{\s+return\s+\{\{"
+        r"(.*?)\}\};\s*\}",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError("missing statsWindowKindControls return block")
+
+    controls: dict[str, tuple[str, bool, bool, bool]] = {}
+    for control in re.finditer(
+        r'\{\s*UiStatsWindowKind::\w+,\s*"(?P<id>[^"]+)",\s*"(?P<label>[^"]+)",'
+        r'\s*"[^"]+",\s*(?:static_cast<[^>]+>\([^)]*\)|[^,]+),\s*'
+        r"(?P<scope_selector>true|false),\s*"
+        r"(?P<stat_picker>true|false),\s*"
+        r"(?P<web>true|false),\s*"
+        r"(?:true|false)\s*\}",
+        match.group(1),
+        re.DOTALL,
+    ):
+        controls[control.group("id")] = (
+            control.group("label"),
+            control.group("scope_selector") == "true",
+            control.group("stat_picker") == "true",
+            control.group("web") == "true",
+        )
+    if not controls:
+        raise AssertionError("could not parse statsWindowKindControls details")
+    return controls
+
+
+def web_stats_window_titles(source: str) -> dict[str, str]:
+    match = re.search(
+        r"function\s+getStatsWindowTitle\([^)]*\):\s*string\s*\{(?P<body>.*?)\n\}",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError("missing getStatsWindowTitle")
+    titles = {
+        item.group("id"): item.group("title")
+        for item in re.finditer(
+            r'case\s+"(?P<id>[^"]+)":\s*return\s+"(?P<title>[^"]+)";',
+            match.group("body"),
+        )
+    }
+    if not titles:
+        raise AssertionError("could not parse getStatsWindowTitle")
+    return titles
+
+
+def web_stats_window_scope_selector_ids(source: str) -> tuple[str, ...]:
+    match = re.search(
+        r"function\s+hasStatsWindowScopeSelector\([^)]*\):\s*boolean\s*\{\s*"
+        r"return\s+(?P<body>.*?);\s*\}",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError("missing hasStatsWindowScopeSelector")
+    return tuple(re.findall(r'kind\s*===\s*"([^"]+)"', match.group("body")))
+
+
+def web_stats_window_stat_picker_ids(source: str, kind_ids: tuple[str, ...]) -> tuple[str, ...]:
+    match = re.search(
+        r"function\s+hasStatsWindowStatPicker\([^)]*\):\s*boolean\s*\{\s*"
+        r"return\s+(?P<body>.*?);\s*\}",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError("missing hasStatsWindowStatPicker")
+    body = match.group("body")
+    excluded = set(re.findall(r'kind\s*!==\s*"([^"]+)"', body))
+    if excluded:
+        return tuple(kind_id for kind_id in kind_ids if kind_id not in excluded)
+    return tuple(re.findall(r'kind\s*===\s*"([^"]+)"', body))
+
+
 def main() -> int:
     rust_source = RUST_SOURCE.read_text(encoding="utf-8")
     plugin_source = PLUGIN_SOURCE.read_text(encoding="utf-8")
@@ -514,6 +594,48 @@ def main() -> int:
         errors.append(
             "web stats window kind order drifted from stats evaluation player: "
             f"expected={web_stats_window_kind_ids!r} actual={plugin_web_stats_window_kind_ids!r}"
+        )
+    plugin_stats_window_details = stats_window_kind_details(plugin_source)
+    web_stats_window_title_by_id = web_stats_window_titles(web_player_main_source)
+    plugin_web_stats_window_titles = tuple(
+        (kind_id, plugin_stats_window_details[kind_id][0])
+        for kind_id in plugin_web_stats_window_kind_ids
+    )
+    web_stats_window_titles_ordered = tuple(
+        (kind_id, web_stats_window_title_by_id[kind_id])
+        for kind_id in web_stats_window_kind_ids
+    )
+    if plugin_web_stats_window_titles != web_stats_window_titles_ordered:
+        errors.append(
+            "web stats window titles drifted from stats evaluation player: "
+            f"expected={web_stats_window_titles_ordered!r} "
+            f"actual={plugin_web_stats_window_titles!r}"
+        )
+    plugin_web_stats_scope_selector_ids = tuple(
+        kind_id
+        for kind_id in plugin_web_stats_window_kind_ids
+        if plugin_stats_window_details[kind_id][1]
+    )
+    web_stats_scope_selector_ids = web_stats_window_scope_selector_ids(web_player_main_source)
+    if plugin_web_stats_scope_selector_ids != web_stats_scope_selector_ids:
+        errors.append(
+            "web stats window scope-selector kinds drifted from stats evaluation player: "
+            f"expected={web_stats_scope_selector_ids!r} "
+            f"actual={plugin_web_stats_scope_selector_ids!r}"
+        )
+    plugin_web_stats_picker_ids = tuple(
+        kind_id
+        for kind_id in plugin_web_stats_window_kind_ids
+        if plugin_stats_window_details[kind_id][2]
+    )
+    web_stats_picker_ids = web_stats_window_stat_picker_ids(
+        web_player_main_source,
+        web_stats_window_kind_ids,
+    )
+    if plugin_web_stats_picker_ids != web_stats_picker_ids:
+        errors.append(
+            "web stats window stat-picker kinds drifted from stats evaluation player: "
+            f"expected={web_stats_picker_ids!r} actual={plugin_web_stats_picker_ids!r}"
         )
     web_launcher_stats_buttons = tuple(
         web_launcher_buttons(web_player_template_source, "data-create-stats-window")

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -941,6 +941,17 @@ def main() -> int:
         "launcher actions expose replay loading like the web player",
         errors,
     )
+    reject_contains(
+        plugin_source,
+        'if (ImGui::Button("Load Replay...", ImVec2{actionButtonWidth, 0.0f})) {\n'
+        "    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);\n"
+        "    resetReplayAnnotations();\n"
+        "    tickReplayAnnotations();\n"
+        "    hideLauncherWindow();\n"
+        "  }",
+        "plugin launcher closes after Load Replay action",
+        errors,
+    )
     require_contains(
         web_player_main_source,
         'renderModuleSummaryGroup("Timeline visualizations", timelineToggles)',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -688,6 +688,63 @@ def main() -> int:
         )
     require_contains(
         web_player_main_source,
+        'select.className = "stats-window-scope-select";',
+        "stats evaluation player scope selector class",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "const teamClass = getStatsWindowScopeTeamClass(statsWindow);\n"
+        "  if (teamClass) {\n"
+        "    select.classList.add(teamClass);\n"
+        "  }",
+        "stats evaluation player scope selector applies team accent class",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        ".stats-window-scope-select.team-blue,\n"
+        ".stats-window-scope-select.team-orange,\n"
+        ".stats-window-stat-target.team-blue,\n"
+        ".stats-window-stat-target.team-orange {\n"
+        "  border-color: var(--team-accent);\n"
+        "  box-shadow: inset 0.22rem 0 0 var(--team-accent);",
+        "stats evaluation player scope selector team accent",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "auto pushStatsScopeSelectorStyle = [](std::optional<LinearColor> teamColor) {\n"
+        "    ImGui::SetNextItemWidth(std::min(208.0f, ImGui::GetContentRegionAvail().x));",
+        "plugin stats scope selector uses bounded web-like width",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PushStyleColor(ImGuiCol_Border, accent);\n"
+        "    ImGui::PushStyleColor(\n"
+        "        ImGuiCol_FrameBg,\n"
+        "        ImVec4{accent.x * 0.18f, accent.y * 0.18f, accent.z * 0.18f, 0.58f});",
+        "plugin stats scope selector applies team accent frame",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const std::optional<LinearColor> selectedColor =\n"
+        "        selected ? std::make_optional(selected->is_team_0 != 0 ? LinearColor{80, 190, 255, 255}",
+        "plugin player stats scope selector derives selected team accent",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const int selectorStyleColors = pushStatsScopeSelectorStyle(selectedColor);\n"
+        "    const bool comboOpen = ImGui::BeginCombo(\n"
+        "        std::format(\"##stats-window-team-scope-{}\", window.id).c_str(),",
+        "plugin team stats scope selector wraps combo in team accent style",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         'queryInput.placeholder = "Search stats";',
         "stats evaluation player stats picker search placeholder",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1490,8 +1490,8 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::TextDisabled("Duration");\n  ImGui::Text("%.2fs", durationSeconds);',
-        "plugin playback duration always renders a numeric readout",
+        'renderWebDetailGridCell("Duration", std::format("{:.2f}s", durationSeconds));',
+        "plugin playback duration uses web-like detail grid readout",
         errors,
     )
     require_contains(
@@ -1699,8 +1699,8 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::Text("%s", recordingStatusReadout.c_str());',
-        "plugin recording status renders the web-like readout",
+        'renderWebDetailGridCell("Status", recordingStatusReadout);',
+        "plugin recording status renders the web-like detail grid readout",
         errors,
     )
     require_contains(
@@ -1849,13 +1849,10 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'auto renderAttachedCameraMetric = [&](const char *format, float value) {\n'
+        'auto attachedCameraMetric = [&](int precision, float value) {\n'
         "    if (!hasAttachedCamera) {\n"
-        '      ImGui::Text("--");\n'
-        "      return;\n"
-        "    }\n"
-        "    ImGui::Text(format, value);\n"
-        "  };",
+        '      return std::string{"--"};\n'
+        "    }\n",
         "plugin camera detail grid uses dash readouts without an attached camera",
         errors,
     )

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1174,11 +1174,25 @@ def main() -> int:
             errors,
         )
     require_contains(
-        plugin_source,
-        '"Live analysis graph",\n            liveAnalysis,\n            "launcher-plugin-tools"',
-        "plugin-specific live analysis toggle lives under launcher plugin tools",
+        web_player_template_source,
+        '<div id="module-settings" class="module-settings" hidden></div>',
+        "stats evaluation player launcher ends with module settings",
         errors,
     )
+    for plugin_only_launcher_surface in (
+        'ImGui::TreeNode("Plugin tools##launcher-plugin-tools")',
+        '"Live analysis graph",\n            liveAnalysis,\n            "launcher-plugin-tools"',
+        'ImGui::Button("Verify graph", ImVec2{pluginToolButtonWidth, 0.0f})',
+        'ImGui::Button("Open modules", ImVec2{pluginToolButtonWidth, 0.0f})',
+        'ImGui::BeginChild("launcher-graph-stats-modules", ImVec2{0.0f, 130.0f}, true);',
+        'renderLauncherWorkspaceControls();',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_launcher_surface,
+            "plugin-only launcher surface",
+            errors,
+        )
     reject_contains(
         plugin_source,
         '"Live analysis graph",\n          liveAnalysis,\n          "launcher-actions"',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1014,6 +1014,42 @@ def main() -> int:
         errors,
     )
     require_contains(
+        plugin_source,
+        'auto renderTimelineControls = [&]() {\n'
+        '    renderEventFilterModuleSummaryToggle("Backboard", "backboard", idSuffix, toggleWidth);\n'
+        "    renderBoolModuleSummaryToggle(\n"
+        '        "Possession",\n'
+        "        timelineRangePossessionEnabled,\n"
+        "        idSuffix,\n"
+        "        toggleWidth);\n"
+        '    renderEventFilterModuleSummaryToggle("50/50", "fifty_fifty", idSuffix, toggleWidth);',
+        "plugin launcher module summary starts with web timeline capability order",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        '    renderEventFilterModuleSummaryToggle("Whiff", "whiff", idSuffix, toggleWidth);\n'
+        "    renderBoolModuleSummaryToggle(\n"
+        '        "Boost pickup timeline",\n'
+        "        timelineRangeBoostEnabled,\n"
+        "        idSuffix,\n"
+        "        toggleWidth);\n"
+        '    renderEventFilterModuleSummaryToggle("Powerslide", "powerslide", idSuffix, toggleWidth);\n'
+        '    renderEventFilterModuleSummaryToggle("Bump", "bump", idSuffix, toggleWidth);\n'
+        "    if (includePluginControls) {\n"
+        '      renderEventFilterModuleSummaryToggle("Dodge refresh", "dodge_reset", idSuffix, toggleWidth);',
+        "plugin-only timeline shortcuts are outside the web-like launcher summary",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'auto renderTimelineControls = [&]() {\n'
+        '    renderEventFilterModuleSummaryToggle("Touch", "touch", idSuffix, toggleWidth);\n'
+        '    renderEventFilterModuleSummaryToggle("Dodge refresh", "dodge_reset", idSuffix, toggleWidth);',
+        "launcher module summary starts with plugin-only timeline shortcuts",
+        errors,
+    )
+    require_contains(
         web_player_main_source,
         'createStatsWindow(button.dataset.createStatsWindow as StatsWindowKind);',
         "stats evaluation player launcher creates stats windows",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1601,6 +1601,18 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        'appendUiEvent(UiEventRecord{\n      "goal",\n      "goal",',
+        "plugin sends goals to the web replay goal event source",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "pushGoalEventMessage(event);\n  pendingGoals.push_back(event);",
+        "plugin surfaces raw goal events before graph submission",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         'pushPlayerStatEventMessage(event);\n      pendingPlayerStatEvents.push_back(event);',
         "plugin surfaces inferred player stat events before graph submission",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2802,8 +2802,50 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'std::format(\n        "{}##mechanics-review-item",\n        title)',
-        "plugin mechanics review rows use web-like title labels without time prefix",
+        "auto renderMechanicsReviewItem = [](const std::string &title,\n"
+        "                                      const std::string &meta,\n"
+        "                                      bool active)",
+        "plugin mechanics review rows use a web-like two-column renderer",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::InvisibleButton("##mechanics-review-item", ImVec2{rowWidth, rowHeight})',
+        "plugin mechanics review rows keep full-row button behavior",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "drawList->AddRectFilled(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(bg), 6.0f);\n"
+        "    drawList->AddRect(rowMin, rowMax, ImGui::ColorConvertFloat4ToU32(border), 6.0f);",
+        "plugin mechanics review rows draw web-like button chrome",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "drawList->AddText(ImVec2{titleX, textY}, IM_COL32(237, 245, 250, 255), title.c_str());",
+        "plugin mechanics review rows render title in left column",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "drawList->AddText(ImVec2{metaX, textY}, IM_COL32(137, 164, 186, 255), metaText.c_str());",
+        "plugin mechanics review rows render metadata in right column",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const std::string meta = joinStrings(metaParts, \" · \");",
+        "plugin mechanics review rows join metadata before rendering",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (renderMechanicsReviewItem(title, meta, active)) {\n"
+        "      mechanicsReviewIndex = static_cast<int>(i);\n"
+        "      scheduleUiConfigAutosave();\n"
+        "    }",
+        "plugin mechanics review row activation updates selection like web",
         errors,
     )
     require_contains(
@@ -3095,10 +3137,21 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'joinStrings(metaParts, " · ")',
+        'const std::string meta = joinStrings(metaParts, " · ");',
         "plugin mechanics review row meta uses web-like dot separator",
         errors,
     )
+    for plugin_only_mechanics_review_row_surface in (
+        'std::format(\n        "{}##mechanics-review-item",\n        title)',
+        "ImGui::Selectable(label.c_str(), active)",
+        'ImGui::TextDisabled("%s", joinStrings(metaParts, " · ").c_str());',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_mechanics_review_row_surface,
+            "plugin mechanics review plugin-only flat row surface",
+            errors,
+        )
     require_contains(
         web_player_main_source,
         "function getStatsPlayerConfigSnapshot(): StatsPlayerConfig",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -357,6 +357,31 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        "placement.viewport_width > 0.0f ? placement.viewport_width : std::max(1.0f, displaySize.x)",
+        "singleton web placement viewport width is positive",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "placement.viewport_height > 0.0f ? placement.viewport_height\n"
+        "                                                                  : std::max(1.0f, displaySize.y)",
+        "singleton web placement viewport height is positive",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "window.viewport_width > 0.0f ? window.viewport_width : std::max(1.0f, displaySize.x)",
+        "stats web placement viewport width is positive",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "window.viewport_height > 0.0f ? window.viewport_height : std::max(1.0f, displaySize.y)",
+        "stats web placement viewport height is positive",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         "writePlacement(file, *window.placement, visible);",
         "plugin windows keep plugin placement shape",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -483,6 +483,49 @@ def main() -> int:
             errors,
         )
     require_contains(
+        web_player_main_source,
+        'empty.textContent = "Load a replay to show stats.";',
+        "stats evaluation player stats windows no-frame empty state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Text("Load a replay to show stats.");',
+        "plugin stats windows no-data empty state mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        'target ? definition.format(definition.read(target)) : "--"',
+        "stats evaluation player scoped stats render missing targets as dash rows",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "void SubtrActorPlugin::renderMissingStatsRows(UiStatsWindow &window)",
+        "plugin scoped stats render missing targets as dash rows",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::Text("--");',
+        "plugin scoped stats missing target value mirrors web dash",
+        errors,
+    )
+    for plugin_only_stats_window_empty_surface in (
+        'ImGui::Text("Waiting for selected player.");',
+        'ImGui::Text("Waiting for sampled players.");',
+        'ImGui::TextWrapped("Start live analysis or load replay stats to show team stats.");',
+        'ImGui::Columns(3, "player-stat-rows", false);',
+        'ImGui::Columns(3, "team-stat-rows", false);',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_stats_window_empty_surface,
+            "plugin stats window table/waiting surface",
+            errors,
+        )
+    require_contains(
         web_player_template_source,
         '<input id="skip-post-goal-transitions" type="checkbox" checked />',
         "stats evaluation player default skips post-goal resets",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1375,13 +1375,37 @@ def main() -> int:
     )
     require_contains(
         web_player_template_source,
+        "<span>Swivel</span>",
+        "stats evaluation player camera swivel label",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderCustomSlider("Swivel", cameraCustomSwivelSpeed, 1.0f, 10.0f, "%.1f");',
+        "plugin camera swivel label mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_template_source,
+        "<span>Transition</span>",
+        "stats evaluation player camera transition label",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'renderCustomSlider(\n        "Transition",\n        cameraCustomTransitionSpeed,\n        0.5f,\n        2.0f,\n        "%.2f");',
+        "plugin camera transition label mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_template_source,
         '<input id="ball-cam" type="checkbox" disabled />',
         "stats evaluation player camera ball-cam toggle",
         errors,
     )
     require_contains(
         plugin_source,
-        'renderCustomSlider(\n        "Transition speed",\n        cameraCustomTransitionSpeed,\n        0.5f,\n        2.0f,\n        "%.2f");\n  }\n\n  bool nextBallCamEnabled = cameraBallCamEnabled;\n  pushCameraDisabledStyle(!hasAttachedCamera);\n  const bool ballCamChanged = ImGui::Checkbox("Ball cam", &nextBallCamEnabled);',
+        'renderCustomSlider(\n        "Transition",\n        cameraCustomTransitionSpeed,\n        0.5f,\n        2.0f,\n        "%.2f");\n  }\n\n  bool nextBallCamEnabled = cameraBallCamEnabled;\n  pushCameraDisabledStyle(!hasAttachedCamera);\n  const bool ballCamChanged = ImGui::Checkbox("Ball cam", &nextBallCamEnabled);',
         "plugin camera ball-cam toggle follows custom settings controls like web",
         errors,
     )
@@ -1391,6 +1415,8 @@ def main() -> int:
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "READOUT");',
         'ImGui::Button("Open player stats")',
         'ImGui::Checkbox("Custom settings", &nextCustomSettingsEnabled)',
+        'renderCustomSlider("Swivel speed", cameraCustomSwivelSpeed',
+        'renderCustomSlider(\n        "Transition speed",',
         'ImGui::Text("%.0f", fov);',
         'ImGui::Text("%.0f", height);',
         'ImGui::Text("%.1f", pitch);',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1341,6 +1341,24 @@ def main() -> int:
             f"plugin boost pickup filter label {boost_filter_label}",
             errors,
         )
+    require_contains(
+        web_player_boost_pickup_filters_source,
+        'optionText.textContent = `${player.name} (${player.isTeamZero ? "Blue" : "Orange"})`;',
+        "stats evaluation player boost pickup player labels include team",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const std::string label = std::format(\n          "{} ({})##boost-pickup-player-{}",',
+        "plugin boost pickup player labels include team like web",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'std::format(\n          "{}##boost-pickup-player-{}",\n          playerLabel(player.player_index, player.is_team_0),',
+        "plugin boost pickup player labels use generic player label without team suffix",
+        errors,
+    )
     for plugin_only_boost_surface in (
         'ImGui::Text("Pickup labels: %s", pickupReadout.c_str());',
         'ImGui::Text("Known pads: %zu", boostPadIds.size());',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -20,6 +20,28 @@ PLUGIN_SOURCE = REPO_ROOT / "bakkesmod/SubtrActorPlugin.cpp"
 PLUGIN_HEADER = REPO_ROOT / "bakkesmod/SubtrActorPlugin.h"
 ABI_HEADER = REPO_ROOT / "crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h"
 
+WEB_SINGLETON_WINDOW_IDS = (
+    "camera",
+    "scoreboard",
+    "playback",
+    "recording",
+    "mechanics",
+    "event-playlist",
+    "mechanics-review",
+    "replay-loading",
+    "boost-pickups",
+    "touch-controls",
+)
+
+WEB_STATS_WINDOW_KIND_IDS = (
+    "player",
+    "team",
+    "all-players",
+    "all-teams",
+    "goals-overview",
+    "ad-hoc",
+)
+
 
 @dataclass(frozen=True)
 class EventFamily:
@@ -191,6 +213,61 @@ def require_contains(source: str, needle: str, label: str, errors: list[str]) ->
         errors.append(f"missing {label}: {needle}")
 
 
+def singleton_window_controls(source: str) -> list[tuple[str, bool, int]]:
+    match = re.search(
+        r"return\s+\{\{(.*?)\}\};\s*\}\s*\n\s*std::vector<SubtrActorPlugin::SingletonWindowControl>",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError("missing singletonWindowControls return block")
+
+    controls: list[tuple[str, bool, int]] = []
+    for control in re.finditer(
+        r'\{\s*"[^"]+",\s*"(?P<id>[^"]+)",\s*"[^"]+",\s*"[^"]+",\s*'
+        r"(?P<web>true|false),\s*(?P<order>\d+),",
+        match.group(1),
+        re.DOTALL,
+    ):
+        controls.append(
+            (
+                control.group("id"),
+                control.group("web") == "true",
+                int(control.group("order")),
+            )
+        )
+    if not controls:
+        raise AssertionError("could not parse singletonWindowControls")
+    return controls
+
+
+def stats_window_kind_controls(source: str) -> list[tuple[str, bool]]:
+    match = re.search(
+        r"SubtrActorPlugin::statsWindowKindControls\(\)\s+const\s+\{\s+return\s+\{\{"
+        r"(.*?)\}\};\s*\}",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError("missing statsWindowKindControls return block")
+
+    controls: list[tuple[str, bool]] = []
+    for control in re.finditer(
+        r'\{\s*UiStatsWindowKind::\w+,\s*"(?P<id>[^"]+)",\s*"[^"]+",\s*"[^"]+",\s*'
+        r"(?:static_cast<[^>]+>\([^)]*\)|[^,]+),\s*"
+        r"(?P<scope_selector>true|false),\s*"
+        r"(?P<stat_picker>true|false),\s*"
+        r"(?P<web>true|false),\s*"
+        r"(?P<default_window>true|false)\s*\}",
+        match.group(1),
+        re.DOTALL,
+    ):
+        controls.append((control.group("id"), control.group("web") == "true"))
+    if not controls:
+        raise AssertionError("could not parse statsWindowKindControls")
+    return controls
+
+
 def main() -> int:
     rust_source = RUST_SOURCE.read_text(encoding="utf-8")
     plugin_source = PLUGIN_SOURCE.read_text(encoding="utf-8")
@@ -214,6 +291,53 @@ def main() -> int:
                 f"registry mismatch {rust_name} != {cpp_name}: "
                 f"Rust={rust_values!r} C++={cpp_values!r}"
             )
+
+    web_window_ids = tuple(
+        window_id
+        for window_id, web_config, _ in sorted(
+            singleton_window_controls(plugin_source),
+            key=lambda control: (control[2], control[0]),
+        )
+        if web_config
+    )
+    if web_window_ids != WEB_SINGLETON_WINDOW_IDS:
+        errors.append(
+            "web singleton window order drifted from stats evaluation player: "
+            f"expected={WEB_SINGLETON_WINDOW_IDS!r} actual={web_window_ids!r}"
+        )
+
+    web_stats_window_kind_ids = tuple(
+        kind_id for kind_id, web_config in stats_window_kind_controls(plugin_source) if web_config
+    )
+    if web_stats_window_kind_ids != WEB_STATS_WINDOW_KIND_IDS:
+        errors.append(
+            "web stats window kind order drifted from stats evaluation player: "
+            f"expected={WEB_STATS_WINDOW_KIND_IDS!r} actual={web_stats_window_kind_ids!r}"
+        )
+
+    require_contains(
+        plugin_source,
+        "constexpr ImGuiWindowFlags UI_FLOATING_WINDOW_FLAGS",
+        "managed floating window flags",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "UI_FLOATING_WINDOW_FLAGS =\n"
+        "    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse |\n"
+        "    ImGuiWindowFlags_NoSavedSettings;",
+        "managed floating windows opt out of implicit ImGui persistence",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "scoreboardFlags =\n"
+        "      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize |\n"
+        "      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse |\n"
+        "      ImGuiWindowFlags_NoSavedSettings;",
+        "scoreboard opts out of implicit ImGui persistence",
+        errors,
+    )
 
     required_event_fields = set(rust_array(rust_source, "REQUIRED_EVENT_HISTORY_FIELD_NAMES"))
     covered_event_fields = {family.graph_field for family in EVENT_FAMILIES}

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -213,6 +213,11 @@ def require_contains(source: str, needle: str, label: str, errors: list[str]) ->
         errors.append(f"missing {label}: {needle}")
 
 
+def reject_contains(source: str, needle: str, label: str, errors: list[str]) -> None:
+    if needle in source:
+        errors.append(f"unexpected {label}: {needle}")
+
+
 def singleton_window_controls(source: str) -> list[tuple[str, bool, int]]:
     match = re.search(
         r"return\s+\{\{(.*?)\}\};\s*\}\s*\n\s*std::vector<SubtrActorPlugin::SingletonWindowControl>",
@@ -348,6 +353,30 @@ def main() -> int:
         "      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse |\n"
         "      ImGuiWindowFlags_NoSavedSettings;",
         "scoreboard opts out of implicit ImGui persistence",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "ImGui::SetNextWindowFocus();\n"
+        "      placement.z_index = nextUiWindowZIndex++;\n"
+        "      placement.pending_focus = false;",
+        "singleton pending-focus render path bumps z-index",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "ImGui::SetNextWindowFocus();\n"
+        "      scoreboardPlacement.z_index = nextUiWindowZIndex++;\n"
+        "      scoreboardPlacement.pending_focus = false;",
+        "scoreboard pending-focus render path bumps z-index",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "ImGui::SetNextWindowFocus();\n"
+        "    window.z_index = nextUiWindowZIndex++;\n"
+        "    window.pending_focus = false;",
+        "stats pending-focus render path bumps z-index",
         errors,
     )
 

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2047,6 +2047,18 @@ def main() -> int:
         "plugin event playlist row title falls back to source label like web",
         errors,
     )
+    require_contains(
+        plugin_source,
+        'const std::string itemLabel = std::format("{}##event-playlist-item", eventLabel);',
+        "plugin event playlist row title excludes time like web title column",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("%s", timeLabel.c_str());\n    ImGui::SameLine(64.0f);',
+        "plugin event playlist renders time as a separate column",
+        errors,
+    )
     reject_contains(
         plugin_source,
         "const std::string eventLabel = event.label.empty() ? event.type : event.label;",
@@ -2129,6 +2141,12 @@ def main() -> int:
         plugin_source,
         'std::format("All ({})", recentUiEvents.size()).c_str()',
         "plugin event playlist all action includes event count",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'std::format("{}  {}##event-playlist-item", timeLabel, eventLabel)',
+        "plugin event playlist row title prefixes time",
         errors,
     )
     for plugin_only_event_playlist_filter_surface in (

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1758,6 +1758,12 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        'jsonPropertyExists(*overlays, "pluginRenderEffects")',
+        "plugin-only render effects import uses separate plugin config field",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         'if (jsonPropertyExists(*boostConfig, "playerIds")) {',
         "web boost playerIds import uses JSON parser",
         errors,
@@ -1806,6 +1812,30 @@ def main() -> int:
         "      writeMechanicFilterId(token);\n"
         "    }",
         "web mechanics config exports concrete mechanic filters for all-mechanics selection",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'writeOverlayId(\n      "mechanics",\n      hudOverlayEnabled && cvarBool("subtr_actor_overlay_mechanics_enabled", true));',
+        "web renderEffects exports plugin-only broad mechanics id",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'writeOverlayId(\n      "team",\n      hudOverlayEnabled && cvarBool("subtr_actor_overlay_team_events_enabled", true));',
+        "web renderEffects exports plugin-only broad team id",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'writeOverlayId(\n      "goal_context",\n      hudOverlayEnabled && cvarBool("subtr_actor_overlay_goal_context_enabled", true));',
+        "web renderEffects exports plugin-only broad goal-context id",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'file << "    \\"pluginRenderEffects\\": [";',
+        "plugin-only render effects export uses separate plugin config field",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -166,6 +166,10 @@ REQUIRED_PLUGIN_ABI_EXPORTS = (
     ("subtr_actor_bakkesmod_replay_annotation_count", "replayAnnotationCount"),
     ("subtr_actor_bakkesmod_replay_annotation_player_count", "replayAnnotationPlayerCount"),
     ("subtr_actor_bakkesmod_write_replay_annotation_players", "writeReplayAnnotationPlayers"),
+    (
+        "subtr_actor_bakkesmod_write_replay_annotation_frame_players",
+        "writeReplayAnnotationFramePlayers",
+    ),
     ("subtr_actor_bakkesmod_replay_annotation_score_at_time", "replayAnnotationScoreAtTime"),
     ("subtr_actor_bakkesmod_poll_replay_annotations", "pollReplayAnnotations"),
 )
@@ -2177,6 +2181,18 @@ def main() -> int:
         plugin_source,
         "replayAnnotationScoreAtTime(replayAnnotations, replayTime, &score)",
         "plugin scoreboard follows replay annotation score at current playback time",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "writeReplayAnnotationFramePlayers(\n        replayAnnotations,\n        replayTime,",
+        "plugin replay annotations update sampled players from current replay stats frame",
+        errors,
+    )
+    require_contains(
+        rust_source,
+        "match_goals: player.core.goals,",
+        "replay annotation frame players expose core goals to plugin stats windows",
         errors,
     )
     reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -487,6 +487,18 @@ def main() -> int:
         "stats window import falls back to present web config",
         errors,
     )
+    require_contains(
+        plugin_source,
+        'std::optional<std::string> placement = parseJsonObjectProperty(object, "placement");',
+        "window array import can default missing web placement",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'if (!webConfig) {\n          continue;\n        }\n        placement = R"({"x":8,"y":8,"viewport":{"width":1,"height":1},"visible":true})";',
+        "web singleton window import mirrors normalizePlacement defaults",
+        errors,
+    )
     reject_contains(
         plugin_source,
         'if (statsWindowObjects.empty()) {\n    statsWindowObjects = parseJsonObjectArrayProperty(json, "statsWindows");\n  }',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1349,6 +1349,18 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        'empty.textContent = "No event types selected.";',
+        "stats evaluation player event playlist no-selection empty state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextDisabled("No event types selected.");',
+        "plugin event playlist no-selection empty state mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         'allButton.textContent = "All";',
         "stats evaluation player event playlist all action label",
         errors,
@@ -1505,6 +1517,7 @@ def main() -> int:
         'ImGui::TextWrapped("Status: %s", eventPlaylistStatus.c_str());',
         "eventPlaylistStatus",
         '"event_playlist_status"',
+        "No events match the selected playlist filters.",
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -762,6 +762,30 @@ def main() -> int:
         "stats evaluation player playback config snapshot is explicit",
         errors,
     )
+    require_contains(
+        web_player_main_source,
+        "playbackRate.disabled = !enabled;",
+        "stats evaluation player disables playback rate without transport",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool playbackRateDisabled = !transportEnabled;\n"
+        "  pushPlaybackDisabledStyle(playbackRateDisabled);\n"
+        "  ImGui::SetNextItemWidth(96.0f);\n"
+        "  const bool playbackRateOpen =\n"
+        '      ImGui::BeginCombo("##playback-rate", playbackRateLabels[playbackRateIndex]);',
+        "plugin playback rate selector is disabled with transport",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "if (playbackRateDisabled) {\n"
+        "      ImGui::CloseCurrentPopup();\n"
+        "      ImGui::EndCombo();",
+        "plugin playback rate disabled selector cannot remain open",
+        errors,
+    )
     reject_contains(
         plugin_source,
         "playbackStatus",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2030,6 +2030,37 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        'return item.label ?? item.meta?.mechanicLabel ?? `Review item ${index + 1}`;',
+        "stats evaluation player mechanics review item labels have mechanic fallback",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "current->label.empty() ? eventTypeDisplayLabel(current->type)\n"
+        "                               : current->label;",
+        "plugin mechanics review current title formats unlabeled mechanics",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const std::string title = event.label.empty() ? eventTypeDisplayLabel(event.type) : event.label;",
+        "plugin mechanics review row title formats unlabeled mechanics",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'ImGui::TextWrapped("%s", current == nullptr ? "No candidate selected" : current->label.c_str());',
+        "plugin mechanics review current title can render an empty raw label",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "const std::string title = event.label.empty() ? event.type : event.label;",
+        "plugin mechanics review row title falls back to raw event type",
+        errors,
+    )
+    require_contains(
         web_player_template_source,
         '<dl class="mechanics-review-fields">',
         "stats evaluation player mechanics review current item field grid",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1788,6 +1788,28 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        "const bool hasSelectedMechanicFilter = std::any_of(\n"
+        "          selectedFilters.begin(),\n"
+        "          selectedFilters.end(),",
+        "web mechanic timeline event import enables mechanic playlist group",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'writeOverlayId("mechanics", eventPlaylistMechanicsEnabled);',
+        "web timelineEvents exports plugin-only broad mechanics id",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "for (const char *token : MECHANIC_FILTER_TOKENS) {\n"
+        "      writeMechanicFilterId(token);\n"
+        "    }",
+        "web mechanics config exports concrete mechanic filters for all-mechanics selection",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         'std::string statId = statsWindowObjectsFromWeb\n                               ? parseJsonStringProperty(entryObject, "statId").value_or("")\n                               : parseJsonStringProperty(entryObject, "stat_id").value_or("");',
         "web selected stat import only reads statId",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -445,6 +445,36 @@ def main() -> int:
         "launcher actions expose replay loading like the web player",
         errors,
     )
+    for label, plugin_needle in (
+        ("Possession", '"Possession",\n        timelineRangePossessionEnabled'),
+        ("Half control", '"Half control",\n        timelineRangePressureEnabled'),
+        ("Rush", '"Rush", timelineRangeRushEnabled'),
+        ("Position zones", '"Position zones",\n        timelineRangeAbsolutePositioningEnabled'),
+    ):
+        require_contains(
+            web_player_main_source,
+            f'"{label}"',
+            f"stats evaluation player module summary label {label}",
+            errors,
+        )
+        require_contains(
+            plugin_source,
+            plugin_needle,
+            f"plugin module summary label {label}",
+            errors,
+        )
+    for stale_label in (
+        '"Possession timeline"',
+        '"Half control timeline"',
+        '"Rush timeline"',
+        '"Position zones timeline"',
+    ):
+        reject_contains(
+            plugin_source,
+            stale_label,
+            "plugin module summary stale timeline suffix label",
+            errors,
+        )
     require_contains(
         plugin_source,
         '"Live analysis graph",\n            liveAnalysis,\n            "launcher-plugin-tools"',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -21,6 +21,7 @@ PLUGIN_HEADER = REPO_ROOT / "bakkesmod/SubtrActorPlugin.h"
 ABI_HEADER = REPO_ROOT / "crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h"
 WEB_PLAYER_CONFIG_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/playerConfig.ts"
 WEB_PLAYER_MAIN_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/main.ts"
+WEB_PLAYER_TEMPLATE_SOURCE = REPO_ROOT / "js/stat-evaluation-player/src/appTemplate.ts"
 
 
 @dataclass(frozen=True)
@@ -210,6 +211,18 @@ def ts_type_alias_strings(source: str, name: str) -> list[str]:
     return quoted_strings(match.group(1))
 
 
+def web_launcher_buttons(source: str, attribute: str) -> list[tuple[str, str]]:
+    return [
+        (match.group("id"), match.group("label").strip())
+        for match in re.finditer(
+            rf'<button\b(?=[^>]*\b{re.escape(attribute)}="(?P<id>[^"]+)")[^>]*>'
+            r"(?P<label>[^<]+)</button>",
+            source,
+            re.DOTALL,
+        )
+    ]
+
+
 def require_contains(source: str, needle: str, label: str, errors: list[str]) -> None:
     if needle not in source:
         errors.append(f"missing {label}: {needle}")
@@ -220,7 +233,7 @@ def reject_contains(source: str, needle: str, label: str, errors: list[str]) -> 
         errors.append(f"unexpected {label}: {needle}")
 
 
-def singleton_window_controls(source: str) -> list[tuple[str, bool, int]]:
+def singleton_window_controls(source: str) -> list[tuple[str, str, bool, int]]:
     match = re.search(
         r"return\s+\{\{(.*?)\}\};\s*\}\s*\n\s*std::vector<SubtrActorPlugin::SingletonWindowControl>",
         source,
@@ -229,9 +242,9 @@ def singleton_window_controls(source: str) -> list[tuple[str, bool, int]]:
     if not match:
         raise AssertionError("missing singletonWindowControls return block")
 
-    controls: list[tuple[str, bool, int]] = []
+    controls: list[tuple[str, str, bool, int]] = []
     for control in re.finditer(
-        r'\{\s*"[^"]+",\s*"(?P<id>[^"]+)",\s*"[^"]+",\s*"[^"]+",\s*'
+        r'\{\s*"(?P<label>[^"]+)",\s*"(?P<id>[^"]+)",\s*"[^"]+",\s*"[^"]+",\s*'
         r"(?P<web>true|false),\s*(?P<order>\d+),",
         match.group(1),
         re.DOTALL,
@@ -239,6 +252,7 @@ def singleton_window_controls(source: str) -> list[tuple[str, bool, int]]:
         controls.append(
             (
                 control.group("id"),
+                control.group("label"),
                 control.group("web") == "true",
                 int(control.group("order")),
             )
@@ -248,7 +262,7 @@ def singleton_window_controls(source: str) -> list[tuple[str, bool, int]]:
     return controls
 
 
-def stats_window_kind_controls(source: str) -> list[tuple[str, bool]]:
+def stats_window_kind_controls(source: str) -> list[tuple[str, str, bool]]:
     match = re.search(
         r"SubtrActorPlugin::statsWindowKindControls\(\)\s+const\s+\{\s+return\s+\{\{"
         r"(.*?)\}\};\s*\}",
@@ -258,9 +272,9 @@ def stats_window_kind_controls(source: str) -> list[tuple[str, bool]]:
     if not match:
         raise AssertionError("missing statsWindowKindControls return block")
 
-    controls: list[tuple[str, bool]] = []
+    controls: list[tuple[str, str, bool]] = []
     for control in re.finditer(
-        r'\{\s*UiStatsWindowKind::\w+,\s*"(?P<id>[^"]+)",\s*"[^"]+",\s*"[^"]+",\s*'
+        r'\{\s*UiStatsWindowKind::\w+,\s*"(?P<id>[^"]+)",\s*"[^"]+",\s*"(?P<label>[^"]+)",\s*'
         r"(?:static_cast<[^>]+>\([^)]*\)|[^,]+),\s*"
         r"(?P<scope_selector>true|false),\s*"
         r"(?P<stat_picker>true|false),\s*"
@@ -269,7 +283,9 @@ def stats_window_kind_controls(source: str) -> list[tuple[str, bool]]:
         match.group(1),
         re.DOTALL,
     ):
-        controls.append((control.group("id"), control.group("web") == "true"))
+        controls.append(
+            (control.group("id"), control.group("label"), control.group("web") == "true")
+        )
     if not controls:
         raise AssertionError("could not parse statsWindowKindControls")
     return controls
@@ -282,6 +298,7 @@ def main() -> int:
     abi_header = ABI_HEADER.read_text(encoding="utf-8")
     web_player_config_source = WEB_PLAYER_CONFIG_SOURCE.read_text(encoding="utf-8")
     web_player_main_source = WEB_PLAYER_MAIN_SOURCE.read_text(encoding="utf-8")
+    web_player_template_source = WEB_PLAYER_TEMPLATE_SOURCE.read_text(encoding="utf-8")
     cpp_combined = plugin_header + "\n" + plugin_source
     errors: list[str] = []
 
@@ -314,27 +331,49 @@ def main() -> int:
         ts_type_alias_strings(web_player_config_source, "StatsWindowKind")
     )
 
-    web_window_ids = tuple(
-        window_id
-        for window_id, web_config, _ in sorted(
+    plugin_web_window_controls = tuple(
+        (window_id, label)
+        for window_id, label, web_config, _ in sorted(
             singleton_window_controls(plugin_source),
-            key=lambda control: (control[2], control[0]),
+            key=lambda control: (control[3], control[0]),
         )
         if web_config
     )
+    web_window_ids = tuple(window_id for window_id, _ in plugin_web_window_controls)
     if web_window_ids != web_singleton_window_ids:
         errors.append(
             "web singleton window order drifted from stats evaluation player: "
             f"expected={web_singleton_window_ids!r} actual={web_window_ids!r}"
         )
+    web_launcher_window_buttons = tuple(
+        web_launcher_buttons(web_player_template_source, "data-window-toggle")
+    )
+    if plugin_web_window_controls != web_launcher_window_buttons:
+        errors.append(
+            "web singleton launcher labels drifted from stats evaluation player: "
+            f"expected={web_launcher_window_buttons!r} actual={plugin_web_window_controls!r}"
+        )
 
+    plugin_web_stats_window_controls = tuple(
+        (kind_id, label)
+        for kind_id, label, web_config in stats_window_kind_controls(plugin_source)
+        if web_config
+    )
     plugin_web_stats_window_kind_ids = tuple(
-        kind_id for kind_id, web_config in stats_window_kind_controls(plugin_source) if web_config
+        kind_id for kind_id, _ in plugin_web_stats_window_controls
     )
     if plugin_web_stats_window_kind_ids != web_stats_window_kind_ids:
         errors.append(
             "web stats window kind order drifted from stats evaluation player: "
             f"expected={web_stats_window_kind_ids!r} actual={plugin_web_stats_window_kind_ids!r}"
+        )
+    web_launcher_stats_buttons = tuple(
+        web_launcher_buttons(web_player_template_source, "data-create-stats-window")
+    )
+    if plugin_web_stats_window_controls != web_launcher_stats_buttons:
+        errors.append(
+            "web stats launcher labels drifted from stats evaluation player: "
+            f"expected={web_launcher_stats_buttons!r} actual={plugin_web_stats_window_controls!r}"
         )
     require_contains(
         plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -345,6 +345,18 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        "auto writeStatsPlayerStatsWindowPlacement = [](",
+        "dedicated stats window web placement writer",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "writeStatsPlayerStatsWindowPlacement(file, window);",
+        "stats windows use web placement shape",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         "writePlacement(file, *window.placement, visible);",
         "plugin windows keep plugin placement shape",
         errors,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2054,6 +2054,25 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_template_source,
+        '<div id="mechanics-review-status" class="mechanics-review-status">\n                Load a review playlist.\n              </div>',
+        "stats evaluation player mechanics review initial status text",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        ': candidates.empty()             ? "Load a review playlist."\n'
+        '                                       : "Loaded review playlist.";',
+        "plugin mechanics review renders web-like default status text",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextWrapped("%s", statusReadout.c_str());',
+        "plugin mechanics review status is always visible like web",
+        errors,
+    )
+    require_contains(
         web_player_main_source,
         "mechanicsReviewPrev.disabled = !review || review.loading || review.currentIndex <= 0;",
         "stats evaluation player mechanics review disables unavailable previous action",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -166,6 +166,7 @@ REQUIRED_PLUGIN_ABI_EXPORTS = (
     ("subtr_actor_bakkesmod_replay_annotation_count", "replayAnnotationCount"),
     ("subtr_actor_bakkesmod_replay_annotation_player_count", "replayAnnotationPlayerCount"),
     ("subtr_actor_bakkesmod_write_replay_annotation_players", "writeReplayAnnotationPlayers"),
+    ("subtr_actor_bakkesmod_replay_annotation_score_at_time", "replayAnnotationScoreAtTime"),
     ("subtr_actor_bakkesmod_poll_replay_annotations", "pollReplayAnnotations"),
 )
 
@@ -2116,6 +2117,18 @@ def main() -> int:
         "      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse |\n"
         "      ImGuiWindowFlags_NoSavedSettings;",
         "scoreboard opts out of implicit ImGui persistence",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "renderScoreboard(state.frameIndex);",
+        "stats evaluation player scoreboard follows current replay frame",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "replayAnnotationScoreAtTime(replayAnnotations, replayTime, &score)",
+        "plugin scoreboard follows replay annotation score at current playback time",
         errors,
     )
     reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -826,8 +826,20 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'ImGui::InputInt("##recording-fps", &nextRecordingFps, 1, 10)',
+        'ImGui::InputInt(\n      "##recording-fps",',
         "plugin recording FPS uses web-like numeric input",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "recordingFps.disabled = isRecording;",
+        "stats evaluation player disables recording FPS while recording",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "recordingSettingsLocked ? ImGuiInputTextFlags_ReadOnly : 0",
+        "plugin recording FPS input is read-only while recording",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1398,6 +1398,7 @@ def main() -> int:
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Touch markers");',
         'ImGui::Text("Touch decay");',
         'ImGui::TextDisabled("Keep each marker visible after the touch");',
+        '"##touch-marker-decay-seconds", &touchMarkerDecaySeconds, 1.0f, 10.0f, "%.1fs"',
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Overlay");',
         'ImGui::Text("Touch mode");',
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "Stat display");',
@@ -1418,6 +1419,7 @@ def main() -> int:
         'ImGui::Button("Show movement")',
         'ImGui::Button("Open touch stats")',
         'ImGui::Button("Inspect touch nodes")',
+        '"Marker decay seconds", &touchMarkerDecaySeconds',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1622,9 +1622,21 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "return sources.sort((left, right) => left.label.localeCompare(right.label));",
+        "stats evaluation player Events window sorts source rows by label",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'std::format(\n        "{}   {} {}##event-sources-{}",\n        option.label,\n        enabled ? "On" : "Off",\n        count,\n        option.value)',
         "plugin Events window source rows expose web-like state count readout",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "std::sort(\n      displaySources.begin(),\n      displaySources.end(),\n      [](const DisplaySource &left, const DisplaySource &right) {\n        return std::string_view{left.option->label} < std::string_view{right.option->label};\n      });",
+        "plugin Events window sorts source rows by label like web",
         errors,
     )
     require_contains(
@@ -1670,6 +1682,12 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "return [...getEventPlaylistReplaySources(ctx), ...eventSources];",
+        "stats evaluation player event playlist keeps replay goal source before event sources",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'eventPlaylistSourceFilter = "default";',
         "plugin replay review playlist starts from web-like default source selection",
@@ -1692,6 +1710,14 @@ def main() -> int:
         plugin_source,
         '{"demo", "Demos", "Replay"}',
         "plugin event playlist demo source label mirrors web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'if (group == "Replay" && std::string_view{option.value} == "goal") {\n'
+        "      return std::tuple{groupRank, 0, std::string_view{option.label}};\n"
+        "    }",
+        "plugin event playlist keeps replay goal source before other event sources",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -211,6 +211,35 @@ def ts_type_alias_strings(source: str, name: str) -> list[str]:
     return quoted_strings(match.group(1))
 
 
+def ts_interface_fields(source: str, name: str) -> tuple[str, ...]:
+    match = re.search(
+        rf"export\s+interface\s+{re.escape(name)}\s*\{{(?P<body>.*?)\n\}}",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(f"missing TypeScript interface {name}")
+    fields = []
+    for line in match.group("body").splitlines():
+        field = re.search(r"\breadonly\s+([A-Za-z0-9_]+)\??\s*:", line)
+        if field:
+            fields.append(field.group(1))
+    if not fields:
+        raise AssertionError(f"could not parse TypeScript interface {name}")
+    return tuple(fields)
+
+
+def cpp_lambda_body(source: str, name: str) -> str:
+    match = re.search(
+        rf"auto\s+{re.escape(name)}\s*=\s*\[\]\((?P<args>.*?)\)\s*\{{(?P<body>.*?)\n\s*\}};",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(f"missing C++ lambda {name}")
+    return match.group("body")
+
+
 def web_launcher_buttons(source: str, attribute: str) -> list[tuple[str, str]]:
     return [
         (match.group("id"), match.group("label").strip())
@@ -330,6 +359,17 @@ def main() -> int:
     web_stats_window_kind_ids = tuple(
         ts_type_alias_strings(web_player_config_source, "StatsWindowKind")
     )
+    web_window_placement_fields = ts_interface_fields(
+        web_player_config_source,
+        "WindowPlacementConfig",
+    )
+    expected_web_window_placement_fields = ("x", "y", "viewport", "zIndex", "visible")
+    if web_window_placement_fields != expected_web_window_placement_fields:
+        errors.append(
+            "stats evaluation player WindowPlacementConfig fields changed: "
+            f"expected={expected_web_window_placement_fields!r} "
+            f"actual={web_window_placement_fields!r}"
+        )
 
     plugin_web_window_controls = tuple(
         (window_id, label)
@@ -442,6 +482,37 @@ def main() -> int:
         "plugin windows keep plugin placement shape",
         errors,
     )
+    web_singleton_placement_writer = cpp_lambda_body(plugin_source, "writeStatsPlayerPlacement")
+    web_stats_placement_writer = cpp_lambda_body(
+        plugin_source,
+        "writeStatsPlayerStatsWindowPlacement",
+    )
+    for writer_name, writer_source in (
+        ("singleton web placement writer", web_singleton_placement_writer),
+        ("stats window web placement writer", web_stats_placement_writer),
+    ):
+        for field in web_window_placement_fields:
+            require_contains(
+                writer_source,
+                f'\\"{field}\\"',
+                f"{writer_name} emits WindowPlacementConfig.{field}",
+                errors,
+            )
+        for legacy_field in (
+            "has_placement",
+            '\\"viewport_width\\"',
+            '\\"viewport_height\\"',
+            "placement.width",
+            "placement.height",
+            "window.width",
+            "window.height",
+        ):
+            reject_contains(
+                writer_source,
+                legacy_field,
+                f"{writer_name} emits plugin-only placement field",
+                errors,
+            )
     require_contains(
         plugin_source,
         'std::format("##stats-window-player-scope-{}", window.id).c_str()',

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2037,15 +2037,35 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        "current->label.empty() ? eventTypeDisplayLabel(current->type)\n"
-        "                               : current->label;",
-        "plugin mechanics review current title formats unlabeled mechanics",
+        'return std::format("Review item {}", index + 1);',
+        "plugin mechanics review item labels have review-item fallback",
         errors,
     )
     require_contains(
         plugin_source,
-        "const std::string title = event.label.empty() ? eventTypeDisplayLabel(event.type) : event.label;",
+        "mechanicsReviewItemTitle(\n"
+        "                               *current,\n"
+        "                               static_cast<size_t>(mechanicsReviewIndex))",
+        "plugin mechanics review current title uses shared web-like item label fallback",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const std::string title = mechanicsReviewItemTitle(event, i);",
         "plugin mechanics review row title formats unlabeled mechanics",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "current->label.empty() ? eventTypeDisplayLabel(current->type)\n"
+        "                               : current->label;",
+        "plugin mechanics review current title omits review item fallback",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        "const std::string title = event.label.empty() ? eventTypeDisplayLabel(event.type) : event.label;",
+        "plugin mechanics review row title omits review item fallback",
         errors,
     )
     reject_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1256,6 +1256,18 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
+        'isCorePlayerStat ? "core" : "mechanics"',
+        "plugin replay/live drained shot-save-assist events use core playlist source",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'if (isCorePlayerStat) {\n    return;\n  }\n  if (!overlayMechanicEnabled(event.kind))',
+        "plugin core replay annotations do not route through mechanic overlay filters",
+        errors,
+    )
+    require_contains(
+        plugin_source,
         'std::format(\n'
         '      "Filters {}/{}##event-playlist-filter",\n'
         "      selectedSourceCount,\n"

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1152,6 +1152,17 @@ def main() -> int:
             "plugin mechanics review current item debug-style rows",
             errors,
         )
+    for mechanics_review_plugin_only_action in (
+        'ImGui::Button("Stop clip")',
+        'ImGui::Button("Show playlist")',
+        'ImGui::Button("Clear decision")',
+    ):
+        reject_contains(
+            plugin_source,
+            mechanics_review_plugin_only_action,
+            "plugin mechanics review plugin-only action",
+            errors,
+        )
     require_contains(
         web_player_main_source,
         "formatMechanicsReviewStatus(candidate.meta?.reviewStatus)",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1217,6 +1217,37 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        'const DEFAULT_UNSELECTED_EVENT_PLAYLIST_SOURCE_IDS = new Set(["module:touch", "module:powerslide"]);',
+        "stats evaluation player defaults touch and powerslide out of playlist",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'eventPlaylistSourceFilter = "default";',
+        "plugin replay review playlist starts from web-like default source selection",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'return optionValue != "all" && optionValue != "mechanics" && optionValue != "touch" &&\n'
+        '         optionValue != "powerslide";',
+        "plugin event playlist default excludes broad mechanics, touch, and powerslide",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        '{"goal", "Goals", "Replay"}',
+        "plugin event playlist goal source label mirrors web",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        '{"demo", "Demos", "Replay"}',
+        "plugin event playlist demo source label mirrors web",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'std::format(\n'
         '      "Filters {}/{}##event-playlist-filter",\n'

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -2209,6 +2209,18 @@ def main() -> int:
         "replay annotation frame players expose core goals to plugin stats windows",
         errors,
     )
+    require_contains(
+        plugin_source,
+        "replayStatsModuleNamesFromFrameJson(currentReplayFrameJson())",
+        "plugin stats module controls can discover modules from replay frame JSON",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const std::vector<std::string> moduleNames = availableStatsModuleNames();",
+        "plugin stats module selectors use live and replay module names",
+        errors,
+    )
     reject_contains(
         plugin_source,
         "ImGui::SetNextWindowFocus();\n"

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1005,8 +1005,8 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'renderModuleSummaryToggle(\n          "All events",\n          allSelected,\n          "event-sources-actions")',
-        "plugin Events window all-events action mirrors web",
+        'std::format("All events   {}##event-sources-actions-all", displaySources.size())',
+        "plugin Events window all-events action mirrors web count readout",
         errors,
     )
     require_contains(
@@ -1017,8 +1017,8 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'renderModuleSummaryToggle(\n          "No events",\n          selected.empty(),\n          "event-sources-actions")',
-        "plugin Events window no-events action mirrors web",
+        'renderEventSourceAction("No events   Off##event-sources-actions-none")',
+        "plugin Events window no-events action mirrors web off readout",
         errors,
     )
     require_contains(
@@ -1053,6 +1053,8 @@ def main() -> int:
         'ImGui::TreeNode("Event sources##event-source-controls")',
         'ImGui::SmallButton("All events##event-sources")',
         'ImGui::SmallButton("No events##event-sources")',
+        'renderModuleSummaryToggle(\n          "All events",\n          allSelected,\n          "event-sources-actions")',
+        'renderModuleSummaryToggle(\n          "No events",\n          selected.empty(),\n          "event-sources-actions")',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -961,6 +961,35 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_template_source,
+        "<p>Load a replay to start.</p>\n          <button id=\"empty-load-replay\" type=\"button\">Load Replay...</button>",
+        "stats evaluation player empty state exposes only replay loading",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'ImGui::TextUnformatted("Load a replay to start.");\n'
+        '  if (ImGui::Button("Load Replay...", ImVec2{150.0f, 0.0f})) {\n'
+        "    showSingletonWindow(uiReplayLoadingOpen, replayLoadingPlacement);\n"
+        "    resetReplayAnnotations();\n"
+        "    tickReplayAnnotations();\n"
+        "  }\n\n"
+        "  ImGui::End();",
+        "plugin empty state mirrors web replay-loading-only card",
+        errors,
+    )
+    for plugin_only_empty_state_surface in (
+        'ImGui::Button("Start live analysis", ImVec2{150.0f, 0.0f})',
+        'ImGui::Button("Open menu", ImVec2{150.0f, 0.0f})',
+        'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "subtr-actor");',
+    ):
+        reject_contains(
+            plugin_source,
+            plugin_only_empty_state_surface,
+            "plugin empty state plugin-only surface",
+            errors,
+        )
+    require_contains(
         web_player_main_source,
         'renderModuleSummaryGroup("Timeline visualizations", timelineToggles)',
         "stats evaluation player launcher module summary timeline group",

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -863,8 +863,11 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'std::format("Add all {}   {}##{}-{}", category, count, window.id, category);',
-        "plugin stats picker category row mirrors web count layout",
+        'renderStatsPickerItem(\n'
+        '            std::format("Add all {}", category),\n'
+        '            std::to_string(count),\n'
+        '            std::format("all-{}", category))',
+        "plugin stats picker category row mirrors web button/count layout",
         errors,
     )
     require_contains(
@@ -875,8 +878,27 @@ def main() -> int:
     )
     require_contains(
         plugin_source,
-        'std::format(\n        "{}   {}##{}-{}",',
-        "plugin stats picker stat row mirrors web label/scope layout",
+        "renderStatsPickerItem(\n"
+        "            definition.label,\n"
+        "            uiStatScopeLabel(definition),\n"
+        "            definition.id,\n"
+        "            disabled)",
+        "plugin stats picker stat row mirrors web button label/scope layout",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'const std::string buttonId = std::format("##stats-picker-item-{}-{}", window.id, id);',
+        "plugin stats picker rows use dedicated hidden ImGui ids like web button rows",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "drawList->AddText(\n"
+        "        ImVec2{rightX, textY},\n"
+        "        disabled ? IM_COL32(107, 133, 156, 255) : IM_COL32(135, 175, 212, 255),\n"
+        "        metaString.c_str());",
+        "plugin stats picker rows draw right-aligned web accent metadata",
         errors,
     )
     require_contains(
@@ -922,8 +944,12 @@ def main() -> int:
         'std::format("Search stats##{}", window.id).c_str()',
         'ImGui::SmallButton(std::format("Clear##stat-search-{}", window.id).c_str())',
         'std::format("Add all {} ({})##{}-{}", category, count, window.id, category)',
+        'std::format("Add all {}   {}##{}-{}", category, count, window.id, category)',
         'std::format(\n        "{}  [{}]##{}-{}",',
+        'std::format(\n        "{}   {}##{}-{}",',
         'ImGui::TextDisabled(\n          "%s  [%s selected]",',
+        'ImGui::TextDisabled(\n          "%s   %s",',
+        "ImGui::Selectable(itemLabel.c_str(), alreadySelected)",
         'ImGui::Text("No matching stats.");',
         'void renderStatsWindowEmpty(std::string_view message) {\n  ImGui::Spacing();\n  ImGui::TextDisabled("%s", std::string{message}.c_str());\n}',
     ):

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1224,6 +1224,7 @@ def main() -> int:
         'renderModuleSummaryToggle(\n          "All",\n          allSourcesEnabled,\n          "event-playlist-sources")',
         'renderModuleSummaryToggle("None", noSourcesEnabled, "event-playlist-sources")',
         'renderModuleSummaryToggle(label.c_str(), source.enabled, "event-playlist-sources")',
+        'ImGui::Text("%zu selected / %zu recent", playlistEventIndexes.size(), recentUiEvents.size());',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1332,9 +1332,33 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        'if (!replayPlayer || state?.cameraViewMode !== "follow" || attachedPlayerId === null) {\n'
+        '    cameraProfileReadout.textContent = "Free camera";\n'
+        '    cameraFovReadout.textContent = "--";\n'
+        '    cameraHeightReadout.textContent = "--";\n'
+        '    cameraPitchReadout.textContent = "--";\n'
+        '    cameraBaseDistanceReadout.textContent = "--";\n'
+        '    cameraStiffnessReadout.textContent = "--";',
+        "stats evaluation player camera detail grid uses dash readouts without an attached camera",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'ImGui::Columns(2, "camera-detail-grid", false);',
         "plugin camera uses web-like detail grid",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'auto renderAttachedCameraMetric = [&](const char *format, float value) {\n'
+        "    if (!hasAttachedCamera) {\n"
+        '      ImGui::Text("--");\n'
+        "      return;\n"
+        "    }\n"
+        "    ImGui::Text(format, value);\n"
+        "  };",
+        "plugin camera detail grid uses dash readouts without an attached camera",
         errors,
     )
     require_contains(
@@ -1367,6 +1391,11 @@ def main() -> int:
         'ImGui::TextColored(ImVec4{0.53f, 0.69f, 0.83f, 1.0f}, "READOUT");',
         'ImGui::Button("Open player stats")',
         'ImGui::Checkbox("Custom settings", &nextCustomSettingsEnabled)',
+        'ImGui::Text("%.0f", fov);',
+        'ImGui::Text("%.0f", height);',
+        'ImGui::Text("%.1f", pitch);',
+        'ImGui::Text("%.0f", distance);',
+        'ImGui::Text("%.2f", stiffness);',
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1700,6 +1700,23 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
+        "for (const source of sources) {\n      source.setActive(true);\n    }",
+        "stats evaluation player Events window all action enables visible sources",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "selected.clear();\n"
+        "    selected.reserve(displaySources.size());\n"
+        "    for (const DisplaySource &source : displaySources) {\n"
+        "      selected.emplace_back(source.option->value);\n"
+        "    }\n"
+        "    applySelection();",
+        "plugin Events window all action enables displayed sources like web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
         'noneName.textContent = "No events";',
         "stats evaluation player Events window no-events action",
         errors,
@@ -1907,6 +1924,29 @@ def main() -> int:
         plugin_source,
         'ImGui::Button("All##event-playlist-sources-all")',
         "plugin event playlist all action label mirrors web",
+        errors,
+    )
+    require_contains(
+        web_player_main_source,
+        "eventPlaylistActiveSourceIds = new Set(sources.map((source) => source.id));",
+        "stats evaluation player event playlist all action enables current sources",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "selectedSources.clear();\n"
+        "      selectedSources.reserve(playlistSources.size());\n"
+        "      for (const PlaylistSource &source : playlistSources) {\n"
+        "        selectedSources.emplace_back(source.option->value);\n"
+        "      }\n"
+        "      eventPlaylistSourceFilter = eventFilterFromSelectedSources(selectedSources);",
+        "plugin event playlist all action enables displayed sources like web",
+        errors,
+    )
+    reject_contains(
+        plugin_source,
+        'eventPlaylistSourceFilter = "all";',
+        "plugin event playlist all action enables hidden global sources",
         errors,
     )
     require_contains(

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1788,6 +1788,24 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_styles_source,
+        ".camera-presets {\n"
+        "  display: grid;\n"
+        "  grid-template-columns: repeat(2, minmax(0, 1fr));\n"
+        "  gap: var(--ui-gap-xs);\n"
+        "}",
+        "stats evaluation player camera presets use a two-column grid",
+        errors,
+    )
+    require_contains(
+        web_player_styles_source,
+        '.camera-presets button[data-active="true"] {\n'
+        "  border-color: rgba(142, 197, 255, 0.42);\n"
+        "  background: linear-gradient(180deg, rgba(33, 71, 107, 0.96), rgba(12, 27, 42, 0.98));",
+        "stats evaluation player active camera preset has accented button chrome",
+        errors,
+    )
+    require_contains(
         web_player_main_source,
         "cameraDistance.disabled = !hasAttachedCamera;",
         "stats evaluation player updates camera settings availability from active camera state",
@@ -1797,6 +1815,38 @@ def main() -> int:
         plugin_source,
         "const bool hasCameraContext = !sampledPlayers.empty();",
         "plugin camera derives replay context for disabled controls",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const float cameraPresetWidth =\n"
+        "      std::max(96.0f, (ImGui::GetContentRegionAvail().x - cameraPresetGap) * 0.5f);",
+        "plugin camera presets use two-column grid sizing",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool active = cameraViewMode == mode;",
+        "plugin camera presets track the active button state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::PushStyleColor(ImGuiCol_Border, ImVec4{0.56f, 0.77f, 1.0f, 0.42f});\n"
+        "      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.13f, 0.28f, 0.42f, 0.96f});",
+        "plugin camera active preset uses web-like accented button chrome",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "const bool clicked = ImGui::Button(label, ImVec2{cameraPresetWidth, 0.0f});",
+        "plugin camera preset controls use equal-width buttons",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        "ImGui::SameLine(0.0f, cameraPresetGap);",
+        "plugin camera preset grid uses explicit web-like gaps",
         errors,
     )
     require_contains(
@@ -1917,6 +1967,8 @@ def main() -> int:
         'ImGui::Text("%.1f", pitch);',
         'ImGui::Text("%.0f", distance);',
         'ImGui::Text("%.2f", stiffness);',
+        "ImGui::RadioButton(label,",
+        "ImGui::SameLine();\n  if (cameraViewButton(\"Follow##camera-view\"",
     ):
         reject_contains(
             plugin_source,

--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -825,6 +825,18 @@ def main() -> int:
         errors,
     )
     require_contains(
+        web_player_main_source,
+        "recordingStart.disabled = !hasRecorder || isRecording;",
+        "stats evaluation player recording start waits for recorder and idle state",
+        errors,
+    )
+    require_contains(
+        plugin_source,
+        'recordingButton("Start", recordingActive || !loaded || !engine)',
+        "plugin recording start waits for analysis engine and idle state",
+        errors,
+    )
+    require_contains(
         plugin_source,
         'recordingButton("Download", recordingActive || !hasGraphSnapshot)',
         "plugin recording exposes web-like download action",

--- a/crates/subtr-actor-bakkesmod/Cargo.toml
+++ b/crates/subtr-actor-bakkesmod/Cargo.toml
@@ -11,6 +11,8 @@ description = "C ABI for feeding BakkesMod live Rocket League samples into subtr
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
+base64 = "0.22.1"
 boxcars.workspace = true
+flate2 = "1.1.2"
 serde_json = "1.0.140"
 subtr-actor = { path = "../.." }

--- a/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
+++ b/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
@@ -298,6 +298,12 @@ size_t subtr_actor_bakkesmod_write_decoded_stats_player_config_json(
     const char *encoded_config,
     uint8_t *out_bytes,
     size_t max_bytes);
+size_t subtr_actor_bakkesmod_encoded_stats_player_config_len(
+    const char *json_config);
+size_t subtr_actor_bakkesmod_write_encoded_stats_player_config(
+    const char *json_config,
+    uint8_t *out_bytes,
+    size_t max_bytes);
 size_t subtr_actor_bakkesmod_events_json_len(const SaEngine *engine);
 size_t subtr_actor_bakkesmod_write_events_json(
     const SaEngine *engine,

--- a/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
+++ b/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
@@ -292,6 +292,14 @@ size_t subtr_actor_bakkesmod_write_replay_annotation_frame_players(
     float replay_time,
     SaPlayerFrame *out_players,
     size_t max_players);
+size_t subtr_actor_bakkesmod_replay_annotation_frame_json_len(
+    const SaReplayAnnotations *annotations,
+    float replay_time);
+size_t subtr_actor_bakkesmod_write_replay_annotation_frame_json(
+    const SaReplayAnnotations *annotations,
+    float replay_time,
+    uint8_t *out_bytes,
+    size_t max_bytes);
 int32_t subtr_actor_bakkesmod_replay_annotation_score_at_time(
     const SaReplayAnnotations *annotations,
     float replay_time,

--- a/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
+++ b/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
@@ -292,6 +292,12 @@ int32_t subtr_actor_bakkesmod_process_frame(SaEngine *engine, const SaLiveFrame 
 size_t subtr_actor_bakkesmod_pending_event_count(const SaEngine *engine);
 size_t subtr_actor_bakkesmod_pending_team_event_count(const SaEngine *engine);
 size_t subtr_actor_bakkesmod_pending_goal_context_event_count(const SaEngine *engine);
+size_t subtr_actor_bakkesmod_decoded_stats_player_config_json_len(
+    const char *encoded_config);
+size_t subtr_actor_bakkesmod_write_decoded_stats_player_config_json(
+    const char *encoded_config,
+    uint8_t *out_bytes,
+    size_t max_bytes);
 size_t subtr_actor_bakkesmod_events_json_len(const SaEngine *engine);
 size_t subtr_actor_bakkesmod_write_events_json(
     const SaEngine *engine,

--- a/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
+++ b/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
@@ -287,6 +287,11 @@ size_t subtr_actor_bakkesmod_write_replay_annotation_players(
     const SaReplayAnnotations *annotations,
     SaReplayPlayerInfo *out_players,
     size_t max_players);
+size_t subtr_actor_bakkesmod_write_replay_annotation_frame_players(
+    const SaReplayAnnotations *annotations,
+    float replay_time,
+    SaPlayerFrame *out_players,
+    size_t max_players);
 int32_t subtr_actor_bakkesmod_replay_annotation_score_at_time(
     const SaReplayAnnotations *annotations,
     float replay_time,

--- a/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
+++ b/crates/subtr-actor-bakkesmod/include/subtr_actor_bakkesmod.h
@@ -170,6 +170,13 @@ typedef struct SaLiveFrame {
   size_t demolish_count;
 } SaLiveFrame;
 
+typedef struct SaReplayScore {
+  int32_t team_zero_score;
+  uint8_t has_team_zero_score;
+  int32_t team_one_score;
+  uint8_t has_team_one_score;
+} SaReplayScore;
+
 typedef enum SaMechanicKind {
   SaMechanicKindSpeedFlip = 1,
   SaMechanicKindHalfFlip = 2,
@@ -280,6 +287,10 @@ size_t subtr_actor_bakkesmod_write_replay_annotation_players(
     const SaReplayAnnotations *annotations,
     SaReplayPlayerInfo *out_players,
     size_t max_players);
+int32_t subtr_actor_bakkesmod_replay_annotation_score_at_time(
+    const SaReplayAnnotations *annotations,
+    float replay_time,
+    SaReplayScore *out_score);
 size_t subtr_actor_bakkesmod_poll_replay_annotations(
     SaReplayAnnotations *annotations,
     float replay_time,

--- a/crates/subtr-actor-bakkesmod/src/lib.rs
+++ b/crates/subtr-actor-bakkesmod/src/lib.rs
@@ -2,11 +2,15 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ffi::{CStr, CString};
+use std::io::Read;
 use std::os::raw::c_char;
 use std::ptr;
 use std::slice;
 
+use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+use base64::Engine as _;
 use boxcars::{ParserBuilder, Quaternion, RemoteId, RigidBody, Vector3f};
+use flate2::read::{DeflateDecoder, ZlibDecoder};
 use subtr_actor::{
     boost_amount_to_percent, builtin_analysis_node_json, builtin_stats_graph_snapshot_json,
     builtin_stats_module_config_json, builtin_stats_module_frame_json, builtin_stats_module_json,
@@ -2757,6 +2761,39 @@ fn serialize_live_graph_output(engine: &SaEngine, output_name: &str) -> Option<V
     }
 }
 
+fn inflate_stats_player_config_bytes(compressed: &[u8]) -> Option<Vec<u8>> {
+    let mut raw_decoder = DeflateDecoder::new(compressed);
+    let mut json = Vec::new();
+    if raw_decoder.read_to_end(&mut json).is_ok()
+        && serde_json::from_slice::<serde_json::Value>(&json).is_ok()
+    {
+        return Some(json);
+    }
+
+    let mut zlib_decoder = ZlibDecoder::new(compressed);
+    let mut json = Vec::new();
+    if zlib_decoder.read_to_end(&mut json).is_ok()
+        && serde_json::from_slice::<serde_json::Value>(&json).is_ok()
+    {
+        return Some(json);
+    }
+
+    None
+}
+
+fn decode_stats_player_config_json(value: &CStr) -> Option<Vec<u8>> {
+    let value = value.to_str().ok()?.trim();
+    if value.starts_with('{') {
+        return Some(value.as_bytes().to_vec());
+    }
+
+    let compressed = URL_SAFE_NO_PAD
+        .decode(value)
+        .or_else(|_| URL_SAFE.decode(value))
+        .ok()?;
+    inflate_stats_player_config_bytes(&compressed)
+}
+
 fn refresh_timeline_graph_state(engine: &mut SaEngine) {
     let Some(events) = engine
         .graph
@@ -3100,6 +3137,56 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_goal_context_event_count(
         .as_ref()
         .map(|engine| engine.pending_goal_context_events.len())
         .unwrap_or(0)
+}
+
+#[no_mangle]
+/// Returns the UTF-8 byte length of a decoded stats-player config JSON payload.
+///
+/// Accepts the compressed base64url `cfg` value emitted by the web stats
+/// evaluation player. Raw JSON is accepted as a compatibility fallback.
+///
+/// # Safety
+///
+/// `encoded_config` must either be null or point to a valid null-terminated
+/// UTF-8 string.
+pub unsafe extern "C" fn subtr_actor_bakkesmod_decoded_stats_player_config_json_len(
+    encoded_config: *const c_char,
+) -> usize {
+    if encoded_config.is_null() {
+        return 0;
+    }
+    let encoded_config = unsafe { CStr::from_ptr(encoded_config) };
+    decode_stats_player_config_json(encoded_config)
+        .map(|bytes| bytes.len())
+        .unwrap_or(0)
+}
+
+#[no_mangle]
+/// Writes a decoded stats-player config JSON payload into caller-owned storage.
+///
+/// Returns the number of bytes written. Call
+/// `subtr_actor_bakkesmod_decoded_stats_player_config_json_len` first to size
+/// the destination buffer.
+///
+/// # Safety
+///
+/// `encoded_config` must point to a valid null-terminated UTF-8 string.
+/// `out_bytes` must point to writable storage for at least `max_bytes` bytes.
+pub unsafe extern "C" fn subtr_actor_bakkesmod_write_decoded_stats_player_config_json(
+    encoded_config: *const c_char,
+    out_bytes: *mut u8,
+    max_bytes: usize,
+) -> usize {
+    if encoded_config.is_null() || out_bytes.is_null() || max_bytes == 0 {
+        return 0;
+    }
+    let encoded_config = unsafe { CStr::from_ptr(encoded_config) };
+    let Some(bytes) = decode_stats_player_config_json(encoded_config) else {
+        return 0;
+    };
+    let count = max_bytes.min(bytes.len());
+    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+    count
 }
 
 #[no_mangle]
@@ -3718,8 +3805,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_drain_goal_context_events(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use std::collections::{BTreeMap, BTreeSet};
     use std::ffi::CString;
+    use std::io::Write as _;
     use subtr_actor::stats::analysis_graph::STATS_TIMELINE_MECHANIC_KINDS;
     use subtr_actor::{
         BoostPickupActivity, BoostPickupComparison, BoostPickupFieldHalf, BoostPickupPadType,
@@ -3740,6 +3829,43 @@ mod tests {
             .join("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay")
             .canonicalize()
             .expect("real replay fixture should resolve")
+    }
+
+    fn deflated_base64url_json(json: &str) -> CString {
+        let mut encoder =
+            flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::best());
+        encoder.write_all(json.as_bytes()).unwrap();
+        let compressed = encoder.finish().unwrap();
+        CString::new(URL_SAFE_NO_PAD.encode(compressed)).unwrap()
+    }
+
+    #[test]
+    fn decodes_stats_player_config_cfg_payload() {
+        let json = r#"{"version":1,"playback":{},"camera":{},"overlays":{"timelineEvents":[],"timelineRanges":[],"mechanics":[],"renderEffects":[],"followedPlayerHud":false,"boostPads":false,"boostPickupAnimation":false},"recording":{},"singletonWindows":[],"statsWindows":[],"moduleConfigs":{}}"#;
+        let encoded = deflated_base64url_json(json);
+
+        let byte_count =
+            unsafe { subtr_actor_bakkesmod_decoded_stats_player_config_json_len(encoded.as_ptr()) };
+        assert_eq!(byte_count, json.len());
+
+        let mut bytes = vec![0; byte_count];
+        let written = unsafe {
+            subtr_actor_bakkesmod_write_decoded_stats_player_config_json(
+                encoded.as_ptr(),
+                bytes.as_mut_ptr(),
+                bytes.len(),
+            )
+        };
+        assert_eq!(written, json.len());
+        assert_eq!(String::from_utf8(bytes).unwrap(), json);
+    }
+
+    #[test]
+    fn decoded_stats_player_config_accepts_raw_json_fallback() {
+        let json = CString::new(r#"{"version":1,"statsWindows":[]}"#).unwrap();
+        let byte_count =
+            unsafe { subtr_actor_bakkesmod_decoded_stats_player_config_json_len(json.as_ptr()) };
+        assert_eq!(byte_count, json.as_bytes().len());
     }
 
     fn header_enum_values(enum_name: &str) -> BTreeMap<String, i32> {

--- a/crates/subtr-actor-bakkesmod/src/lib.rs
+++ b/crates/subtr-actor-bakkesmod/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ffi::{CStr, CString};
-use std::io::Read;
+use std::io::{Read, Write};
 use std::os::raw::c_char;
 use std::ptr;
 use std::slice;
@@ -10,7 +10,11 @@ use std::slice;
 use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
 use base64::Engine as _;
 use boxcars::{ParserBuilder, Quaternion, RemoteId, RigidBody, Vector3f};
-use flate2::read::{DeflateDecoder, ZlibDecoder};
+use flate2::{
+    read::{DeflateDecoder, ZlibDecoder},
+    write::DeflateEncoder,
+    Compression,
+};
 use subtr_actor::{
     boost_amount_to_percent, builtin_analysis_node_json, builtin_stats_graph_snapshot_json,
     builtin_stats_module_config_json, builtin_stats_module_frame_json, builtin_stats_module_json,
@@ -2794,6 +2798,16 @@ fn decode_stats_player_config_json(value: &CStr) -> Option<Vec<u8>> {
     inflate_stats_player_config_bytes(&compressed)
 }
 
+fn encode_stats_player_config_json(value: &CStr) -> Option<Vec<u8>> {
+    let value = value.to_str().ok()?.trim();
+    serde_json::from_str::<serde_json::Value>(value).ok()?;
+
+    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::best());
+    encoder.write_all(value.as_bytes()).ok()?;
+    let compressed = encoder.finish().ok()?;
+    Some(URL_SAFE_NO_PAD.encode(compressed).into_bytes())
+}
+
 fn refresh_timeline_graph_state(engine: &mut SaEngine) {
     let Some(events) = engine
         .graph
@@ -3182,6 +3196,56 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_decoded_stats_player_config
     }
     let encoded_config = unsafe { CStr::from_ptr(encoded_config) };
     let Some(bytes) = decode_stats_player_config_json(encoded_config) else {
+        return 0;
+    };
+    let count = max_bytes.min(bytes.len());
+    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+    count
+}
+
+#[no_mangle]
+/// Returns the byte length of the compressed base64url stats-player cfg value.
+///
+/// The output format matches the web stats evaluation player's `cfg` payload:
+/// raw deflate of UTF-8 JSON, encoded as unpadded base64url.
+///
+/// # Safety
+///
+/// `json_config` must either be null or point to a valid null-terminated UTF-8
+/// JSON string.
+pub unsafe extern "C" fn subtr_actor_bakkesmod_encoded_stats_player_config_len(
+    json_config: *const c_char,
+) -> usize {
+    if json_config.is_null() {
+        return 0;
+    }
+    let json_config = unsafe { CStr::from_ptr(json_config) };
+    encode_stats_player_config_json(json_config)
+        .map(|bytes| bytes.len())
+        .unwrap_or(0)
+}
+
+#[no_mangle]
+/// Writes the compressed base64url stats-player cfg value into caller storage.
+///
+/// Returns the number of bytes written. Call
+/// `subtr_actor_bakkesmod_encoded_stats_player_config_len` first to size the
+/// destination buffer.
+///
+/// # Safety
+///
+/// `json_config` must point to a valid null-terminated UTF-8 JSON string.
+/// `out_bytes` must point to writable storage for at least `max_bytes` bytes.
+pub unsafe extern "C" fn subtr_actor_bakkesmod_write_encoded_stats_player_config(
+    json_config: *const c_char,
+    out_bytes: *mut u8,
+    max_bytes: usize,
+) -> usize {
+    if json_config.is_null() || out_bytes.is_null() || max_bytes == 0 {
+        return 0;
+    }
+    let json_config = unsafe { CStr::from_ptr(json_config) };
+    let Some(bytes) = encode_stats_player_config_json(json_config) else {
         return 0;
     };
     let count = max_bytes.min(bytes.len());
@@ -3808,7 +3872,6 @@ mod tests {
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use std::collections::{BTreeMap, BTreeSet};
     use std::ffi::CString;
-    use std::io::Write as _;
     use subtr_actor::stats::analysis_graph::STATS_TIMELINE_MECHANIC_KINDS;
     use subtr_actor::{
         BoostPickupActivity, BoostPickupComparison, BoostPickupFieldHalf, BoostPickupPadType,
@@ -3866,6 +3929,44 @@ mod tests {
         let byte_count =
             unsafe { subtr_actor_bakkesmod_decoded_stats_player_config_json_len(json.as_ptr()) };
         assert_eq!(byte_count, json.as_bytes().len());
+    }
+
+    #[test]
+    fn encodes_stats_player_config_cfg_payload() {
+        let json = r#"{"version":1,"statsWindows":[]}"#;
+        let json_cstr = CString::new(json).unwrap();
+
+        let encoded_count =
+            unsafe { subtr_actor_bakkesmod_encoded_stats_player_config_len(json_cstr.as_ptr()) };
+        assert!(encoded_count > 0);
+        assert!(encoded_count < json.len() * 2);
+
+        let mut encoded = vec![0; encoded_count];
+        let written = unsafe {
+            subtr_actor_bakkesmod_write_encoded_stats_player_config(
+                json_cstr.as_ptr(),
+                encoded.as_mut_ptr(),
+                encoded.len(),
+            )
+        };
+        assert_eq!(written, encoded_count);
+        let encoded_cstr = CString::new(encoded).unwrap();
+
+        let decoded_count = unsafe {
+            subtr_actor_bakkesmod_decoded_stats_player_config_json_len(encoded_cstr.as_ptr())
+        };
+        assert_eq!(decoded_count, json.len());
+
+        let mut decoded = vec![0; decoded_count];
+        let decoded_written = unsafe {
+            subtr_actor_bakkesmod_write_decoded_stats_player_config_json(
+                encoded_cstr.as_ptr(),
+                decoded.as_mut_ptr(),
+                decoded.len(),
+            )
+        };
+        assert_eq!(decoded_written, json.len());
+        assert_eq!(String::from_utf8(decoded).unwrap(), json);
     }
 
     fn header_enum_values(enum_name: &str) -> BTreeMap<String, i32> {

--- a/crates/subtr-actor-bakkesmod/src/lib.rs
+++ b/crates/subtr-actor-bakkesmod/src/lib.rs
@@ -31,9 +31,9 @@ use subtr_actor::{
     GoalEvent, GoalTagEvent, GoalTagKind, LivePlayState, MechanicEvent, MechanicTiming,
     PlayerFrameState, PlayerId, PlayerInfo, PlayerSample, PlayerStatEvent, PlayerStatEventKind,
     ProcessorView, ReplayMeta, ReplayStatsFrame, ReplayStatsTimeline, ReplayStatsTimelineEvents,
-    RushEvent, ShotEventMetadata, StatsTimelineEventCollector, SubtrActorError,
-    SubtrActorErrorVariant, SubtrActorResult, TimelineEvent, TimelineEventKind, TouchEvent,
-    TouchStateCalculator, WhiffEvent,
+    RushEvent, ShotEventMetadata, StatsTimelineCollector, StatsTimelineEventCollector,
+    SubtrActorError, SubtrActorErrorVariant, SubtrActorResult, TimelineEvent, TimelineEventKind,
+    TouchEvent, TouchStateCalculator, WhiffEvent,
 };
 
 #[repr(C)]
@@ -236,6 +236,15 @@ pub struct SaLiveFrame {
 }
 
 #[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SaReplayScore {
+    pub team_zero_score: i32,
+    pub has_team_zero_score: u8,
+    pub team_one_score: i32,
+    pub has_team_one_score: u8,
+}
+
+#[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SaMechanicKind {
     SpeedFlip = 1,
@@ -365,6 +374,7 @@ pub struct SaEngine {
 
 pub struct SaReplayAnnotations {
     events: Vec<SaMechanicEvent>,
+    frames: Vec<ReplayStatsFrame>,
     players: Vec<SaReplayPlayerInfo>,
     _player_names: Vec<CString>,
     cursor: usize,
@@ -2861,10 +2871,12 @@ fn build_replay_annotations(path: &CStr) -> SubtrActorResult<SaReplayAnnotations
         })?;
     let timeline =
         StatsTimelineEventCollector::new().get_replay_stats_timeline_scaffold(&replay)?;
+    let score_timeline = StatsTimelineCollector::new().get_legacy_replay_stats_timeline(&replay)?;
     let events = replay_annotations_from_timeline(&timeline.replay_meta, &timeline.events);
     let (player_names, players) = replay_annotation_players(&timeline.replay_meta);
     Ok(SaReplayAnnotations {
         events,
+        frames: score_timeline.frames,
         players,
         _player_names: player_names,
         cursor: 0,
@@ -2941,6 +2953,41 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_players(
         ptr::copy_nonoverlapping(annotations.players.as_ptr(), out_players, count);
     }
     count
+}
+
+/// Returns the scoreboard value for the latest processed replay frame at or before
+/// `replay_time`.
+#[no_mangle]
+pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_score_at_time(
+    annotations: *const SaReplayAnnotations,
+    replay_time: f32,
+    out_score: *mut SaReplayScore,
+) -> i32 {
+    let Some(annotations) = (unsafe { annotations.as_ref() }) else {
+        return -1;
+    };
+    if out_score.is_null() {
+        return -1;
+    }
+    let Some(frame) = annotations
+        .frames
+        .iter()
+        .take_while(|frame| frame.time <= replay_time + f32::EPSILON)
+        .last()
+        .or_else(|| annotations.frames.first())
+    else {
+        return -2;
+    };
+
+    unsafe {
+        *out_score = SaReplayScore {
+            team_zero_score: frame.team_zero.core.goals,
+            has_team_zero_score: 1,
+            team_one_score: frame.team_one.core.goals,
+            has_team_one_score: 1,
+        };
+    }
+    0
 }
 
 /// Drains annotation events whose normal replay-processing timestamp has been
@@ -4352,6 +4399,17 @@ mod tests {
             .iter()
             .any(|player| !player.name.is_null()));
         let final_time = unsafe { (*annotations).events.last().expect("events").time + 1.0 };
+        let mut score = SaReplayScore::default();
+        let score_result = unsafe {
+            subtr_actor_bakkesmod_replay_annotation_score_at_time(
+                annotations,
+                final_time,
+                &mut score,
+            )
+        };
+        assert_eq!(score_result, 0);
+        assert_eq!(score.has_team_zero_score, 1);
+        assert_eq!(score.has_team_one_score, 1);
 
         let mut events = vec![
             SaMechanicEvent {
@@ -4597,6 +4655,15 @@ mod tests {
                 ],
             ),
             (
+                "SaReplayScore",
+                vec![
+                    ("int32_t", "team_zero_score"),
+                    ("uint8_t", "has_team_zero_score"),
+                    ("int32_t", "team_one_score"),
+                    ("uint8_t", "has_team_one_score"),
+                ],
+            ),
+            (
                 "SaMechanicEvent",
                 vec![
                     ("SaMechanicKind", "kind"),
@@ -4836,6 +4903,12 @@ mod tests {
         assert_offset!(SaLiveFrame, player_stat_event_count, 208);
         assert_offset!(SaLiveFrame, demolishes, 216);
         assert_offset!(SaLiveFrame, demolish_count, 224);
+
+        assert_layout!(SaReplayScore, size = 16, align = 4);
+        assert_offset!(SaReplayScore, team_zero_score, 0);
+        assert_offset!(SaReplayScore, has_team_zero_score, 4);
+        assert_offset!(SaReplayScore, team_one_score, 8);
+        assert_offset!(SaReplayScore, has_team_one_score, 12);
 
         assert_layout!(SaMechanicEvent, size = 32, align = 8);
         assert_offset!(SaMechanicEvent, kind, 0);

--- a/crates/subtr-actor-bakkesmod/src/lib.rs
+++ b/crates/subtr-actor-bakkesmod/src/lib.rs
@@ -382,6 +382,18 @@ pub struct SaReplayAnnotations {
     initialized: bool,
 }
 
+fn replay_annotation_frame_at_time(
+    annotations: &SaReplayAnnotations,
+    replay_time: f32,
+) -> Option<&ReplayStatsFrame> {
+    annotations
+        .frames
+        .iter()
+        .take_while(|frame| frame.time <= replay_time + f32::EPSILON)
+        .last()
+        .or_else(|| annotations.frames.first())
+}
+
 const LIVE_GRAPH_OUTPUT_NAMES: &[&str] = &[
     "events",
     "frame",
@@ -2955,6 +2967,48 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_players(
     count
 }
 
+/// Copies replay players and current-frame core stats for replay playback.
+#[no_mangle]
+pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_frame_players(
+    annotations: *const SaReplayAnnotations,
+    replay_time: f32,
+    out_players: *mut SaPlayerFrame,
+    max_players: usize,
+) -> usize {
+    let Some(annotations) = (unsafe { annotations.as_ref() }) else {
+        return 0;
+    };
+    if max_players == 0 || out_players.is_null() {
+        return 0;
+    }
+    let Some(frame) = replay_annotation_frame_at_time(annotations, replay_time) else {
+        return 0;
+    };
+
+    let count = frame.players.len().min(max_players);
+    for (index, player) in frame.players.iter().take(count).enumerate() {
+        let player_info = annotations.players.get(index);
+        let player_frame = SaPlayerFrame {
+            player_index: player_info
+                .map(|info| info.player_index)
+                .unwrap_or(index as u32),
+            player_name: player_info.map(|info| info.name).unwrap_or(ptr::null()),
+            is_team_0: player.is_team_0 as u8,
+            has_match_stats: 1,
+            match_goals: player.core.goals,
+            match_assists: player.core.assists,
+            match_saves: player.core.saves,
+            match_shots: player.core.shots,
+            match_score: player.core.score,
+            ..SaPlayerFrame::default()
+        };
+        unsafe {
+            *out_players.add(index) = player_frame;
+        }
+    }
+    count
+}
+
 /// Returns the scoreboard value for the latest processed replay frame at or before
 /// `replay_time`.
 #[no_mangle]
@@ -2969,13 +3023,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_score_at_time(
     if out_score.is_null() {
         return -1;
     }
-    let Some(frame) = annotations
-        .frames
-        .iter()
-        .take_while(|frame| frame.time <= replay_time + f32::EPSILON)
-        .last()
-        .or_else(|| annotations.frames.first())
-    else {
+    let Some(frame) = replay_annotation_frame_at_time(annotations, replay_time) else {
         return -2;
     };
 
@@ -4399,6 +4447,19 @@ mod tests {
             .iter()
             .any(|player| !player.name.is_null()));
         let final_time = unsafe { (*annotations).events.last().expect("events").time + 1.0 };
+        let mut frame_players = vec![SaPlayerFrame::default(); player_count];
+        let copied_frame_players = unsafe {
+            subtr_actor_bakkesmod_write_replay_annotation_frame_players(
+                annotations,
+                final_time,
+                frame_players.as_mut_ptr(),
+                frame_players.len(),
+            )
+        };
+        assert_eq!(copied_frame_players, player_count);
+        assert!(frame_players[..copied_frame_players]
+            .iter()
+            .all(|player| player.has_match_stats == 1 && !player.player_name.is_null()));
         let mut score = SaReplayScore::default();
         let score_result = unsafe {
             subtr_actor_bakkesmod_replay_annotation_score_at_time(

--- a/crates/subtr-actor-bakkesmod/src/lib.rs
+++ b/crates/subtr-actor-bakkesmod/src/lib.rs
@@ -3009,6 +3009,58 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_frame_pla
     count
 }
 
+fn serialize_replay_annotation_frame(
+    annotations: &SaReplayAnnotations,
+    replay_time: f32,
+) -> Option<Vec<u8>> {
+    replay_annotation_frame_at_time(annotations, replay_time)
+        .and_then(|frame| serde_json::to_vec(frame).ok())
+}
+
+/// Returns the UTF-8 byte length of the replay stats frame at `replay_time`.
+///
+/// The JSON payload is a `ReplayStatsFrame` from the preprocessed replay
+/// timeline. It is the replay-mode counterpart of
+/// `subtr_actor_bakkesmod_frame_json_len`.
+#[no_mangle]
+pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_frame_json_len(
+    annotations: *const SaReplayAnnotations,
+    replay_time: f32,
+) -> usize {
+    annotations
+        .as_ref()
+        .and_then(|annotations| serialize_replay_annotation_frame(annotations, replay_time))
+        .map(|bytes| bytes.len())
+        .unwrap_or(0)
+}
+
+/// Writes the replay stats frame at `replay_time` into caller-owned storage.
+///
+/// Returns the number of bytes written. Call
+/// `subtr_actor_bakkesmod_replay_annotation_frame_json_len` first to size the
+/// destination buffer.
+#[no_mangle]
+pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_frame_json(
+    annotations: *const SaReplayAnnotations,
+    replay_time: f32,
+    out_bytes: *mut u8,
+    max_bytes: usize,
+) -> usize {
+    let Some(annotations) = annotations.as_ref() else {
+        return 0;
+    };
+    if out_bytes.is_null() || max_bytes == 0 {
+        return 0;
+    }
+
+    let Some(bytes) = serialize_replay_annotation_frame(annotations, replay_time) else {
+        return 0;
+    };
+    let count = max_bytes.min(bytes.len());
+    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+    count
+}
+
 /// Returns the scoreboard value for the latest processed replay frame at or before
 /// `replay_time`.
 #[no_mangle]
@@ -4460,6 +4512,24 @@ mod tests {
         assert!(frame_players[..copied_frame_players]
             .iter()
             .all(|player| player.has_match_stats == 1 && !player.player_name.is_null()));
+        let frame_json_len = unsafe {
+            subtr_actor_bakkesmod_replay_annotation_frame_json_len(annotations, final_time)
+        };
+        assert!(frame_json_len > 0);
+        let mut frame_json = vec![0; frame_json_len];
+        let frame_json_written = unsafe {
+            subtr_actor_bakkesmod_write_replay_annotation_frame_json(
+                annotations,
+                final_time,
+                frame_json.as_mut_ptr(),
+                frame_json.len(),
+            )
+        };
+        assert_eq!(frame_json_written, frame_json_len);
+        let frame_json =
+            String::from_utf8(frame_json).expect("replay annotation frame JSON should be UTF-8");
+        assert!(frame_json.contains("\"players\""));
+        assert!(frame_json.contains("\"team_zero\""));
         let mut score = SaReplayScore::default();
         let score_result = unsafe {
             subtr_actor_bakkesmod_replay_annotation_score_at_time(

--- a/js/stat-evaluation-player/README.md
+++ b/js/stat-evaluation-player/README.md
@@ -129,6 +129,9 @@ To inspect the stats-player configuration loaded from a share link, add
 the exact parsed URL parameters, the selected `cfg` source, the raw `cfg` text,
 and the normalized decoded configuration. If both the query string and hash
 contain `cfg`, the hash value is used and the debug log includes a warning.
+The `cfg` value normally uses compressed base64url encoding, but URL-encoded
+raw JSON is also accepted for tooling that needs to hand off configuration
+without running the web encoder.
 
 The package also exports the stat timeline helpers and overlay utilities used by
 the viewer, so consumers can build their own derived UI around the same data.

--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -828,6 +828,12 @@ function getStatsPlayerConfigSnapshot(): StatsPlayerConfig {
       timelineRanges: [...activeTimelineRangeModuleIds],
       mechanics: [...activeMechanicTimelineKinds],
       renderEffects: [...activeRenderEffectModuleIds],
+      ...(initialUrlConfig?.overlays.pluginRenderEffects !== undefined
+        ? { pluginRenderEffects: [...initialUrlConfig.overlays.pluginRenderEffects] }
+        : {}),
+      ...(initialUrlConfig?.overlays.pluginHudOverlay !== undefined
+        ? { pluginHudOverlay: initialUrlConfig.overlays.pluginHudOverlay }
+        : {}),
       followedPlayerHud: false,
       boostPads: boostPadOverlayEnabled,
       boostPickupAnimation: replayPlayer?.getState().boostPickupAnimationEnabled ?? false,

--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -2450,10 +2450,14 @@ function renderMechanicsReviewWindow(): void {
     title.textContent = getMechanicsReviewItemLabel(candidate, index);
 
     const meta = document.createElement("strong");
-    meta.textContent = [
-      getMechanicsReviewMechanicLabel(candidate),
-      formatMechanicsReviewStatus(candidate.meta?.reviewStatus),
-    ].join(" · ");
+    meta.textContent =
+      [
+        getMechanicsReviewMechanicLabel(candidate),
+        getMechanicsReviewPlayerName(candidate),
+        formatMechanicsReviewStatus(candidate.meta?.reviewStatus),
+      ]
+        .filter((part) => part && part !== "--")
+        .join(" · ") || "--";
 
     button.append(title, meta);
     mechanicsReviewList.append(button);

--- a/js/stat-evaluation-player/src/playerConfig.test.ts
+++ b/js/stat-evaluation-player/src/playerConfig.test.ts
@@ -130,6 +130,10 @@ test("stats player config round-trips through compressed url-safe encoding", () 
   assert.deepEqual(decodeStatsPlayerConfig(encoded), CONFIG);
 });
 
+test("stats player config also accepts uncompressed JSON cfg payloads", () => {
+  assert.deepEqual(decodeStatsPlayerConfig(JSON.stringify(CONFIG)), CONFIG);
+});
+
 test("stats player config can live in the URL hash without disturbing query params", () => {
   const url = setStatsPlayerConfigOnUrl(
     new URL("https://viewer.example/app/?r=abc#tab=stats"),
@@ -141,6 +145,15 @@ test("stats player config can live in the URL hash without disturbing query para
     search: url.search,
     hash: url.hash,
   } as Location);
+  assert.deepEqual(decoded, CONFIG);
+});
+
+test("stats player config accepts raw JSON from URL hash cfg values", () => {
+  const decoded = getStatsPlayerConfigFromLocation({
+    search: "",
+    hash: `#cfg=${encodeURIComponent(JSON.stringify(CONFIG))}`,
+  } as Location);
+
   assert.deepEqual(decoded, CONFIG);
 });
 

--- a/js/stat-evaluation-player/src/playerConfig.test.ts
+++ b/js/stat-evaluation-player/src/playerConfig.test.ts
@@ -134,6 +134,19 @@ test("stats player config also accepts uncompressed JSON cfg payloads", () => {
   assert.deepEqual(decodeStatsPlayerConfig(JSON.stringify(CONFIG)), CONFIG);
 });
 
+test("stats player config preserves plugin-only overlay extension fields", () => {
+  const config: StatsPlayerConfig = {
+    ...CONFIG,
+    overlays: {
+      ...CONFIG.overlays,
+      pluginRenderEffects: ["mechanics", "team", "goal_context"],
+      pluginHudOverlay: false,
+    },
+  };
+
+  assert.deepEqual(decodeStatsPlayerConfig(JSON.stringify(config)), config);
+});
+
 test("stats player config can live in the URL hash without disturbing query params", () => {
   const url = setStatsPlayerConfigOnUrl(
     new URL("https://viewer.example/app/?r=abc#tab=stats"),

--- a/js/stat-evaluation-player/src/playerConfig.ts
+++ b/js/stat-evaluation-player/src/playerConfig.ts
@@ -80,6 +80,8 @@ export interface PlayerOverlayConfig {
   readonly timelineRanges: string[];
   readonly mechanics: string[];
   readonly renderEffects: string[];
+  readonly pluginRenderEffects?: string[];
+  readonly pluginHudOverlay?: boolean;
   readonly followedPlayerHud: boolean;
   readonly boostPads: boolean;
   readonly boostPickupAnimation: boolean;
@@ -332,11 +334,19 @@ function normalizeCameraSettings(value: unknown): CameraSettings | null | undefi
 
 function normalizeOverlayConfig(value: unknown): PlayerOverlayConfig {
   const record = isRecord(value) ? value : {};
+  const hasPluginRenderEffects = Object.hasOwn(record, "pluginRenderEffects");
+  const hasPluginHudOverlay = Object.hasOwn(record, "pluginHudOverlay");
   return {
     timelineEvents: stringArray(record.timelineEvents),
     timelineRanges: stringArray(record.timelineRanges),
     mechanics: stringArray(record.mechanics),
     renderEffects: stringArray(record.renderEffects),
+    ...(hasPluginRenderEffects
+      ? { pluginRenderEffects: stringArray(record.pluginRenderEffects) }
+      : {}),
+    ...(hasPluginHudOverlay
+      ? { pluginHudOverlay: booleanValue(record.pluginHudOverlay) ?? false }
+      : {}),
     followedPlayerHud: booleanValue(record.followedPlayerHud) ?? false,
     boostPads: booleanValue(record.boostPads) ?? true,
     boostPickupAnimation: booleanValue(record.boostPickupAnimation) ?? false,

--- a/js/stat-evaluation-player/src/playerConfig.ts
+++ b/js/stat-evaluation-player/src/playerConfig.ts
@@ -148,9 +148,13 @@ export function decodeStatsPlayerConfig(value: string): StatsPlayerConfig {
   try {
     parsed = JSON.parse(strFromU8(inflateSync(base64UrlToBytes(value))));
   } catch (error) {
-    throw new Error(
-      `Invalid stats player config: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      throw new Error(
+        `Invalid stats player config: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   return normalizeStatsPlayerConfig(parsed);


### PR DESCRIPTION
## Summary
- adds the BakkesMod in-game UI/window system for subtr-actor replay annotations and stats surfaces
- reuses the normal replay-processing analysis graph through the Rust DLL and exposes stats/event data in game
- scopes the in-game launcher to plugin-owned surfaces; Rocket League handles camera/playback, and replay annotations follow the current replay rather than a multi-replay queue
- adds Nix-based Linux DLL build support and source/export verifiers for the plugin

## Validation
- python3 bakkesmod/verify-plugin-source.py
- git diff --check origin/master..HEAD
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- env XDG_CACHE_HOME=/tmp/subtr-actor-nix-cache RUST_MIN_STACK=67108864 CARGO_BUILD_JOBS=1 nix build .#bakkesmod-plugin
- python3 bakkesmod/verify-rust-dll-exports.py result/subtr_actor_bakkesmod.dll result/bakkesmod-install/data/subtr-actor/subtr_actor_bakkesmod.dll
- size scan: no files over 5 MB outside ignored build/dependency dirs