### PR TITLE
[codex] speed up rust test suite

### DIFF
--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -3121,7 +3121,12 @@ def main() -> int:
     )
     require_contains(
         web_player_main_source,
-        'return item.label ?? item.meta?.mechanicLabel ?? `Review item ${index + 1}`;',
+        "return (\n"
+        "    item.label ??\n"
+        "    item.meta?.eventTypeLabel ??\n"
+        "    item.meta?.mechanicLabel ??\n"
+        "    `Review item ${index + 1}`\n"
+        "  );",
         "stats evaluation player mechanics review item labels have mechanic fallback",
         errors,
     )
@@ -3281,7 +3286,8 @@ def main() -> int:
         )
     require_contains(
         web_player_main_source,
-        'return typeof item.meta?.mechanic === "string" ? formatMechanicKind(item.meta.mechanic) : "--";',
+        "const eventType = item.meta?.eventType ?? item.meta?.mechanic;\n"
+        '  return typeof eventType === "string" ? formatMechanicKind(eventType) : "--";',
         "stats evaluation player mechanics review formats mechanic ids",
         errors,
     )

--- a/src/collector/ndarray/collector.rs
+++ b/src/collector/ndarray/collector.rs
@@ -125,9 +125,9 @@ impl<F> NDArrayCollector<F> {
         let column_headers = self.get_column_headers();
         Ok((
             ReplayMetaWithHeaders {
-                replay_meta: self.replay_meta.ok_or(SubtrActorError::new(
-                    SubtrActorErrorVariant::CouldNotBuildReplayMeta,
-                ))?,
+                replay_meta: self.replay_meta.ok_or_else(|| {
+                    SubtrActorError::new(SubtrActorErrorVariant::CouldNotBuildReplayMeta)
+                })?,
                 column_headers,
             },
             ndarray::Array2::from_shape_vec((self.frames_added, features_per_row), self.data)
@@ -148,9 +148,9 @@ impl<F> NDArrayCollector<F> {
             replay_meta: self
                 .replay_meta
                 .as_ref()
-                .ok_or(SubtrActorError::new(
-                    SubtrActorErrorVariant::CouldNotBuildReplayMeta,
-                ))?
+                .ok_or_else(|| {
+                    SubtrActorError::new(SubtrActorErrorVariant::CouldNotBuildReplayMeta)
+                })?
                 .clone(),
             column_headers: self.get_column_headers(),
         })
@@ -160,9 +160,7 @@ impl<F> NDArrayCollector<F> {
         let player_count = self
             .replay_meta
             .as_ref()
-            .ok_or(SubtrActorError::new(
-                SubtrActorErrorVariant::CouldNotBuildReplayMeta,
-            ))?
+            .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::CouldNotBuildReplayMeta))?
             .player_count();
         let global_feature_count: usize = self
             .feature_adders

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -133,7 +133,11 @@ pub struct SubtrActorError {
 impl SubtrActorError {
     pub fn new(variant: SubtrActorErrorVariant) -> Self {
         Self {
-            backtrace: Backtrace::capture(),
+            backtrace: if std::env::var_os("SUBTR_ACTOR_ERROR_BACKTRACE").is_some() {
+                Backtrace::capture()
+            } else {
+                Backtrace::disabled()
+            },
             variant,
         }
     }

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -601,9 +601,7 @@ impl<'a> ReplayProcessor<'a> {
             .replay
             .network_frames
             .as_ref()
-            .ok_or(SubtrActorError::new(
-                SubtrActorErrorVariant::NoNetworkFrames,
-            ))?
+            .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::NoNetworkFrames))?
             .frames
             .iter()
             .enumerate()
@@ -660,9 +658,7 @@ impl<'a> ReplayProcessor<'a> {
             .replay
             .network_frames
             .as_ref()
-            .ok_or(SubtrActorError::new(
-                SubtrActorErrorVariant::NoNetworkFrames,
-            ))?
+            .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::NoNetworkFrames))?
             .frames
             .iter()
             .enumerate()

--- a/src/processor/player_queries.rs
+++ b/src/processor/player_queries.rs
@@ -71,9 +71,7 @@ impl<'a> ReplayProcessor<'a> {
     /// Returns the current ball rigid body from live actor state.
     pub fn get_ball_rigid_body(&self) -> SubtrActorResult<&boxcars::RigidBody> {
         self.ball_actor_id
-            .ok_or(SubtrActorError::new(
-                SubtrActorErrorVariant::BallActorNotFound,
-            ))
+            .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::BallActorNotFound))
             .and_then(|actor_id| self.get_actor_rigid_body(&actor_id).map(|v| v.0))
     }
 
@@ -96,9 +94,7 @@ impl<'a> ReplayProcessor<'a> {
         &self,
     ) -> SubtrActorResult<(&boxcars::RigidBody, &usize)> {
         self.ball_actor_id
-            .ok_or(SubtrActorError::new(
-                SubtrActorErrorVariant::BallActorNotFound,
-            ))
+            .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::BallActorNotFound))
             .and_then(|actor_id| {
                 get_attribute_and_updated!(
                     self,
@@ -251,7 +247,7 @@ impl<'a> ReplayProcessor<'a> {
         } else {
             self.team_one.first()
         }
-        .ok_or(SubtrActorError::new(SubtrActorErrorVariant::NoGameActor))?;
+        .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::NoGameActor))?;
 
         self.player_to_team
             .get(&self.get_player_actor_id(player_id)?)

--- a/src/processor/queries.rs
+++ b/src/processor/queries.rs
@@ -13,9 +13,7 @@ impl<'a> ReplayProcessor<'a> {
             .replay
             .network_frames
             .as_ref()
-            .ok_or(SubtrActorError::new(
-                SubtrActorErrorVariant::NoNetworkFrames,
-            ))?;
+            .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::NoNetworkFrames))?;
         match direction {
             SearchDirection::Forward => {
                 for index in (current_index + 1)..frames.frames.len() {
@@ -201,14 +199,10 @@ impl<'a> ReplayProcessor<'a> {
         self.replay
             .network_frames
             .as_ref()
-            .ok_or(SubtrActorError::new(
-                SubtrActorErrorVariant::NoNetworkFrames,
-            ))?
+            .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::NoNetworkFrames))?
             .frames
             .get(frame_index)
-            .ok_or(SubtrActorError::new(
-                SubtrActorErrorVariant::FrameIndexOutOfBounds,
-            ))
+            .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::FrameIndexOutOfBounds))
     }
 
     pub(crate) fn velocities_applied_rigid_body(
@@ -368,9 +362,8 @@ impl<'a> ReplayProcessor<'a> {
 
     /// Returns the tracked actor id for the replay ball.
     pub fn get_ball_actor_id(&self) -> SubtrActorResult<boxcars::ActorId> {
-        self.ball_actor_id.ok_or(SubtrActorError::new(
-            SubtrActorErrorVariant::BallActorNotFound,
-        ))
+        self.ball_actor_id
+            .ok_or_else(|| SubtrActorError::new(SubtrActorErrorVariant::BallActorNotFound))
     }
 
     /// Returns the main game metadata actor id.

--- a/src/stats/analysis_graph/module_tests.rs
+++ b/src/stats/analysis_graph/module_tests.rs
@@ -186,6 +186,7 @@ fn continuous_ball_control_is_directly_callable() {
 }
 
 #[test]
+#[ignore = "broad real-replay JSON smoke is slow; graph construction and focused replay regressions run in CI"]
 fn every_builtin_analysis_node_has_shared_json_output_on_real_replay() {
     let replay = parse_replay(ANALYSIS_GRAPH_REAL_REPLAY_FIXTURE);
     let graph = collect_analysis_graph_for_replay(&replay, graph_with_all_analysis_nodes())
@@ -283,6 +284,7 @@ fn evaluates_all_reducer_nodes_against_a_real_replay() {
 }
 
 #[test]
+#[ignore = "full graph versus legacy timeline replay parity is slow; run explicitly when changing graph/timeline transfer"]
 fn full_analysis_graph_matches_stats_timeline_events_on_real_replay() {
     let replay = parse_replay(ANALYSIS_GRAPH_REAL_REPLAY_FIXTURE);
     let graph = collect_analysis_graph_for_replay(&replay, graph_with_all_analysis_nodes())

--- a/src/stats/analysis_graph/module_tests.rs
+++ b/src/stats/analysis_graph/module_tests.rs
@@ -14,6 +14,8 @@ use std::any::TypeId;
 use std::collections::HashSet;
 use std::path::Path;
 
+const ANALYSIS_GRAPH_REAL_REPLAY_FIXTURE: &str = "assets/post-eac-ranked-duel-2026-04-28-a.replay";
+
 fn parse_replay(path: &str) -> boxcars::Replay {
     let replay_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
     let data = std::fs::read(&replay_path)
@@ -185,9 +187,11 @@ fn continuous_ball_control_is_directly_callable() {
 
 #[test]
 fn every_builtin_analysis_node_has_shared_json_output_on_real_replay() {
-    let replay = parse_replay("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay");
+    let replay = parse_replay(ANALYSIS_GRAPH_REAL_REPLAY_FIXTURE);
     let graph = collect_analysis_graph_for_replay(&replay, graph_with_all_analysis_nodes())
         .expect("graph should evaluate a real replay");
+
+    assert_all_reducer_states_are_present(&graph);
 
     for name in builtin_analysis_node_names() {
         let value = builtin_analysis_node_json(name, &graph)
@@ -237,12 +241,7 @@ fn every_builtin_analysis_node_has_shared_json_output_on_real_replay() {
     );
 }
 
-#[test]
-fn evaluates_all_reducer_nodes_against_a_real_replay() {
-    let replay = parse_replay("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay");
-    let graph = collect_analysis_graph_for_replay(&replay, graph_with_all_analysis_nodes())
-        .expect("graph should evaluate a real replay");
-
+fn assert_all_reducer_states_are_present(graph: &AnalysisGraph) {
     assert!(graph.state::<PlayerVerticalState>().is_some());
     assert!(graph.state::<TouchState>().is_some());
     assert!(graph.state::<PossessionState>().is_some());
@@ -274,8 +273,18 @@ fn evaluates_all_reducer_nodes_against_a_real_replay() {
 }
 
 #[test]
+#[ignore = "covered by every_builtin_analysis_node_has_shared_json_output_on_real_replay; run explicitly when debugging graph state materialization"]
+fn evaluates_all_reducer_nodes_against_a_real_replay() {
+    let replay = parse_replay(ANALYSIS_GRAPH_REAL_REPLAY_FIXTURE);
+    let graph = collect_analysis_graph_for_replay(&replay, graph_with_all_analysis_nodes())
+        .expect("graph should evaluate a real replay");
+
+    assert_all_reducer_states_are_present(&graph);
+}
+
+#[test]
 fn full_analysis_graph_matches_stats_timeline_events_on_real_replay() {
-    let replay = parse_replay("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay");
+    let replay = parse_replay(ANALYSIS_GRAPH_REAL_REPLAY_FIXTURE);
     let graph = collect_analysis_graph_for_replay(&replay, graph_with_all_analysis_nodes())
         .expect("full graph should evaluate a real replay");
     let graph_events = graph

--- a/src/stats/timeline/collector_tests.rs
+++ b/src/stats/timeline/collector_tests.rs
@@ -319,6 +319,7 @@ fn assert_event_timeline_scaffold_matches_full_timeline_without_stat_snapshots(r
 }
 
 #[test]
+#[ignore = "compact/full timeline scaffold replay parity is slow; run explicitly when changing timeline transfer"]
 fn event_timeline_scaffold_matches_full_timeline_without_stat_snapshots() {
     assert_event_timeline_scaffold_matches_full_timeline_without_stat_snapshots(
         STATS_TIMELINE_FIXTURE,

--- a/src/stats/timeline/collector_tests.rs
+++ b/src/stats/timeline/collector_tests.rs
@@ -1,8 +1,7 @@
 use super::*;
 use std::collections::BTreeMap;
 
-const STATS_TIMELINE_FIXTURE: &str =
-    "assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay";
+const STATS_TIMELINE_FIXTURE: &str = "assets/post-eac-ranked-duel-2026-04-28-a.replay";
 
 const REPLAY_FORMAT_EVOLUTION_DOC: &str = include_str!("../../../docs/replay-format-evolution.md");
 

--- a/tests/air_dribble_replay_test.rs
+++ b/tests/air_dribble_replay_test.rs
@@ -5,7 +5,7 @@ use subtr_actor::{GoalTagKind, StatsTimelineEventCollector};
 const AIR_DRIBBLE_GOAL_MOUTH_REPLAY: &str = "assets/air-dribble-goal-mouth-2026-05-24.replay";
 
 #[test]
-fn detects_colonelpanic8_air_dribble_goal_roughly_at_goal_sequence() {
+fn detects_air_dribble_goal_and_rejects_unrelated_half_volley_tag() {
     let replay = common::parse_replay(AIR_DRIBBLE_GOAL_MOUTH_REPLAY);
     let timeline = StatsTimelineEventCollector::new()
         .get_replay_stats_timeline_scaffold(&replay)
@@ -29,14 +29,6 @@ fn detects_colonelpanic8_air_dribble_goal_roughly_at_goal_sequence() {
         common::mechanic_event_unsigned_property(event, "touch_count").unwrap_or(0) >= 3,
         "expected colonelpanic8 air dribble to include at least 3 touches"
     );
-}
-
-#[test]
-fn does_not_tag_sixth_goal_as_half_volley() {
-    let replay = common::parse_replay(AIR_DRIBBLE_GOAL_MOUTH_REPLAY);
-    let timeline = StatsTimelineEventCollector::new()
-        .get_replay_stats_timeline_scaffold(&replay)
-        .expect("failed to collect stats timeline for air dribble goal replay");
 
     assert!(
         timeline.events.goal_context.len() >= 6,

--- a/tests/air_dribble_replay_test.rs
+++ b/tests/air_dribble_replay_test.rs
@@ -1,18 +1,19 @@
 mod common;
 
-use subtr_actor::{GoalTagKind, StatsTimelineCollector};
+use subtr_actor::{GoalTagKind, StatsTimelineEventCollector};
 
 const AIR_DRIBBLE_GOAL_MOUTH_REPLAY: &str = "assets/air-dribble-goal-mouth-2026-05-24.replay";
 
 #[test]
 fn detects_colonelpanic8_air_dribble_goal_roughly_at_goal_sequence() {
     let replay = common::parse_replay(AIR_DRIBBLE_GOAL_MOUTH_REPLAY);
-    let timeline = StatsTimelineCollector::new()
-        .get_legacy_replay_stats_timeline(&replay)
+    let timeline = StatsTimelineEventCollector::new()
+        .get_replay_stats_timeline_scaffold(&replay)
         .expect("failed to collect stats timeline for air dribble goal replay");
 
-    let event = common::assert_mechanic_event_roughly_at(
-        &timeline,
+    let event = common::assert_mechanic_event_roughly_at_in_meta(
+        &timeline.replay_meta,
+        &timeline.events.mechanics,
         "air_dribble",
         "colonelpanic8",
         56.37,
@@ -33,8 +34,8 @@ fn detects_colonelpanic8_air_dribble_goal_roughly_at_goal_sequence() {
 #[test]
 fn does_not_tag_sixth_goal_as_half_volley() {
     let replay = common::parse_replay(AIR_DRIBBLE_GOAL_MOUTH_REPLAY);
-    let timeline = StatsTimelineCollector::new()
-        .get_legacy_replay_stats_timeline(&replay)
+    let timeline = StatsTimelineEventCollector::new()
+        .get_replay_stats_timeline_scaffold(&replay)
         .expect("failed to collect stats timeline for air dribble goal replay");
 
     assert!(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use serde::Serialize;
 use serde_json::Value;
 use subtr_actor::{
-    CoreTeamStats, ReplayStatsFrame, ReplayStatsTimeline, ReplayStatsTimelineEvents,
+    CoreTeamStats, ReplayMeta, ReplayStatsFrame, ReplayStatsTimeline, ReplayStatsTimelineEvents,
     StatsEventPropertyValue, StatsEventTiming, StatsTimelineTagEvent, TeamStatsSnapshot,
 };
 
@@ -35,11 +35,60 @@ pub fn mechanic_event_player_name<'a>(
     timeline: &'a ReplayStatsTimeline,
     event: &StatsTimelineTagEvent,
 ) -> Option<&'a str> {
-    timeline
-        .replay_meta
+    mechanic_event_player_name_in_meta(&timeline.replay_meta, event)
+}
+
+#[allow(dead_code)]
+pub fn mechanic_event_player_name_in_meta<'a>(
+    replay_meta: &'a ReplayMeta,
+    event: &StatsTimelineTagEvent,
+) -> Option<&'a str> {
+    replay_meta
         .player_order()
         .find(|player| player.remote_id == event.player_id)
         .map(|player| player.name.as_str())
+}
+
+#[allow(dead_code)]
+pub fn assert_mechanic_event_roughly_at_in_meta<'a>(
+    replay_meta: &'a ReplayMeta,
+    events: &'a [StatsTimelineTagEvent],
+    kind: &str,
+    player_name: &str,
+    expected_start_time: f32,
+    expected_end_time: f32,
+    tolerance_seconds: f32,
+) -> &'a StatsTimelineTagEvent {
+    let event = events.iter().find(|event| {
+        if event.kind != kind {
+            return false;
+        }
+        if mechanic_event_player_name_in_meta(replay_meta, event) != Some(player_name) {
+            return false;
+        }
+        let (start_time, end_time) = mechanic_event_time_span(event);
+        (start_time - expected_start_time).abs() <= tolerance_seconds
+            && (end_time - expected_end_time).abs() <= tolerance_seconds
+    });
+
+    event.unwrap_or_else(|| {
+        let candidates = events
+            .iter()
+            .filter(|event| event.kind == kind)
+            .map(|event| {
+                let (start_time, end_time) = mechanic_event_time_span(event);
+                let player =
+                    mechanic_event_player_name_in_meta(replay_meta, event).unwrap_or("<unknown>");
+                format!("{kind} by {player} at {start_time:.3}-{end_time:.3}s")
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        panic!(
+            "expected {kind} by {player_name} around \
+             {expected_start_time:.3}-{expected_end_time:.3}s (+/- {tolerance_seconds:.3}s); \
+             candidates: [{candidates}]"
+        );
+    })
 }
 
 #[allow(dead_code)]
@@ -51,37 +100,15 @@ pub fn assert_mechanic_event_roughly_at<'a>(
     expected_end_time: f32,
     tolerance_seconds: f32,
 ) -> &'a StatsTimelineTagEvent {
-    let event = timeline.events.mechanics.iter().find(|event| {
-        if event.kind != kind {
-            return false;
-        }
-        if mechanic_event_player_name(timeline, event) != Some(player_name) {
-            return false;
-        }
-        let (start_time, end_time) = mechanic_event_time_span(event);
-        (start_time - expected_start_time).abs() <= tolerance_seconds
-            && (end_time - expected_end_time).abs() <= tolerance_seconds
-    });
-
-    event.unwrap_or_else(|| {
-        let candidates = timeline
-            .events
-            .mechanics
-            .iter()
-            .filter(|event| event.kind == kind)
-            .map(|event| {
-                let (start_time, end_time) = mechanic_event_time_span(event);
-                let player = mechanic_event_player_name(timeline, event).unwrap_or("<unknown>");
-                format!("{kind} by {player} at {start_time:.3}-{end_time:.3}s")
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        panic!(
-            "expected {kind} by {player_name} around \
-             {expected_start_time:.3}-{expected_end_time:.3}s (+/- {tolerance_seconds:.3}s); \
-             candidates: [{candidates}]"
-        );
-    })
+    assert_mechanic_event_roughly_at_in_meta(
+        &timeline.replay_meta,
+        &timeline.events.mechanics,
+        kind,
+        player_name,
+        expected_start_time,
+        expected_end_time,
+        tolerance_seconds,
+    )
 }
 
 #[allow(dead_code)]

--- a/tests/double_tap_replay_test.rs
+++ b/tests/double_tap_replay_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use subtr_actor::{GoalTagKind, StatsFrameResolution, StatsTimelineEventCollector};
+use subtr_actor::{GoalTagKind, StatsTimelineEventCollector};
 
 const THIRD_GOAL_DOUBLE_TAP_REPLAY: &str =
     "assets/colonelpanic8-double-tap-third-goal-2026-05-24.replay";
@@ -42,9 +42,21 @@ fn tags_colonelpanic8_third_goal_as_double_tap() {
         "expected third goal to be tagged as a double tap; got {:?}",
         timeline.events.goal_context
     );
+
+    let value = serde_json::to_value(&timeline).expect("event timeline should serialize");
+    let mechanics = value["events"]["mechanics"]
+        .as_array()
+        .expect("timeline value should expose mechanics as an array");
+    assert!(
+        mechanics
+            .iter()
+            .any(|event| event["kind"].as_str() == Some("double_tap")),
+        "expected value timeline mechanics stream to include the double tap"
+    );
 }
 
 #[test]
+#[ignore = "second full-replay double-tap variant is slow and duplicates default double-tap coverage"]
 fn tags_nuttrback_seventh_goal_as_double_tap() {
     let replay = common::parse_replay(NUTTRBACK_GOAL_7_DOUBLE_TAP_REPLAY);
     let timeline = StatsTimelineEventCollector::new()
@@ -81,25 +93,5 @@ fn tags_nuttrback_seventh_goal_as_double_tap() {
             .any(|tag| tag.kind() == GoalTagKind::DoubleTapGoal)),
         "expected seventh goal to be tagged as a double tap; got {:?}",
         timeline.events.goal_context
-    );
-}
-
-#[test]
-fn dynamic_stats_timeline_value_includes_normalized_mechanics_stream() {
-    let replay = common::parse_replay(THIRD_GOAL_DOUBLE_TAP_REPLAY);
-    let value = StatsTimelineEventCollector::new()
-        .with_frame_resolution(StatsFrameResolution::TimeStep { seconds: 1.0 })
-        .get_replay_stats_timeline_scaffold(&replay)
-        .expect("failed to collect event timeline for double tap replay");
-    let value = serde_json::to_value(value).expect("event timeline should serialize");
-
-    let mechanics = value["events"]["mechanics"]
-        .as_array()
-        .expect("timeline value should expose mechanics as an array");
-    assert!(
-        mechanics
-            .iter()
-            .any(|event| event["kind"].as_str() == Some("double_tap")),
-        "expected value timeline mechanics stream to include the double tap"
     );
 }

--- a/tests/double_tap_replay_test.rs
+++ b/tests/double_tap_replay_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use subtr_actor::{GoalTagKind, StatsCollector, StatsFrameResolution, StatsTimelineCollector};
+use subtr_actor::{GoalTagKind, StatsFrameResolution, StatsTimelineEventCollector};
 
 const THIRD_GOAL_DOUBLE_TAP_REPLAY: &str =
     "assets/colonelpanic8-double-tap-third-goal-2026-05-24.replay";
@@ -10,8 +10,8 @@ const NUTTRBACK_GOAL_7_DOUBLE_TAP_REPLAY: &str =
 #[test]
 fn tags_colonelpanic8_third_goal_as_double_tap() {
     let replay = common::parse_replay(THIRD_GOAL_DOUBLE_TAP_REPLAY);
-    let timeline = StatsTimelineCollector::new()
-        .get_legacy_replay_stats_timeline(&replay)
+    let timeline = StatsTimelineEventCollector::new()
+        .get_replay_stats_timeline_scaffold(&replay)
         .expect("failed to collect stats timeline for double tap replay");
 
     assert!(
@@ -47,8 +47,8 @@ fn tags_colonelpanic8_third_goal_as_double_tap() {
 #[test]
 fn tags_nuttrback_seventh_goal_as_double_tap() {
     let replay = common::parse_replay(NUTTRBACK_GOAL_7_DOUBLE_TAP_REPLAY);
-    let timeline = StatsTimelineCollector::new()
-        .get_legacy_replay_stats_timeline(&replay)
+    let timeline = StatsTimelineEventCollector::new()
+        .get_replay_stats_timeline_scaffold(&replay)
         .expect("failed to collect stats timeline for double tap replay");
 
     assert!(
@@ -87,13 +87,11 @@ fn tags_nuttrback_seventh_goal_as_double_tap() {
 #[test]
 fn dynamic_stats_timeline_value_includes_normalized_mechanics_stream() {
     let replay = common::parse_replay(THIRD_GOAL_DOUBLE_TAP_REPLAY);
-    let value = StatsCollector::new()
+    let value = StatsTimelineEventCollector::new()
         .with_frame_resolution(StatsFrameResolution::TimeStep { seconds: 1.0 })
-        .capture_frames()
-        .get_captured_data(&replay)
-        .expect("failed to capture stats frames for double tap replay")
-        .into_legacy_stats_timeline_value()
-        .expect("failed to convert captured stats frames to timeline value");
+        .get_replay_stats_timeline_scaffold(&replay)
+        .expect("failed to collect event timeline for double tap replay");
+    let value = serde_json::to_value(value).expect("event timeline should serialize");
 
     let mechanics = value["events"]["mechanics"]
         .as_array()

--- a/tests/post_eac_replay_fixture_test.rs
+++ b/tests/post_eac_replay_fixture_test.rs
@@ -75,7 +75,7 @@ fn assert_finite_json(value: &Value, path: &str) {
 }
 
 #[test]
-fn post_eac_ranked_standard_second_goal_is_not_own_half_goal() {
+fn post_eac_ranked_standard_goal_tags_handle_late_touch_and_low_touch_cases() {
     let replay = common::parse_replay(POST_EAC_RANKED_STANDARD_REPLAY);
     let timeline = StatsTimelineEventCollector::new()
         .get_replay_stats_timeline_scaffold(&replay)
@@ -108,14 +108,6 @@ fn post_eac_ranked_standard_second_goal_is_not_own_half_goal() {
             .any(|tag| tag.kind() == GoalTagKind::OwnHalfGoal)),
         "second goal should not be tagged as own-half"
     );
-}
-
-#[test]
-fn post_eac_ranked_standard_third_goal_is_not_aerial_goal() {
-    let replay = common::parse_replay(POST_EAC_RANKED_STANDARD_REPLAY);
-    let timeline = StatsTimelineEventCollector::new()
-        .get_replay_stats_timeline_scaffold(&replay)
-        .expect("failed to collect stats timeline for post-EAC standard replay");
 
     let third_goal = timeline
         .events
@@ -189,136 +181,156 @@ fn post_eac_replays_parse_and_match_expected_headers() {
 
 #[test]
 fn post_eac_replays_emit_structured_replay_data() {
-    for fixture in POST_EAC_FIXTURES {
-        let replay = common::parse_replay(fixture.path);
-        let replay_data = ReplayDataCollector::new()
-            .get_replay_data(&replay)
-            .unwrap_or_else(|error| {
-                panic!(
-                    "failed to collect structured replay data for {}: {error:?}",
-                    fixture.path
-                )
-            });
-
-        assert_eq!(
-            replay_data.meta.player_count(),
-            fixture.player_count,
-            "{} player count",
-            fixture.path
-        );
-        assert!(
-            replay_data.frame_data.frame_count() > 0,
-            "{} should emit frame data",
-            fixture.path
-        );
-        assert!(
-            replay_data.frame_data.duration() > 0.0,
-            "{} should have positive duration",
-            fixture.path
-        );
-        assert!(
-            replay_data
-                .frame_data
-                .players
-                .iter()
-                .all(|(_, player_data)| player_data.frames().iter().any(|frame| {
-                    matches!(frame, PlayerFrame::Data { rigid_body, .. } if rigid_body.location.x.is_finite())
-                })),
-            "{} should emit finite player rigid-body samples for every player",
-            fixture.path
-        );
-        assert!(
-            !replay_data.touch_events.is_empty(),
-            "{} should expose exact touch events",
-            fixture.path
-        );
-        assert!(
-            !replay_data.player_stat_events.is_empty(),
-            "{} should expose exact player-stat events",
-            fixture.path
-        );
-
-        let replay_json =
-            serde_json::to_value(&replay_data).expect("ReplayData should serialize to JSON");
-        assert_finite_json(&replay_json, fixture.path);
-    }
+    assert_post_eac_replay_emits_structured_replay_data(&POST_EAC_FIXTURES[0]);
 }
 
 #[test]
-fn post_eac_replays_emit_ndarray_features() {
+#[ignore = "broad post-EAC structured replay-data coverage is slow; representative fixture runs in CI"]
+fn all_post_eac_replays_emit_structured_replay_data() {
     for fixture in POST_EAC_FIXTURES {
-        let replay = common::parse_replay(fixture.path);
-        let mut collector = NDArrayCollector::<f32>::from_strings(
-            &[
-                "BallRigidBody",
-                "BallRigidBodyQuaternions",
-                "BallRigidBodyBasis",
-                "VelocityAddedBallRigidBodyNoVelocities",
-                "InterpolatedBallRigidBodyNoVelocities",
-                "SecondsRemaining",
-                "CurrentTime",
-                "FrameTime",
-                "ReplicatedStateName",
-                "ReplicatedGameStateTimeRemaining",
-                "BallHasBeenHit",
-            ],
-            &[
-                "PlayerRigidBody",
-                "PlayerRigidBodyQuaternions",
-                "PlayerRigidBodyBasis",
-                "PlayerRelativeBallPosition",
-                "PlayerRelativeBallVelocity",
-                "PlayerLocalRelativeBallPosition",
-                "PlayerLocalRelativeBallVelocity",
-                "VelocityAddedPlayerRigidBodyNoVelocities",
-                "InterpolatedPlayerRigidBodyNoVelocities",
-                "PlayerBallDistance",
-                "PlayerBoost",
-                "PlayerJump",
-                "PlayerAnyJump",
-                "PlayerDodgeRefreshed",
-                "PlayerDemolishedBy",
-            ],
-        )
-        .expect("post-EAC ndarray feature selection should be valid");
+        assert_post_eac_replay_emits_structured_replay_data(fixture);
+    }
+}
 
-        FrameRateDecorator::new_from_fps(30.0, &mut collector)
-            .process_replay(&replay)
-            .unwrap_or_else(|error| {
-                panic!(
-                    "failed to collect ndarray features for {}: {error:?}",
-                    fixture.path
-                )
-            });
-        let (meta, array) = collector.get_meta_and_ndarray().unwrap_or_else(|error| {
+fn assert_post_eac_replay_emits_structured_replay_data(fixture: &PostEacFixture) {
+    let replay = common::parse_replay(fixture.path);
+    let replay_data = ReplayDataCollector::new()
+        .get_replay_data(&replay)
+        .unwrap_or_else(|error| {
             panic!(
-                "failed to build ndarray output for {}: {error:?}",
+                "failed to collect structured replay data for {}: {error:?}",
                 fixture.path
             )
         });
 
-        assert_eq!(
-            meta.replay_meta.player_count(),
-            fixture.player_count,
-            "{} ndarray player count",
-            fixture.path
-        );
-        assert!(
-            array.nrows() > 0,
-            "{} should emit ndarray rows",
-            fixture.path
-        );
-        assert!(
-            array.ncols() > 0,
-            "{} should emit ndarray columns",
-            fixture.path
-        );
-        assert!(
-            array.iter().all(|value| value.is_finite()),
-            "{} ndarray should contain only finite values",
-            fixture.path
-        );
+    assert_eq!(
+        replay_data.meta.player_count(),
+        fixture.player_count,
+        "{} player count",
+        fixture.path
+    );
+    assert!(
+        replay_data.frame_data.frame_count() > 0,
+        "{} should emit frame data",
+        fixture.path
+    );
+    assert!(
+        replay_data.frame_data.duration() > 0.0,
+        "{} should have positive duration",
+        fixture.path
+    );
+    assert!(
+        replay_data
+            .frame_data
+            .players
+            .iter()
+            .all(|(_, player_data)| player_data.frames().iter().any(|frame| {
+                matches!(frame, PlayerFrame::Data { rigid_body, .. } if rigid_body.location.x.is_finite())
+            })),
+        "{} should emit finite player rigid-body samples for every player",
+        fixture.path
+    );
+    assert!(
+        !replay_data.touch_events.is_empty(),
+        "{} should expose exact touch events",
+        fixture.path
+    );
+    assert!(
+        !replay_data.player_stat_events.is_empty(),
+        "{} should expose exact player-stat events",
+        fixture.path
+    );
+
+    let replay_json =
+        serde_json::to_value(&replay_data).expect("ReplayData should serialize to JSON");
+    assert_finite_json(&replay_json, fixture.path);
+}
+
+#[test]
+fn post_eac_replays_emit_ndarray_features() {
+    assert_post_eac_replay_emits_ndarray_features(&POST_EAC_FIXTURES[0]);
+}
+
+#[test]
+#[ignore = "broad post-EAC ndarray coverage is slow; representative fixture runs in CI"]
+fn all_post_eac_replays_emit_ndarray_features() {
+    for fixture in POST_EAC_FIXTURES {
+        assert_post_eac_replay_emits_ndarray_features(fixture);
     }
+}
+
+fn assert_post_eac_replay_emits_ndarray_features(fixture: &PostEacFixture) {
+    let replay = common::parse_replay(fixture.path);
+    let mut collector = NDArrayCollector::<f32>::from_strings(
+        &[
+            "BallRigidBody",
+            "BallRigidBodyQuaternions",
+            "BallRigidBodyBasis",
+            "VelocityAddedBallRigidBodyNoVelocities",
+            "InterpolatedBallRigidBodyNoVelocities",
+            "SecondsRemaining",
+            "CurrentTime",
+            "FrameTime",
+            "ReplicatedStateName",
+            "ReplicatedGameStateTimeRemaining",
+            "BallHasBeenHit",
+        ],
+        &[
+            "PlayerRigidBody",
+            "PlayerRigidBodyQuaternions",
+            "PlayerRigidBodyBasis",
+            "PlayerRelativeBallPosition",
+            "PlayerRelativeBallVelocity",
+            "PlayerLocalRelativeBallPosition",
+            "PlayerLocalRelativeBallVelocity",
+            "VelocityAddedPlayerRigidBodyNoVelocities",
+            "InterpolatedPlayerRigidBodyNoVelocities",
+            "PlayerBallDistance",
+            "PlayerBoost",
+            "PlayerJump",
+            "PlayerAnyJump",
+            "PlayerDodgeRefreshed",
+            "PlayerDemolishedBy",
+        ],
+    )
+    .expect("post-EAC ndarray feature selection should be valid");
+
+    FrameRateDecorator::new_from_fps(30.0, &mut collector)
+        .process_replay(&replay)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to collect ndarray features for {}: {error:?}",
+                fixture.path
+            )
+        });
+    let (meta, array) = collector.get_meta_and_ndarray().unwrap_or_else(|error| {
+        panic!(
+            "failed to build ndarray output for {}: {error:?}",
+            fixture.path
+        )
+    });
+
+    assert_eq!(
+        meta.replay_meta.player_count(),
+        fixture.player_count,
+        "{} ndarray player count",
+        fixture.path
+    );
+    assert!(
+        array.nrows() > 0,
+        "{} should emit ndarray rows",
+        fixture.path
+    );
+    assert!(
+        array.ncols() > 0,
+        "{} should emit ndarray columns",
+        fixture.path
+    );
+    assert!(
+        array.iter().all(|value| value.is_finite()),
+        "{} ndarray should contain only finite values",
+        fixture.path
+    );
 }
 
 fn assert_post_eac_stats_outputs(fixture: &PostEacFixture) {
@@ -393,6 +405,7 @@ fn assert_post_eac_stats_outputs(fixture: &PostEacFixture) {
 }
 
 #[test]
+#[ignore = "representative post-EAC stats output coverage is slow and duplicates stats_collector_test API coverage"]
 fn post_eac_replays_emit_stats_outputs() {
     assert_post_eac_stats_outputs(&POST_EAC_FIXTURES[0]);
 }

--- a/tests/post_eac_replay_fixture_test.rs
+++ b/tests/post_eac_replay_fixture_test.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use subtr_actor::{
     builtin_stats_module_names, Collector, FrameRateDecorator, GoalTagKind, NDArrayCollector,
     PlayerFrame, ReplayDataCollector, StatsCollector, StatsFrameResolution, StatsTimelineCollector,
+    StatsTimelineEventCollector,
 };
 
 struct PostEacFixture {
@@ -76,8 +77,8 @@ fn assert_finite_json(value: &Value, path: &str) {
 #[test]
 fn post_eac_ranked_standard_second_goal_is_not_own_half_goal() {
     let replay = common::parse_replay(POST_EAC_RANKED_STANDARD_REPLAY);
-    let timeline = StatsTimelineCollector::new()
-        .get_legacy_replay_stats_timeline(&replay)
+    let timeline = StatsTimelineEventCollector::new()
+        .get_replay_stats_timeline_scaffold(&replay)
         .expect("failed to collect stats timeline for post-EAC standard replay");
 
     assert!(
@@ -112,8 +113,8 @@ fn post_eac_ranked_standard_second_goal_is_not_own_half_goal() {
 #[test]
 fn post_eac_ranked_standard_third_goal_is_not_aerial_goal() {
     let replay = common::parse_replay(POST_EAC_RANKED_STANDARD_REPLAY);
-    let timeline = StatsTimelineCollector::new()
-        .get_legacy_replay_stats_timeline(&replay)
+    let timeline = StatsTimelineEventCollector::new()
+        .get_replay_stats_timeline_scaffold(&replay)
         .expect("failed to collect stats timeline for post-EAC standard replay");
 
     let third_goal = timeline
@@ -320,95 +321,135 @@ fn post_eac_replays_emit_ndarray_features() {
     }
 }
 
+fn assert_post_eac_stats_outputs(fixture: &PostEacFixture) {
+    let replay = common::parse_replay(fixture.path);
+    let timeline = StatsTimelineEventCollector::new()
+        .with_frame_resolution(StatsFrameResolution::TimeStep { seconds: 1.0 })
+        .get_replay_stats_timeline_scaffold(&replay)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to collect compact stats timeline for {}: {error:?}",
+                fixture.path
+            )
+        });
+    assert_eq!(
+        timeline.replay_meta.player_count(),
+        fixture.player_count,
+        "{} typed timeline player count",
+        fixture.path
+    );
+    assert!(
+        timeline.frames.len() > 1,
+        "{} typed timeline should include sampled frames",
+        fixture.path
+    );
+    assert!(
+        timeline
+            .frames
+            .windows(2)
+            .all(|frames| frames[1].time >= frames[0].time),
+        "{} typed timeline frame times should be sorted",
+        fixture.path
+    );
+    assert!(
+        timeline.frames.iter().all(|frame| {
+            frame.players.len() == fixture.player_count
+                && frame.time.is_finite()
+                && frame.dt.is_finite()
+        }),
+        "{} typed timeline frames should carry finite player snapshots",
+        fixture.path
+    );
+
+    let timeline_json = serde_json::to_value(&timeline)
+        .expect("ReplayStatsTimelineScaffold should serialize to JSON");
+    assert_finite_json(&timeline_json, fixture.path);
+
+    let collected = StatsCollector::new()
+        .get_stats(&replay)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to collect representative aggregate stats for {}: {error:?}",
+                fixture.path
+            )
+        });
+    assert_eq!(
+        collected.replay_meta.player_count(),
+        fixture.player_count,
+        "{} aggregate stats player count",
+        fixture.path
+    );
+    assert_eq!(
+        collected.module_names().count(),
+        builtin_stats_module_names().len(),
+        "{} should collect every builtin stats module",
+        fixture.path
+    );
+
+    let collected_json =
+        serde_json::to_value(&collected).expect("CollectedStats should serialize to JSON");
+    assert_collected_stats_modules(&collected_json, fixture.path);
+    assert_finite_json(&collected_json, fixture.path);
+}
+
 #[test]
 fn post_eac_replays_emit_stats_outputs() {
+    assert_post_eac_stats_outputs(&POST_EAC_FIXTURES[0]);
+}
+
+#[test]
+#[ignore = "broad post-EAC stats output coverage is slow; run explicitly when changing stats collectors"]
+fn all_post_eac_replays_emit_stats_outputs() {
     for fixture in POST_EAC_FIXTURES {
-        let replay = common::parse_replay(fixture.path);
-        let collected = StatsCollector::new()
-            .get_stats(&replay)
-            .unwrap_or_else(|error| {
-                panic!(
-                    "failed to collect aggregate stats for {}: {error:?}",
-                    fixture.path
-                )
-            });
-        assert_eq!(
-            collected.replay_meta.player_count(),
-            fixture.player_count,
-            "{} aggregate stats player count",
-            fixture.path
-        );
-        assert_eq!(
-            collected.module_names().count(),
-            builtin_stats_module_names().len(),
-            "{} should collect every builtin stats module",
-            fixture.path
-        );
-
-        let collected_json =
-            serde_json::to_value(&collected).expect("CollectedStats should serialize to JSON");
-        assert_collected_stats_modules(&collected_json, fixture.path);
-        assert_finite_json(&collected_json, fixture.path);
-
-        let timeline = StatsTimelineCollector::new()
-            .with_frame_resolution(StatsFrameResolution::TimeStep { seconds: 1.0 })
-            .get_legacy_replay_stats_timeline(&replay)
-            .unwrap_or_else(|error| {
-                panic!(
-                    "failed to collect typed stats timeline for {}: {error:?}",
-                    fixture.path
-                )
-            });
-        assert_eq!(
-            timeline.replay_meta.player_count(),
-            fixture.player_count,
-            "{} typed timeline player count",
-            fixture.path
-        );
-        assert!(
-            timeline.frames.len() > 1,
-            "{} typed timeline should include sampled frames",
-            fixture.path
-        );
-        assert!(
-            timeline
-                .frames
-                .windows(2)
-                .all(|frames| frames[1].time >= frames[0].time),
-            "{} typed timeline frame times should be sorted",
-            fixture.path
-        );
-        assert!(
-            timeline.frames.iter().all(|frame| {
-                frame.players.len() == fixture.player_count
-                    && frame.time.is_finite()
-                    && frame.dt.is_finite()
-            }),
-            "{} typed timeline frames should carry finite player snapshots",
-            fixture.path
-        );
-
-        let timeline_json =
-            serde_json::to_value(&timeline).expect("ReplayStatsTimeline should serialize to JSON");
-        assert_finite_json(&timeline_json, fixture.path);
-
-        let playback_value = StatsCollector::new()
-            .with_frame_resolution(StatsFrameResolution::TimeStep { seconds: 1.0 })
-            .capture_frames()
-            .get_captured_data(&replay)
-            .unwrap_or_else(|error| {
-                panic!(
-                    "failed to capture dynamic stats frames for {}: {error:?}",
-                    fixture.path
-                )
-            })
-            .into_legacy_stats_timeline_value()
-            .unwrap_or_else(|error| {
-                panic!(
-                    "failed to convert dynamic stats frames for {}: {error:?}",
-                    fixture.path
-                )
-            });
-        assert_finite_json(&playback_value, fixture.path);
+        assert_post_eac_stats_outputs(fixture);
     }
+}
+
+#[test]
+#[ignore = "full legacy stats timeline snapshots are slow; run explicitly when changing full snapshot serialization"]
+fn representative_post_eac_replay_emits_full_stats_timeline_outputs() {
+    let fixture = &POST_EAC_FIXTURES[0];
+    let replay = common::parse_replay(fixture.path);
+    let timeline = StatsTimelineCollector::new()
+        .with_frame_resolution(StatsFrameResolution::TimeStep { seconds: 1.0 })
+        .get_legacy_replay_stats_timeline(&replay)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to collect representative full stats timeline for {}: {error:?}",
+                fixture.path
+            )
+        });
+    assert_eq!(
+        timeline.replay_meta.player_count(),
+        fixture.player_count,
+        "{} representative full timeline player count",
+        fixture.path
+    );
+    assert!(
+        timeline.frames.len() > 1,
+        "{} representative full timeline should include sampled frames",
+        fixture.path
+    );
+    let timeline_json =
+        serde_json::to_value(&timeline).expect("ReplayStatsTimeline should serialize to JSON");
+    assert_finite_json(&timeline_json, fixture.path);
+
+    let playback_value = StatsCollector::new()
+        .with_frame_resolution(StatsFrameResolution::TimeStep { seconds: 1.0 })
+        .capture_frames()
+        .get_captured_data(&replay)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to capture representative dynamic stats frames for {}: {error:?}",
+                fixture.path
+            )
+        })
+        .into_legacy_stats_timeline_value()
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to convert representative dynamic stats frames for {}: {error:?}",
+                fixture.path
+            )
+        });
+    assert_finite_json(&playback_value, fixture.path);
 }

--- a/tests/replay_processing_test/replay_data_tests.rs
+++ b/tests/replay_processing_test/replay_data_tests.rs
@@ -18,6 +18,7 @@ fn test_all_replays_parse_successfully() {
 
 /// Test ReplayDataCollector works on known-good replays
 #[test]
+#[ignore = "broad multi-replay collector sweep is slow; focused replay-data regressions run in CI"]
 fn test_replay_data_collector_multiple_replays() {
     // Use replays that are known to work with the collector
     let replays = [
@@ -510,7 +511,7 @@ fn test_processor_extracts_touch_events() {
 }
 
 #[test]
-fn test_processor_extracts_flip_reset_events() {
+fn test_processor_extracts_flip_reset_and_post_wall_dodge_events() {
     let replay = parse_replay("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay");
     let mut processor = ReplayProcessor::new(&replay).expect("Failed to construct processor");
     let mut tracker = FlipResetTracker::new();
@@ -543,16 +544,6 @@ fn test_processor_extracts_flip_reset_events() {
         }),
         "Expected flip-reset candidate team labels to agree with the resolved player team"
     );
-}
-
-#[test]
-fn test_processor_extracts_post_wall_dodge_events() {
-    let replay = parse_replay("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay");
-    let mut processor = ReplayProcessor::new(&replay).expect("Failed to construct processor");
-    let mut tracker = FlipResetTracker::new();
-    processor
-        .process(&mut tracker)
-        .expect("Failed to process replay for post-wall dodge extraction");
 
     assert!(
         !tracker.post_wall_dodge_events().is_empty(),
@@ -574,6 +565,7 @@ fn test_processor_extracts_post_wall_dodge_events() {
 }
 
 #[test]
+#[ignore = "second full-replay flip-reset fixture is slow; default flip-reset/post-wall extraction coverage runs in CI"]
 fn test_processor_extracts_flip_reset_followup_dodge_events() {
     let replay =
         parse_replay("assets/replay-format-2026-01-14-v868-32-net10-demolish-extended.replay");
@@ -679,6 +671,7 @@ fn test_processor_extracts_player_stat_events() {
 }
 
 #[test]
+#[ignore = "heuristic quality comparison does two full replay traversals; focused touch and goal extraction tests run in CI"]
 fn test_touch_attribution_usually_matches_goal_scorer() {
     let replay = parse_replay("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay");
     let mut processor = ReplayProcessor::new(&replay).expect("Failed to construct processor");

--- a/tests/speed_flip_replay_regression_test.rs
+++ b/tests/speed_flip_replay_regression_test.rs
@@ -1,4 +1,4 @@
-use subtr_actor::{PlayerId, StatsTimelineCollector};
+use subtr_actor::{PlayerId, ReplayMeta, StatsTimelineEventCollector};
 
 const COLONELPANIC_NO_SPEED_FLIP_REPLAY: &str =
     "assets/colonelpanic8-double-tap-third-goal-2026-05-24.replay";
@@ -12,15 +12,11 @@ fn parse_replay(path: &str) -> boxcars::Replay {
         .unwrap_or_else(|_| panic!("Failed to parse replay: {path}"))
 }
 
-fn player_ids_by_name<'a>(
-    timeline: &'a subtr_actor::ReplayStatsTimeline,
-    name: &str,
-) -> Vec<&'a PlayerId> {
-    timeline
-        .replay_meta
+fn player_ids_by_name<'a>(replay_meta: &'a ReplayMeta, name: &str) -> Vec<&'a PlayerId> {
+    replay_meta
         .team_zero
         .iter()
-        .chain(timeline.replay_meta.team_one.iter())
+        .chain(replay_meta.team_one.iter())
         .filter(|player| player.name == name)
         .map(|player| &player.remote_id)
         .collect()
@@ -29,10 +25,10 @@ fn player_ids_by_name<'a>(
 #[test]
 fn colonelpanic_replay_has_no_speed_flip_at_normalized_28_1_seconds() {
     let replay = parse_replay(COLONELPANIC_NO_SPEED_FLIP_REPLAY);
-    let timeline = StatsTimelineCollector::new()
-        .get_legacy_replay_stats_timeline(&replay)
+    let timeline = StatsTimelineEventCollector::new()
+        .get_replay_stats_timeline_scaffold(&replay)
         .expect("stats timeline should build");
-    let colonelpanic_ids = player_ids_by_name(&timeline, "colonelpanic8");
+    let colonelpanic_ids = player_ids_by_name(&timeline.replay_meta, "colonelpanic8");
     assert!(
         !colonelpanic_ids.is_empty(),
         "fixture should contain colonelpanic8"

--- a/tests/stats_collector_test.rs
+++ b/tests/stats_collector_test.rs
@@ -5,31 +5,17 @@ use subtr_actor::{builtin_stats_module_names, StatsCollector, StatsFrameResoluti
 const SMALL_STATS_FIXTURE: &str = "assets/post-eac-ranked-duel-2026-04-28-a.replay";
 
 #[test]
-fn stats_collector_serializes_selected_modules_by_name() {
+fn stats_collector_serializes_selected_modules_and_aliases_by_name() {
     let replay = common::parse_replay(SMALL_STATS_FIXTURE);
-    let collected = StatsCollector::with_builtin_module_names(["boost", "movement"])
-        .expect("builtin module selection should be valid")
-        .get_stats(&replay)
-        .expect("stats collection should succeed");
-
-    let value = serde_json::to_value(&collected).expect("stats should serialize to json");
-    let modules = value
-        .get("modules")
-        .and_then(|value| value.as_object())
-        .expect("modules should serialize as an object");
-
-    assert!(modules.contains_key("boost"));
-    assert!(modules.contains_key("movement"));
-    assert!(!modules.contains_key("core"));
-}
-
-#[test]
-fn stats_collector_accepts_air_dribble_as_ball_carry_backed_module() {
-    let replay = common::parse_replay(SMALL_STATS_FIXTURE);
-    let collected = StatsCollector::with_builtin_module_names(["air_dribble", "ball_carry"])
-        .expect("air_dribble should be a valid builtin module")
-        .get_stats(&replay)
-        .expect("stats collection should succeed");
+    let collected = StatsCollector::with_builtin_module_names([
+        "air_dribble",
+        "ball_carry",
+        "boost",
+        "movement",
+    ])
+    .expect("builtin module selection should be valid")
+    .get_stats(&replay)
+    .expect("stats collection should succeed");
 
     let value = serde_json::to_value(&collected).expect("stats should serialize to json");
     let modules = value
@@ -39,9 +25,13 @@ fn stats_collector_accepts_air_dribble_as_ball_carry_backed_module() {
 
     assert!(modules.contains_key("air_dribble"));
     assert!(modules.contains_key("ball_carry"));
+    assert!(modules.contains_key("boost"));
+    assert!(modules.contains_key("movement"));
+    assert!(!modules.contains_key("core"));
 }
 
 #[test]
+#[ignore = "broad all-module aggregate replay pass is slow; selected-module replay coverage runs in CI"]
 fn stats_collector_processes_all_builtin_modules() {
     let replay = common::parse_replay(SMALL_STATS_FIXTURE);
     let collected = StatsCollector::new()
@@ -64,6 +54,7 @@ fn stats_collector_processes_all_builtin_modules() {
 }
 
 #[test]
+#[ignore = "captured-frame transform test covers the frame capture path in default CI"]
 fn stats_collector_captures_module_keyed_snapshot_frames() {
     let replay = common::parse_replay(SMALL_STATS_FIXTURE);
     let snapshot = StatsCollector::with_builtin_module_names(["boost", "movement"])

--- a/tests/stats_collector_test.rs
+++ b/tests/stats_collector_test.rs
@@ -2,10 +2,11 @@ mod common;
 
 use subtr_actor::{builtin_stats_module_names, StatsCollector, StatsFrameResolution};
 
+const SMALL_STATS_FIXTURE: &str = "assets/post-eac-ranked-duel-2026-04-28-a.replay";
+
 #[test]
 fn stats_collector_serializes_selected_modules_by_name() {
-    let replay =
-        common::parse_replay("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay");
+    let replay = common::parse_replay(SMALL_STATS_FIXTURE);
     let collected = StatsCollector::with_builtin_module_names(["boost", "movement"])
         .expect("builtin module selection should be valid")
         .get_stats(&replay)
@@ -24,7 +25,7 @@ fn stats_collector_serializes_selected_modules_by_name() {
 
 #[test]
 fn stats_collector_accepts_air_dribble_as_ball_carry_backed_module() {
-    let replay = common::parse_replay("assets/air-dribble-goal-mouth-2026-05-24.replay");
+    let replay = common::parse_replay(SMALL_STATS_FIXTURE);
     let collected = StatsCollector::with_builtin_module_names(["air_dribble", "ball_carry"])
         .expect("air_dribble should be a valid builtin module")
         .get_stats(&replay)
@@ -42,8 +43,7 @@ fn stats_collector_accepts_air_dribble_as_ball_carry_backed_module() {
 
 #[test]
 fn stats_collector_processes_all_builtin_modules() {
-    let replay =
-        common::parse_replay("assets/replay-format-2016-07-21-v868-12-net-none-lan.replay");
+    let replay = common::parse_replay(SMALL_STATS_FIXTURE);
     let collected = StatsCollector::new()
         .get_stats(&replay)
         .expect("stats collection should succeed");
@@ -65,8 +65,7 @@ fn stats_collector_processes_all_builtin_modules() {
 
 #[test]
 fn stats_collector_captures_module_keyed_snapshot_frames() {
-    let replay =
-        common::parse_replay("assets/replay-format-2016-07-21-v868-12-net-none-lan.replay");
+    let replay = common::parse_replay(SMALL_STATS_FIXTURE);
     let snapshot = StatsCollector::with_builtin_module_names(["boost", "movement"])
         .expect("builtin module selection should be valid")
         .with_frame_resolution(StatsFrameResolution::TimeStep { seconds: 1.0 })
@@ -89,8 +88,7 @@ fn stats_collector_captures_module_keyed_snapshot_frames() {
 #[test]
 #[allow(clippy::result_large_err)]
 fn stats_collector_transforms_captured_frame_modules() {
-    let replay =
-        common::parse_replay("assets/replay-format-2016-07-21-v868-12-net-none-lan.replay");
+    let replay = common::parse_replay(SMALL_STATS_FIXTURE);
     let transformed = StatsCollector::with_builtin_module_names(["boost", "movement"])
         .expect("builtin module selection should be valid")
         .with_frame_resolution(StatsFrameResolution::TimeStep { seconds: 1.0 })

--- a/tests/stats_frame_resolution_test.rs
+++ b/tests/stats_frame_resolution_test.rs
@@ -5,10 +5,12 @@ use subtr_actor::{
     StatsTimelineCollector,
 };
 
+const SMALL_STATS_FIXTURE: &str = "assets/replay-format-2016-07-21-v868-12-net-none-lan.replay";
+
 #[test]
+#[ignore = "full replay-backed stats frame parity is slow; frame persistence is covered by collector unit tests"]
 fn stats_collector_default_resolution_matches_every_frame() {
-    let replay =
-        common::parse_replay("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay");
+    let replay = common::parse_replay(SMALL_STATS_FIXTURE);
 
     let default_stats_collector = StatsCollector::new()
         .get_legacy_replay_stats_timeline(&replay)
@@ -24,9 +26,9 @@ fn stats_collector_default_resolution_matches_every_frame() {
 }
 
 #[test]
+#[ignore = "full replay-backed stats frame parity is slow; frame persistence is covered by collector unit tests"]
 fn stats_collector_and_timeline_collector_match_at_sampled_resolution() {
-    let replay =
-        common::parse_replay("assets/replay-format-2016-11-09-v868-14-net-none-rlcs-lan.replay");
+    let replay = common::parse_replay(SMALL_STATS_FIXTURE);
     let resolution = StatsFrameResolution::TimeStep { seconds: 0.5 };
 
     let full_timeline = StatsTimelineCollector::new()


### PR DESCRIPTION
## Summary
- avoid eager SubtrActorError construction and make expensive error backtraces opt-in via SUBTR_ACTOR_ERROR_BACKTRACE
- switch event-only replay regression tests to StatsTimelineEventCollector
- narrow or mark opt-in the replay-backed full snapshot parity tests that were dominating default runtime

## Validation
- cargo test --quiet: passed in 110.7s
- CARGO_INCREMENTAL=0 cargo clippy --all-targets --all-features -- -D warnings: passed

## Notes
- Full legacy stats timeline snapshot checks remain available as ignored tests for explicit runs when changing full snapshot serialization or frame parity behavior.