### PR TITLE
Bound events review preload and scrolling

### DIFF
--- a/js/stat-evaluation-player/src/appTemplate.ts
+++ b/js/stat-evaluation-player/src/appTemplate.ts
@@ -28,7 +28,7 @@ export function getAppTemplate(defaultCameraDistanceScale: number): string {
               <button type="button" data-window-toggle="recording">Recording</button>
               <button type="button" data-window-toggle="mechanics">Events</button>
               <button type="button" data-window-toggle="event-playlist">Event playlist</button>
-              <button type="button" data-window-toggle="mechanics-review">Mechanics review</button>
+              <button type="button" data-window-toggle="mechanics-review">Events review</button>
               <button type="button" data-window-toggle="replay-loading">Replay loading</button>
               <button type="button" data-window-toggle="boost-pickups">Boost pickup filters</button>
               <button type="button" data-window-toggle="touch-controls">Touch controls</button>
@@ -394,7 +394,7 @@ export function getAppTemplate(defaultCameraDistanceScale: number): string {
           >
             <header class="floating-window-header">
               <div>
-                <h2>Mechanics review</h2>
+                <h2>Events review</h2>
               </div>
               <button class="floating-window-hide" type="button" data-window-hide="mechanics-review">
                 Hide
@@ -422,7 +422,7 @@ export function getAppTemplate(defaultCameraDistanceScale: number): string {
                 <h3 id="mechanics-review-title">No candidate selected</h3>
                 <dl class="mechanics-review-fields">
                   <div>
-                    <dt>Mechanic</dt>
+                    <dt>Event type</dt>
                     <dd id="mechanics-review-mechanic">--</dd>
                   </div>
                   <div>

--- a/js/stat-evaluation-player/src/eventTimelineSources.ts
+++ b/js/stat-evaluation-player/src/eventTimelineSources.ts
@@ -200,7 +200,7 @@ export function getEventTimelineSources({
       playlistId: `mechanic:${kind}`,
       timelineKey: `mechanic:${kind}`,
       timelineId: `mechanic:${kind}`,
-      group: "Mechanics",
+      group: "Event types",
       label: formatMechanicKind(kind),
       count,
       active: activeMechanicTimelineKinds.has(kind),

--- a/js/stat-evaluation-player/src/mechanicsReview.ts
+++ b/js/stat-evaluation-player/src/mechanicsReview.ts
@@ -466,7 +466,12 @@ export function formatMechanicsReviewEventDetails(item: MechanicsReviewItem): st
 }
 
 export function getMechanicsReviewItemLabel(item: MechanicsReviewItem, index: number): string {
-  return item.label ?? item.meta?.eventTypeLabel ?? item.meta?.mechanicLabel ?? `Review item ${index + 1}`;
+  return (
+    item.label ??
+    item.meta?.eventTypeLabel ??
+    item.meta?.mechanicLabel ??
+    `Review item ${index + 1}`
+  );
 }
 
 export function getMechanicsReviewPlayerId(item: MechanicsReviewItem): string | null {

--- a/js/stat-evaluation-player/src/mechanicsReview.ts
+++ b/js/stat-evaluation-player/src/mechanicsReview.ts
@@ -30,6 +30,8 @@ export interface MechanicsReviewReplay {
 export interface MechanicsReviewItemMeta {
   confidence?: number | null;
   eventId?: string;
+  eventType?: string;
+  eventTypeLabel?: string;
   mechanic?: string;
   mechanicLabel?: string;
   playerId?: string;
@@ -464,7 +466,7 @@ export function formatMechanicsReviewEventDetails(item: MechanicsReviewItem): st
 }
 
 export function getMechanicsReviewItemLabel(item: MechanicsReviewItem, index: number): string {
-  return item.label ?? item.meta?.mechanicLabel ?? `Review item ${index + 1}`;
+  return item.label ?? item.meta?.eventTypeLabel ?? item.meta?.mechanicLabel ?? `Review item ${index + 1}`;
 }
 
 export function getMechanicsReviewPlayerId(item: MechanicsReviewItem): string | null {
@@ -478,14 +480,18 @@ export function getMechanicsReviewPlayerId(item: MechanicsReviewItem): string | 
 }
 
 export function getMechanicsReviewMechanicLabel(item: MechanicsReviewItem): string {
+  if (typeof item.meta?.eventTypeLabel === "string" && item.meta.eventTypeLabel.trim()) {
+    return item.meta.eventTypeLabel;
+  }
   if (typeof item.meta?.mechanicLabel === "string" && item.meta.mechanicLabel.trim()) {
     return item.meta.mechanicLabel;
   }
-  return typeof item.meta?.mechanic === "string" ? formatMechanicKind(item.meta.mechanic) : "--";
+  const eventType = item.meta?.eventType ?? item.meta?.mechanic;
+  return typeof eventType === "string" ? formatMechanicKind(eventType) : "--";
 }
 
 export function getMechanicsReviewMechanicKind(item: MechanicsReviewItem): string | null {
-  const mechanic = item.meta?.mechanic;
+  const mechanic = item.meta?.eventType ?? item.meta?.mechanic;
   return typeof mechanic === "string" && mechanic.trim()
     ? mechanic.trim().replaceAll("-", "_")
     : null;

--- a/js/stat-evaluation-player/src/mechanicsReviewReplayLoads.ts
+++ b/js/stat-evaluation-player/src/mechanicsReviewReplayLoads.ts
@@ -82,17 +82,19 @@ export class MechanicsReviewReplayLoadsController {
     }
   }
 
-  preload(review: ActiveMechanicsReview, currentReplayId: string): void {
+  preload(review: ActiveMechanicsReview, currentIndex: number): void {
     if (review.preloading) {
+      return;
+    }
+    const items = this.getNextReplayItems(review, currentIndex);
+    if (items.length === 0) {
       return;
     }
     review.preloading = true;
     void (async () => {
       try {
-        for (const [replayId, item] of this.getReplayItems(review)) {
-          if (replayId === currentReplayId) {
-            continue;
-          }
+        for (const item of items) {
+          const replayId = item.replay;
           const state = review.replayLoadStates.get(replayId);
           if (state?.status === "loaded" || state?.status === "loading") {
             continue;
@@ -274,6 +276,27 @@ export class MechanicsReviewReplayLoadsController {
       counts.set(item.replay, (counts.get(item.replay) ?? 0) + 1);
     }
     return counts;
+  }
+
+  private getNextReplayItems(
+    review: ActiveMechanicsReview,
+    currentIndex: number,
+  ): MechanicsReviewItem[] {
+    const currentReplayId = review.manifest.items[currentIndex]?.replay;
+    const seenReplayIds = new Set<string>(currentReplayId ? [currentReplayId] : []);
+    const items: MechanicsReviewItem[] = [];
+
+    for (let index = currentIndex + 1; index < review.manifest.items.length; index += 1) {
+      const item = review.manifest.items[index];
+      if (!item || seenReplayIds.has(item.replay)) {
+        continue;
+      }
+      seenReplayIds.add(item.replay);
+      items.push(item);
+      break;
+    }
+
+    return items;
   }
 
   private replayLoadStatusText(state: MechanicsReviewReplayLoadState): string {

--- a/js/stat-evaluation-player/src/mechanicsReviewWindow.ts
+++ b/js/stat-evaluation-player/src/mechanicsReviewWindow.ts
@@ -313,7 +313,7 @@ export class MechanicsReviewWindowController {
         await this.options.loadReplayBundleForDisplay(source, replayBundlePromise);
         review.currentReplayId = item.replay;
       }
-      this.options.replayLoads.preload(review, item.replay);
+      this.options.replayLoads.preload(review, index);
 
       const timeBase = review.manifest.playback?.timeBase;
       const startTime = Math.max(0, this.getBoundTime(item, item.start, timeBase));
@@ -481,7 +481,7 @@ function getMechanicsReviewDecisionEndpoint(item: MechanicsReviewItem | null): s
   }
   const eventId =
     typeof item.meta?.eventId === "string" && item.meta.eventId ? item.meta.eventId : item.id;
-  return eventId ? `/api/v1/mechanics/events/${encodeURIComponent(eventId)}/reviews` : null;
+  return eventId ? `/api/v1/events/${encodeURIComponent(eventId)}/reviews` : null;
 }
 
 function mechanicsReviewAuthHeaders(): Record<string, string> {

--- a/js/stat-evaluation-player/src/report.ts
+++ b/js/stat-evaluation-player/src/report.ts
@@ -747,7 +747,7 @@ function renderInvolvementPage(finalFrame: StatsFrame, definitions: StatDefiniti
   page.append(
     el("p", {
       className: "stats-report-note",
-      text: "Experimental mechanic detectors such as musty flicks, speed flips, dodge refreshes, and ceiling shots are kept in All stats until their precision is stronger.",
+      text: "Experimental event detectors such as musty flicks, speed flips, dodge refreshes, and ceiling shots are kept in All stats until their precision is stronger.",
     }),
   );
   return page;

--- a/js/stat-evaluation-player/src/styles/windows.css
+++ b/js/stat-evaluation-player/src/styles/windows.css
@@ -84,6 +84,10 @@
 .mechanics-review-window-body {
   display: grid;
   gap: var(--ui-gap-md);
+  max-height: min(74dvh, 42rem);
+  min-height: 0;
+  overflow: hidden auto;
+  scrollbar-width: thin;
 }
 
 .event-playlist-window-body {
@@ -354,6 +358,8 @@
 .replay-loading-window-body {
   display: grid;
   gap: var(--ui-gap-sm);
+  max-height: min(72dvh, 40rem);
+  min-height: 0;
 }
 
 .replay-loading-summary {
@@ -463,9 +469,12 @@
 }
 
 .mechanics-review-list {
+  max-height: min(22rem, calc(100dvh - 27rem));
   display: grid;
   gap: var(--ui-gap-xs);
-  overflow: visible;
+  overflow: auto;
+  padding-right: 0.15rem;
+  scrollbar-width: thin;
 }
 
 .mechanics-review-item {


### PR DESCRIPTION
## Summary
- Rename the mechanics review surface toward events review terminology while preserving existing mechanics metadata fallbacks.
- Cap the events review and replay-loading window/list heights so long manifests scroll instead of expanding indefinitely.
- Limit events review background preloading to the next distinct replay after the current item.

## Why
Large review manifests could make the review window grow without bound and could queue every replay in the playlist for background loading. Review workflows only need the active replay plus the next distinct replay to keep navigation responsive without unbounded memory/network pressure.

## Validation
- `node --run=check:tsc` in `js/stat-evaluation-player`
