### PR TITLE
Avoid full projections for compact stats timelines

### DIFF
--- a/src/stats/analysis_graph/nodes/stats_timeline_events.rs
+++ b/src/stats/analysis_graph/nodes/stats_timeline_events.rs
@@ -60,7 +60,7 @@ impl StatsTimelineEventsNode {
             gameplay_state_dependency(),
             live_play_dependency(),
             match_stats_dependency(),
-            stats_projection_dependency(),
+            // Keep compact event transfer independent from full partial-sum projection.
             backboard_dependency(),
             ceiling_shot_dependency(),
             wall_aerial_dependency(),

--- a/src/stats/timeline/collector_tests.rs
+++ b/src/stats/timeline/collector_tests.rs
@@ -174,6 +174,10 @@ fn event_timeline_graph_does_not_build_full_stats_frame_snapshots() {
         !node_names.contains(&"stats_timeline_frame"),
         "event timeline transfer should not evaluate the full partial-sum frame node"
     );
+    assert!(
+        !node_names.contains(&"stats_projection"),
+        "event timeline transfer should not evaluate full partial-sum projections"
+    );
 }
 
 fn assert_event_timeline_scaffold_matches_full_timeline_without_stat_snapshots(replay_path: &str) {


### PR DESCRIPTION
## Summary
- remove the unused stats projection dependency from compact stats timeline event export
- add a graph-shape regression assertion so compact event timelines do not materialize full partial-sum projections

## Root cause
`StatsTimelineEventsNode` depended on `stats_projection` even though it only exports event streams. That forced `StatsTimelineEventCollector` to run the full per-frame stats projection path, where several modules replay accumulated event streams each frame.

## Validation
- `cargo test -q -p subtr-actor event_timeline_graph_does_not_build_full_stats_frame_snapshots`
- pre-commit hook: `cargo clippy --all-targets --all-features -- -D warnings`
- release benchmark on `assets/post-eac-ranked-standard-2026-04-28.replay`: compact stats timeline averaged ~1.48s after the fix versus ~90.6s before