### PR TITLE
Keep replay timeline time canonical

### DIFF
--- a/js/player/src/player-internals/timeline.ts
+++ b/js/player/src/player-internals/timeline.ts
@@ -198,7 +198,6 @@ export function projectReplayTimeToTimeline(
   replayTime: number,
 ): ReplayPlayerTimelineProjection {
   const clampedReplayTime = THREE.MathUtils.clamp(replayTime, 0, replayDuration);
-  let skippedDuration = 0;
 
   for (const segment of segments) {
     if (clampedReplayTime < segment.startTime) {
@@ -208,18 +207,16 @@ export function projectReplayTimeToTimeline(
     if (clampedReplayTime < segment.endTime) {
       return {
         replayTime: clampedReplayTime,
-        timelineTime: segment.startTime - skippedDuration,
-        seekTime: segment.startTime,
+        timelineTime: clampedReplayTime,
+        seekTime: segment.endTime,
         hiddenBySkip: true,
       };
     }
-
-    skippedDuration += segment.endTime - segment.startTime;
   }
 
   return {
     replayTime: clampedReplayTime,
-    timelineTime: clampedReplayTime - skippedDuration,
+    timelineTime: clampedReplayTime,
     seekTime: clampedReplayTime,
     hiddenBySkip: false,
   };
@@ -231,19 +228,9 @@ export function projectTimelineTimeToReplay(
   segments: ReplayPlayerTimelineSegment[],
   timelineTime: number,
 ): number {
-  const clampedTimelineTime = THREE.MathUtils.clamp(timelineTime, 0, timelineDuration);
-  let skippedDuration = 0;
-
-  for (const segment of segments) {
-    const visibleEnd = segment.startTime - skippedDuration;
-    if (clampedTimelineTime <= visibleEnd) {
-      return clampedTimelineTime + skippedDuration;
-    }
-
-    skippedDuration += segment.endTime - segment.startTime;
-  }
-
-  return THREE.MathUtils.clamp(clampedTimelineTime + skippedDuration, 0, replayDuration);
+  void timelineDuration;
+  void segments;
+  return THREE.MathUtils.clamp(timelineTime, 0, replayDuration);
 }
 
 export function getReplayPlaybackEndTime(

--- a/js/player/src/player.ts
+++ b/js/player/src/player.ts
@@ -85,7 +85,6 @@ export class ReplayPlayer extends EventTarget {
   private readonly kickoffGameState: number | null;
   private timelineSegmentsCacheKey: string | null = null;
   private timelineSegmentsCache: ReplayPlayerTimelineSegment[] = [];
-  private timelineDurationCache = 0;
   private resizeObserver: ResizeObserver | null = null;
   private animationFrameId: number | null = null;
   private disposed = false;
@@ -128,8 +127,6 @@ export class ReplayPlayer extends EventTarget {
     this.skipPostGoalTransitionsEnabled = initialSettings.skipPostGoalTransitionsEnabled;
     this.skipKickoffsEnabled = initialSettings.skipKickoffsEnabled;
     this.setHitboxWireframeVisibility();
-    this.skipPostGoalTransitionIfNeeded();
-    this.skipPastKickoffIfNeeded();
 
     this.installResizeHandling();
     for (const plugin of options.plugins ?? []) {
@@ -150,6 +147,8 @@ export class ReplayPlayer extends EventTarget {
     }
 
     this.playing = true;
+    this.skipPostGoalTransitionIfNeeded();
+    this.skipPastKickoffIfNeeded();
     this.reanchorPlaybackClock();
     this.emitChange();
   }
@@ -255,7 +254,7 @@ export class ReplayPlayer extends EventTarget {
 
   setSkipPostGoalTransitionsEnabled(enabled: boolean): void {
     this.skipPostGoalTransitionsEnabled = enabled;
-    if (enabled) {
+    if (enabled && this.playing) {
       this.skipPostGoalTransitionIfNeeded();
     }
     this.render();
@@ -264,7 +263,7 @@ export class ReplayPlayer extends EventTarget {
 
   setSkipKickoffsEnabled(enabled: boolean): void {
     this.skipKickoffsEnabled = enabled;
-    if (enabled) {
+    if (enabled && this.playing) {
       this.skipPostGoalTransitionIfNeeded();
       this.skipPastKickoffIfNeeded();
     }
@@ -274,8 +273,10 @@ export class ReplayPlayer extends EventTarget {
 
   seek(time: number): void {
     this.currentTime = this.clampReplayTime(time);
-    this.skipPostGoalTransitionIfNeeded();
-    this.skipPastKickoffIfNeeded();
+    if (this.playing) {
+      this.skipPostGoalTransitionIfNeeded();
+      this.skipPastKickoffIfNeeded();
+    }
     if (this.playing) {
       this.reanchorPlaybackClock();
     }
@@ -375,10 +376,10 @@ export class ReplayPlayer extends EventTarget {
       }
     }
     if (this.playing) {
+      this.skipPostGoalTransitionIfNeeded(now);
+      this.skipPastKickoffIfNeeded(now);
       this.reanchorPlaybackClock(now);
     }
-    this.skipPostGoalTransitionIfNeeded(now);
-    this.skipPastKickoffIfNeeded(now);
 
     this.render();
     this.emitChange();
@@ -411,9 +412,7 @@ export class ReplayPlayer extends EventTarget {
   }
 
   getTimelineDuration(): number {
-    return this.getTimelineSegments().length === 0
-      ? this.replay.duration
-      : this.timelineDurationCache;
+    return this.replay.duration;
   }
 
   getTimelineCurrentTime(): number {
@@ -428,14 +427,6 @@ export class ReplayPlayer extends EventTarget {
 
     this.timelineSegmentsCacheKey = cacheKey;
     this.timelineSegmentsCache = this.computeTimelineSegments();
-    this.timelineDurationCache = Math.max(
-      0,
-      this.replay.duration -
-        this.timelineSegmentsCache.reduce(
-          (total, segment) => total + (segment.endTime - segment.startTime),
-          0,
-        ),
-    );
     return this.timelineSegmentsCache;
   }
 

--- a/js/player/test/timeline.test.ts
+++ b/js/player/test/timeline.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   computeTimelineSegments,
   getReplayPlaybackEndTime,
+  projectReplayTimeToTimeline,
   projectTimelineTimeToReplay,
 } from "../src/player-internals/timeline";
 import type { ReplayModel } from "../src/types";
@@ -48,4 +49,25 @@ test("playback end keeps raw duration when final frames are visible", () => {
 
   assert.deepEqual(segments, [{ startTime: 2, endTime: 4 }]);
   assert.equal(getReplayPlaybackEndTime(replay.duration, segments), 5);
+});
+
+test("timeline projection keeps replay times canonical after skipped ranges", () => {
+  const segments = [{ startTime: 2, endTime: 4 }];
+
+  assert.deepEqual(projectReplayTimeToTimeline(10, segments, 7), {
+    replayTime: 7,
+    timelineTime: 7,
+    seekTime: 7,
+    hiddenBySkip: false,
+  });
+  assert.equal(projectTimelineTimeToReplay(10, 10, segments, 7), 7);
+});
+
+test("timeline projection identifies skipped ranges without compacting them", () => {
+  assert.deepEqual(projectReplayTimeToTimeline(10, [{ startTime: 2, endTime: 4 }], 3), {
+    replayTime: 3,
+    timelineTime: 3,
+    seekTime: 4,
+    hiddenBySkip: true,
+  });
 });


### PR DESCRIPTION
## Summary
- keep player timeline projection in canonical replay seconds instead of subtracting skipped ranges
- make kickoff/post-goal skipping a playback-only cursor jump instead of a seek/scrub-time rewrite
- add timeline projection regression coverage for skipped ranges before later events

## Why
Event review clips and timeline event markers are keyed by replay time. Compacting the timeline after skipped kickoff/post-goal ranges shifted markers and seek targets away from the underlying replay event, so review playback could start in a window with no matching event.

## Validation
- npm test -- --test-reporter=spec in js/player
- npm run check:style in js
