### PR TITLE
Default missing replay metadata during export

### DIFF
--- a/src/collector/replay_data.rs
+++ b/src/collector/replay_data.rs
@@ -421,16 +421,14 @@ impl MetadataFrame {
     ///
     /// # Errors
     ///
-    /// Returns a [`SubtrActorError`] if the seconds remaining cannot be retrieved
-    /// from the processor.
+    /// Missing replay metadata fields default to 0 so frame export can continue
+    /// for replays whose metadata actor does not carry every optional property.
     fn new_from_processor(processor: &dyn ProcessorView, time: f32) -> SubtrActorResult<Self> {
         Ok(Self::new(
             time,
-            processor.get_seconds_remaining()?,
-            processor.get_replicated_state_name().unwrap_or(0),
-            processor
-                .get_replicated_game_state_time_remaining()
-                .unwrap_or(0),
+            metadata_i32_or_default(processor.get_seconds_remaining()),
+            metadata_i32_or_default(processor.get_replicated_state_name()),
+            metadata_i32_or_default(processor.get_replicated_game_state_time_remaining()),
         ))
     }
 
@@ -461,6 +459,14 @@ impl MetadataFrame {
         }
     }
 }
+
+fn metadata_i32_or_default(value: SubtrActorResult<i32>) -> i32 {
+    value.unwrap_or(0)
+}
+
+#[cfg(test)]
+#[path = "replay_data_tests.rs"]
+mod replay_data_tests;
 
 /// Contains all frame-by-frame data for a Rocket League replay.
 ///

--- a/src/collector/replay_data_tests.rs
+++ b/src/collector/replay_data_tests.rs
@@ -1,0 +1,15 @@
+use super::*;
+
+#[test]
+fn missing_metadata_i32_defaults_to_zero() {
+    let missing_seconds = SubtrActorError::new(SubtrActorErrorVariant::PropertyNotFoundInState {
+        property: SECONDS_REMAINING_KEY,
+    });
+
+    assert_eq!(metadata_i32_or_default(Err(missing_seconds)), 0);
+}
+
+#[test]
+fn present_metadata_i32_is_preserved() {
+    assert_eq!(metadata_i32_or_default(Ok(42)), 42);
+}


### PR DESCRIPTION
## Summary

- Default missing replay metadata integer fields to `0` when exporting `ReplayData` frames.
- Apply the same best-effort behavior to `SecondsRemaining` that the replay data export already used for replicated game-state fields.
- Add focused tests for preserving present metadata and defaulting missing metadata.

## Root cause

The browser replay/review player reparses replay files through the WASM `ReplayDataCollector`. Some replay frames can lack `TAGame.GameEvent_Soccar_TA:SecondsRemaining` on the metadata actor, and the collector previously propagated that lookup error while assembling frame metadata. That made review playback fail even when event detection had already processed the replay successfully through other pipelines.

## Validation

- `cargo test -p subtr-actor collector::replay_data::replay_data_tests`
- `cargo run -q -p subtr-actor-tools --bin replay_probe -- plausibility /tmp/rs-019e5429-5ac5-76e3-b7d1-d829d3d994ea.replay`
- `cargo clippy -p subtr-actor --all-targets -- -D warnings`
