### PR TITLE
[codex] Emit inferred touch events in replay data

### DIFF
--- a/src/collector/replay_data.rs
+++ b/src/collector/replay_data.rs
@@ -497,7 +497,8 @@ pub struct FrameData {
 /// * `demolish_infos` - Information about all demolition events that occurred during the replay
 /// * `boost_pad_events` - Exact boost pad pickup/availability events detected while processing
 /// * `boost_pads` - Resolved standard boost pad layout annotated with replay pad ids when known
-/// * `touch_events` - Exact team touch events plus attributed player when available
+/// * `touch_events` - Confirmed touch-state events, including replay-reported
+///   team touches and inferred player touches
 /// * `dodge_refreshed_events` - Exact counter-derived dodge refresh events from the replay
 /// * `player_stat_events` - Exact shot/save/assist counter increment events
 /// * `goal_events` - Exact goal explosion events with scorer and cumulative score when available
@@ -535,7 +536,11 @@ pub struct ReplayData {
     pub boost_pad_events: Vec<BoostPadEvent>,
     /// Resolved standard boost pad layout annotated with replay pad ids when known
     pub boost_pads: Vec<ResolvedBoostPad>,
-    /// Exact touch events observed during the replay
+    /// Confirmed touch-state events observed during the replay.
+    ///
+    /// This stream matches the touch signal used by stats timeline touch
+    /// counts. It includes replay-reported team touches and inferred player
+    /// touches from ball/player state.
     pub touch_events: Vec<TouchEvent>,
     /// Exact dodge refresh events observed via the replay's refreshed-dodge counter
     pub dodge_refreshed_events: Vec<DodgeRefreshedEvent>,
@@ -687,6 +692,10 @@ impl FrameData {
 pub struct ReplayDataCollector {
     /// Internal storage for frame-by-frame data during collection
     frame_data: FrameData,
+    touch_events: Vec<TouchEvent>,
+    touch_state_calculator: TouchStateCalculator,
+    live_play_tracker: LivePlayTracker,
+    last_sample_time: Option<f32>,
 }
 
 impl Default for ReplayDataCollector {
@@ -707,6 +716,10 @@ impl ReplayDataCollector {
     pub fn new() -> Self {
         ReplayDataCollector {
             frame_data: FrameData::new(),
+            touch_events: Vec::new(),
+            touch_state_calculator: TouchStateCalculator::new(),
+            live_play_tracker: LivePlayTracker::default(),
+            last_sample_time: None,
         }
     }
 
@@ -735,17 +748,22 @@ impl ReplayDataCollector {
         processor: ReplayProcessor<'_>,
         boost_pads: Vec<ResolvedBoostPad>,
     ) -> SubtrActorResult<ReplayData> {
+        let ReplayDataCollector {
+            frame_data,
+            touch_events,
+            ..
+        } = self;
         let meta = processor.get_replay_meta()?;
         Ok(ReplayData {
             meta,
             demolish_infos: processor.demolishes().to_vec(),
             boost_pad_events: processor.boost_pad_events().to_vec(),
             boost_pads,
-            touch_events: processor.touch_events().to_vec(),
+            touch_events,
             dodge_refreshed_events: processor.dodge_refreshed_events().to_vec(),
             player_stat_events: processor.player_stat_events().to_vec(),
             goal_events: processor.goal_events().to_vec(),
-            frame_data: self.get_frame_data(),
+            frame_data,
         })
     }
 
@@ -861,9 +879,32 @@ impl Collector for ReplayDataCollector {
         &mut self,
         processor: &dyn ProcessorView,
         _frame: &boxcars::Frame,
-        _frame_number: usize,
+        frame_number: usize,
         current_time: f32,
     ) -> SubtrActorResult<TimeAdvance> {
+        let dt = self
+            .last_sample_time
+            .map(|last_time| (current_time - last_time).max(0.0))
+            .unwrap_or(0.0);
+        let frame_input = FrameInput::timeline(processor, frame_number, current_time, dt);
+        let frame_info = frame_input.frame_info();
+        let gameplay_state = frame_input.gameplay_state();
+        let ball_frame_state = frame_input.ball_frame_state();
+        let player_frame_state = frame_input.player_frame_state();
+        let frame_events_state = frame_input.frame_events_state();
+        let live_play_state = self
+            .live_play_tracker
+            .state_parts(&gameplay_state, &frame_events_state);
+        let touch_state = self.touch_state_calculator.update(
+            &frame_info,
+            &ball_frame_state,
+            &player_frame_state,
+            &frame_events_state,
+            &live_play_state,
+        );
+        self.touch_events.extend(touch_state.touch_events);
+        self.last_sample_time = Some(current_time);
+
         let metadata_frame = MetadataFrame::new_from_processor(processor, current_time)?;
         let ball_frame = BallFrame::new_from_processor(processor, current_time);
         let player_frames = self.get_player_frames(processor, current_time)?;

--- a/tests/replay_data_collector_test.rs
+++ b/tests/replay_data_collector_test.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
 use subtr_actor::collector::replay_data::{BallFrame, PlayerFrame, ReplayDataCollector};
-use subtr_actor::{ReplayProcessor, ResolvedBoostPadCollector, BOOST_KICKOFF_START_AMOUNT};
+use subtr_actor::{
+    ReplayProcessor, ResolvedBoostPadCollector, StatsTimelineEventCollector,
+    BOOST_KICKOFF_START_AMOUNT,
+};
 
 fn parse_replay(path: &str) -> boxcars::Replay {
     let replay_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
@@ -136,4 +139,34 @@ fn replay_data_collectors_can_be_composed_in_a_single_processor_pass() {
     );
     assert_eq!(actual.player_stat_events, expected.player_stat_events);
     assert_eq!(actual.goal_events, expected.goal_events);
+}
+
+#[test]
+fn replay_data_touch_events_match_stats_timeline_player_touch_counts() {
+    let replay =
+        parse_replay("assets/replay-format-2026-03-03-v868-32-net11-dodge-refresh-counter.replay");
+    let replay_data = ReplayDataCollector::new()
+        .get_replay_data(&replay)
+        .expect("Failed to collect replay data");
+    let stats_timeline = StatsTimelineEventCollector::new()
+        .get_replay_stats_timeline_scaffold(&replay)
+        .expect("Failed to collect stats timeline");
+
+    let mut replay_data_counts = std::collections::BTreeMap::new();
+    for touch in replay_data
+        .touch_events
+        .iter()
+        .filter_map(|touch| touch.player.as_ref().map(|player| format!("{player:?}")))
+    {
+        *replay_data_counts.entry(touch).or_insert(0usize) += 1;
+    }
+
+    let mut stats_counts = std::collections::BTreeMap::new();
+    for touch in &stats_timeline.events.touch {
+        *stats_counts
+            .entry(format!("{:?}", touch.player))
+            .or_insert(0usize) += 1;
+    }
+
+    assert_eq!(replay_data_counts, stats_counts);
 }


### PR DESCRIPTION
## Summary
- make `ReplayDataCollector.touch_events` collect the same touch-state event stream used by stats touch counts
- keep exact processor touch events available internally, but stop using them as the replay-data touch event output
- add a replay-data regression test comparing per-player touch counts against `StatsTimelineEventCollector.events.touch`

## Root cause
`ReplayDataCollector.touch_events` was populated from `ReplayProcessor::touch_events()`, which only sees narrow replay-reported team touch updates. The stats player page uses `TouchStateCalculator`, which also emits inferred/proximity touch events from ball/player state and dodge-refresh signals. That made replay-data/event-stream touch counts much smaller than the stats view.

## Validation
- `cargo test --test replay_data_collector_test`
- `just test` from rocket-sense
- scratch audit over colonelpanic8 latest 10 downloaded replays: replay-data player touch counts now match stats timeline touch counts at the larger values (126, 153, 65, 172, 77, 104, 74, 81, 91, 80)
