### PR TITLE
Refine double tap surface continuity

### DIFF
--- a/src/stats/analysis_graph/nodes/backboard_bounce.rs
+++ b/src/stats/analysis_graph/nodes/backboard_bounce.rs
@@ -23,6 +23,7 @@ impl_analysis_node! {
     dependencies = [
         frame_info_dependency() => FrameInfo,
         ball_frame_state_dependency() => BallFrameState,
+        player_frame_state_dependency() => PlayerFrameState,
         touch_state_dependency() => TouchState,
         live_play_dependency() => LivePlayState,
     ],

--- a/src/stats/analysis_graph/nodes/double_tap.rs
+++ b/src/stats/analysis_graph/nodes/double_tap.rs
@@ -31,6 +31,7 @@ impl AnalysisNode for DoubleTapNode {
         vec![
             frame_info_dependency(),
             ball_frame_state_dependency(),
+            player_frame_state_dependency(),
             touch_state_dependency(),
             backboard_bounce_state_dependency(),
             live_play_dependency(),
@@ -41,6 +42,7 @@ impl AnalysisNode for DoubleTapNode {
         self.calculator.update(
             ctx.get::<FrameInfo>()?,
             ctx.get::<BallFrameState>()?,
+            ctx.get::<PlayerFrameState>()?,
             ctx.get::<TouchState>()?,
             ctx.get::<BackboardBounceState>()?,
             ctx.get::<LivePlayState>()?,

--- a/src/stats/calculators/backboard_bounce.rs
+++ b/src/stats/calculators/backboard_bounce.rs
@@ -103,6 +103,7 @@ impl BackboardBounceCalculator {
         &mut self,
         frame: &FrameInfo,
         ball: &BallFrameState,
+        players: &PlayerFrameState,
         touch_state: &TouchState,
         live_play_state: &LivePlayState,
     ) -> BackboardBounceState {
@@ -111,6 +112,16 @@ impl BackboardBounceCalculator {
             self.last_touch = None;
             self.last_bounce_event = None;
             return BackboardBounceState::default();
+        }
+
+        if self
+            .last_touch
+            .as_ref()
+            .and_then(|touch| touch.player.as_ref())
+            .and_then(|player_id| players.player(player_id))
+            .is_some_and(player_sample_is_touching_surface)
+        {
+            self.last_touch = None;
         }
 
         let bounce_events: Vec<_> = self

--- a/src/stats/calculators/backboard_bounce_tests.rs
+++ b/src/stats/calculators/backboard_bounce_tests.rs
@@ -30,6 +30,29 @@ fn ball(position: glam::Vec3, velocity: glam::Vec3) -> BallFrameState {
     })
 }
 
+fn player(player_id: PlayerId, is_team_0: bool, position: glam::Vec3) -> PlayerSample {
+    PlayerSample {
+        player_id,
+        is_team_0,
+        hitbox: CarHitbox::octane(),
+        rigid_body: Some(rigid_body(position, glam::Vec3::ZERO)),
+        boost_amount: None,
+        last_boost_amount: None,
+        boost_active: false,
+        dodge_active: false,
+        powerslide_active: false,
+        match_goals: None,
+        match_assists: None,
+        match_saves: None,
+        match_shots: None,
+        match_score: None,
+    }
+}
+
+fn players(samples: Vec<PlayerSample>) -> PlayerFrameState {
+    PlayerFrameState { players: samples }
+}
+
 fn touch(player: PlayerId, is_team_0: bool, gap: f32) -> TouchEvent {
     TouchEvent {
         time: 0.1,
@@ -62,6 +85,7 @@ fn backboard_bounce_uses_primary_touch_not_last_contested_candidate() {
             glam::Vec3::new(0.0, 4700.0, 650.0),
             glam::Vec3::new(0.0, 500.0, 0.0),
         ),
+        &PlayerFrameState::default(),
         &touch_state,
         &LivePlayState::active_play(),
     );
@@ -71,6 +95,7 @@ fn backboard_bounce_uses_primary_touch_not_last_contested_candidate() {
             glam::Vec3::new(0.0, 4800.0, 650.0),
             glam::Vec3::new(0.0, -300.0, 0.0),
         ),
+        &PlayerFrameState::default(),
         &TouchState::default(),
         &LivePlayState::active_play(),
     );
@@ -80,4 +105,61 @@ fn backboard_bounce_uses_primary_touch_not_last_contested_candidate() {
     };
     assert_eq!(bounce.player, primary_player);
     assert!(bounce.is_team_0);
+}
+
+#[test]
+fn surface_contact_between_touch_and_bounce_drops_attribution() {
+    let shooter = boxcars::RemoteId::Steam(1);
+    let touch_state = TouchState {
+        touch_events: vec![touch(shooter.clone(), true, 0.0)],
+        last_touch: None,
+        last_touch_player: None,
+        last_touch_team_is_team_0: None,
+    };
+    let mut calculator = BackboardBounceCalculator::new();
+
+    calculator.update(
+        &frame(1),
+        &ball(
+            glam::Vec3::new(0.0, 4700.0, 650.0),
+            glam::Vec3::new(0.0, 500.0, 0.0),
+        ),
+        &players(vec![player(
+            shooter.clone(),
+            true,
+            glam::Vec3::new(0.0, 3000.0, PLAYER_GROUND_Z_THRESHOLD + 200.0),
+        )]),
+        &touch_state,
+        &LivePlayState::active_play(),
+    );
+    calculator.update(
+        &frame(2),
+        &ball(
+            glam::Vec3::new(0.0, 4750.0, 650.0),
+            glam::Vec3::new(0.0, 500.0, 0.0),
+        ),
+        &players(vec![player(
+            shooter.clone(),
+            true,
+            glam::Vec3::new(0.0, 3000.0, PLAYER_GROUND_Z_THRESHOLD),
+        )]),
+        &TouchState::default(),
+        &LivePlayState::active_play(),
+    );
+    let state = calculator.update(
+        &frame(3),
+        &ball(
+            glam::Vec3::new(0.0, 4800.0, 650.0),
+            glam::Vec3::new(0.0, -300.0, 0.0),
+        ),
+        &players(vec![player(
+            shooter,
+            true,
+            glam::Vec3::new(0.0, 3000.0, PLAYER_GROUND_Z_THRESHOLD + 200.0),
+        )]),
+        &TouchState::default(),
+        &LivePlayState::active_play(),
+    );
+
+    assert!(state.bounce_events.is_empty());
 }

--- a/src/stats/calculators/double_tap.rs
+++ b/src/stats/calculators/double_tap.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Maximum time between the attributed backboard bounce and the follow-up touch.
-const DOUBLE_TAP_TOUCH_WINDOW_SECONDS: f32 = 2.5;
+const DOUBLE_TAP_TOUCH_WINDOW_SECONDS: f32 = 0.65;
 
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]

--- a/src/stats/calculators/double_tap.rs
+++ b/src/stats/calculators/double_tap.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Maximum time between the attributed backboard bounce and the follow-up touch.
-const DOUBLE_TAP_TOUCH_WINDOW_SECONDS: f32 = 0.65;
+const DOUBLE_TAP_TOUCH_WINDOW_SECONDS: f32 = 2.5;
 
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
@@ -32,9 +32,10 @@ struct PendingBackboardBounce {
 /// 1. A [`BackboardBounceEvent`] arms a pending double tap for the player who
 ///    last touched the ball before the bounce. The exact backboard geometry and
 ///    attribution thresholds live in [`BackboardBounceCalculator`].
-/// 2. The same player must touch the ball again within
+/// 2. The touch that armed the backboard bounce must be airborne.
+/// 3. The same player must touch the ball again within
 ///    [`DOUBLE_TAP_TOUCH_WINDOW_SECONDS`] while the replay is in live play.
-/// 3. The ball's post-touch constant-velocity trajectory must project into or
+/// 4. The ball's post-touch constant-velocity trajectory must project into or
 ///    close to the opponent goal mouth.
 ///
 /// The detector intentionally does not aim at the center of the goal. Near-post
@@ -66,6 +67,10 @@ impl DoubleTapCalculator {
 
     fn record_backboard_bounces(&mut self, state: &BackboardBounceState) {
         for event in &state.bounce_events {
+            if Self::backboard_touch_was_grounded(event) {
+                continue;
+            }
+
             if let Some(existing) = self
                 .pending_backboard_bounces
                 .iter_mut()
@@ -86,6 +91,12 @@ impl DoubleTapCalculator {
                 });
             }
         }
+    }
+
+    fn backboard_touch_was_grounded(event: &BackboardBounceEvent) -> bool {
+        event
+            .player_position
+            .is_some_and(|position| PlayerVerticalBand::from_height(position[2]).is_grounded())
     }
 
     fn resolve_double_tap_touches(

--- a/src/stats/calculators/double_tap.rs
+++ b/src/stats/calculators/double_tap.rs
@@ -1,8 +1,5 @@
 use super::*;
 
-const SOCCAR_CEILING_Z: f32 = 2044.0;
-const CEILING_CONTACT_MAX_GAP: f32 = 90.0;
-
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
 pub struct DoubleTapEvent {
@@ -95,26 +92,11 @@ impl DoubleTapCalculator {
             .is_some_and(|position| PlayerVerticalBand::from_height(position[2]).is_grounded())
     }
 
-    fn player_is_on_ceiling(position: glam::Vec3) -> bool {
-        SOCCAR_CEILING_Z - position.z <= CEILING_CONTACT_MAX_GAP
-    }
-
-    fn player_is_touching_surface(position: glam::Vec3) -> bool {
-        PlayerVerticalBand::from_height(position.z).is_grounded()
-            || player_is_on_wall(position)
-            || Self::player_is_on_ceiling(position)
-    }
-
     fn prune_surface_contacts(&mut self, players: &PlayerFrameState) {
         self.pending_backboard_bounces.retain(|pending| {
-            let Some(position) = players
-                .player_position(&pending.player_id)
-                .map(glam::Vec3::from_array)
-            else {
-                return true;
-            };
-
-            !Self::player_is_touching_surface(position)
+            !players
+                .player(&pending.player_id)
+                .is_some_and(player_sample_is_touching_surface)
         });
     }
 

--- a/src/stats/calculators/double_tap.rs
+++ b/src/stats/calculators/double_tap.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-/// Maximum time between the attributed backboard bounce and the follow-up touch.
-const DOUBLE_TAP_TOUCH_WINDOW_SECONDS: f32 = 2.5;
+const SOCCAR_CEILING_Z: f32 = 2044.0;
+const CEILING_CONTACT_MAX_GAP: f32 = 90.0;
 
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
@@ -33,9 +33,10 @@ struct PendingBackboardBounce {
 ///    last touched the ball before the bounce. The exact backboard geometry and
 ///    attribution thresholds live in [`BackboardBounceCalculator`].
 /// 2. The touch that armed the backboard bounce must be airborne.
-/// 3. The same player must touch the ball again within
-///    [`DOUBLE_TAP_TOUCH_WINDOW_SECONDS`] while the replay is in live play.
-/// 4. The ball's post-touch constant-velocity trajectory must project into or
+/// 3. The same player must remain off ground, wall, and ceiling surfaces.
+/// 4. The same player must make the next attributed ball touch while the replay
+///    is in live play.
+/// 5. The ball's post-touch constant-velocity trajectory must project into or
 ///    close to the opponent goal mouth.
 ///
 /// The detector intentionally does not aim at the center of the goal. Near-post
@@ -58,11 +59,6 @@ impl DoubleTapCalculator {
 
     pub fn new_events(&self) -> &[DoubleTapEvent] {
         self.events.new_events()
-    }
-
-    fn prune_pending_backboard_bounces(&mut self, current_time: f32) {
-        self.pending_backboard_bounces
-            .retain(|entry| current_time - entry.time <= DOUBLE_TAP_TOUCH_WINDOW_SECONDS);
     }
 
     fn record_backboard_bounces(&mut self, state: &BackboardBounceState) {
@@ -99,58 +95,75 @@ impl DoubleTapCalculator {
             .is_some_and(|position| PlayerVerticalBand::from_height(position[2]).is_grounded())
     }
 
+    fn player_is_on_ceiling(position: glam::Vec3) -> bool {
+        SOCCAR_CEILING_Z - position.z <= CEILING_CONTACT_MAX_GAP
+    }
+
+    fn player_is_touching_surface(position: glam::Vec3) -> bool {
+        PlayerVerticalBand::from_height(position.z).is_grounded()
+            || player_is_on_wall(position)
+            || Self::player_is_on_ceiling(position)
+    }
+
+    fn prune_surface_contacts(&mut self, players: &PlayerFrameState) {
+        self.pending_backboard_bounces.retain(|pending| {
+            let Some(position) = players
+                .player_position(&pending.player_id)
+                .map(glam::Vec3::from_array)
+            else {
+                return true;
+            };
+
+            !Self::player_is_touching_surface(position)
+        });
+    }
+
     fn resolve_double_tap_touches(
         &mut self,
         frame: &FrameInfo,
         ball: &BallFrameState,
-        touch_events: &[TouchEvent],
+        touch_state: &TouchState,
     ) {
-        if touch_events.is_empty() || self.pending_backboard_bounces.is_empty() {
+        if self.pending_backboard_bounces.is_empty() {
             return;
         }
 
+        let Some(touch) = touch_state.primary_touch_event() else {
+            return;
+        };
+
         let mut completed_events = Vec::new();
         self.pending_backboard_bounces.retain(|pending| {
-            if frame.time <= pending.time {
+            if touch.time <= pending.time {
                 return true;
             }
 
-            let matching_touch = Self::latest_matching_touch(touch_events, pending);
-
-            if let Some(matching_touch) = matching_touch {
-                if Self::followup_touch_projects_on_goal_mouth(ball, pending.is_team_0) {
-                    completed_events.push(DoubleTapEvent {
-                        time: matching_touch.time,
-                        frame: matching_touch.frame,
-                        player: pending.player_id.clone(),
-                        player_position: matching_touch
-                            .player_position
-                            .map(|position| vec_to_glam(&position).to_array()),
-                        is_team_0: pending.is_team_0,
-                        backboard_time: pending.time,
-                        backboard_frame: pending.frame,
-                    });
-                }
+            let is_matching_followup = touch.team_is_team_0 == pending.is_team_0
+                && touch.player.as_ref() == Some(&pending.player_id);
+            if !is_matching_followup {
+                return false;
             }
+
+            if Self::followup_touch_projects_on_goal_mouth(ball, pending.is_team_0) {
+                completed_events.push(DoubleTapEvent {
+                    time: touch.time,
+                    frame: touch.frame,
+                    player: pending.player_id.clone(),
+                    player_position: touch
+                        .player_position
+                        .map(|position| vec_to_glam(&position).to_array()),
+                    is_team_0: pending.is_team_0,
+                    backboard_time: pending.time,
+                    backboard_frame: pending.frame,
+                });
+            }
+
             false
         });
 
         for event in completed_events {
             self.record_double_tap(frame, event);
         }
-    }
-
-    fn latest_matching_touch<'a>(
-        touch_events: &'a [TouchEvent],
-        pending: &PendingBackboardBounce,
-    ) -> Option<&'a TouchEvent> {
-        touch_events
-            .iter()
-            .filter(|touch| {
-                touch.team_is_team_0 == pending.is_team_0
-                    && touch.player.as_ref() == Some(&pending.player_id)
-            })
-            .max_by(|left, right| TouchEvent::timestamp_ordering(left, right))
     }
 
     fn record_double_tap(&mut self, _frame: &FrameInfo, event: DoubleTapEvent) {
@@ -194,6 +207,7 @@ impl DoubleTapCalculator {
         &mut self,
         frame: &FrameInfo,
         ball: &BallFrameState,
+        players: &PlayerFrameState,
         touch_state: &TouchState,
         backboard_bounce_state: &BackboardBounceState,
         live_play_state: &LivePlayState,
@@ -203,9 +217,9 @@ impl DoubleTapCalculator {
             self.pending_backboard_bounces.clear();
         }
 
-        self.prune_pending_backboard_bounces(frame.time);
         self.record_backboard_bounces(backboard_bounce_state);
-        self.resolve_double_tap_touches(frame, ball, &touch_state.touch_events);
+        self.prune_surface_contacts(players);
+        self.resolve_double_tap_touches(frame, ball, touch_state);
         Ok(())
     }
 }

--- a/src/stats/calculators/double_tap_tests.rs
+++ b/src/stats/calculators/double_tap_tests.rs
@@ -21,6 +21,29 @@ fn ball(position: glam::Vec3, velocity: glam::Vec3) -> BallFrameState {
     })
 }
 
+fn player(player_id: PlayerId, is_team_0: bool, position: glam::Vec3) -> PlayerSample {
+    PlayerSample {
+        player_id,
+        is_team_0,
+        hitbox: CarHitbox::octane(),
+        rigid_body: Some(rigid_body(position, glam::Vec3::ZERO)),
+        boost_amount: None,
+        last_boost_amount: None,
+        boost_active: false,
+        dodge_active: false,
+        powerslide_active: false,
+        match_goals: None,
+        match_assists: None,
+        match_saves: None,
+        match_shots: None,
+        match_score: None,
+    }
+}
+
+fn players(samples: Vec<PlayerSample>) -> PlayerFrameState {
+    PlayerFrameState { players: samples }
+}
+
 fn frame(frame_number: usize, time: f32) -> FrameInfo {
     FrameInfo {
         frame_number,
@@ -78,10 +101,29 @@ fn update(
     touch_events: Vec<TouchEvent>,
     backboard_bounce_state: BackboardBounceState,
 ) {
+    update_with_players(
+        calculator,
+        frame,
+        ball,
+        PlayerFrameState::default(),
+        touch_events,
+        backboard_bounce_state,
+    );
+}
+
+fn update_with_players(
+    calculator: &mut DoubleTapCalculator,
+    frame: FrameInfo,
+    ball: BallFrameState,
+    players: PlayerFrameState,
+    touch_events: Vec<TouchEvent>,
+    backboard_bounce_state: BackboardBounceState,
+) {
     calculator
         .update(
             &frame,
             &ball,
+            &players,
             &TouchState {
                 touch_events,
                 ..TouchState::default()
@@ -117,7 +159,57 @@ fn followup_touch_rejects_trajectory_projecting_wide_of_goal_mouth() {
 }
 
 #[test]
-fn counts_matching_followup_even_with_same_frame_other_touch() {
+fn counts_delayed_followup_when_player_stays_airborne_and_touches_are_consecutive() {
+    let shooter = PlayerId::Steam(1);
+    let mut calculator = DoubleTapCalculator::new();
+
+    update_with_players(
+        &mut calculator,
+        frame(10, 1.0),
+        ball(
+            glam::Vec3::new(0.0, 5000.0, 700.0),
+            glam::Vec3::new(0.0, -1000.0, 0.0),
+        ),
+        players(vec![player(
+            shooter.clone(),
+            true,
+            glam::Vec3::new(0.0, 3000.0, PLAYER_GROUND_Z_THRESHOLD + 200.0),
+        )]),
+        Vec::new(),
+        backboard_bounce_with_position(
+            10,
+            1.0,
+            shooter.clone(),
+            true,
+            Some(glam::Vec3::new(
+                0.0,
+                3000.0,
+                PLAYER_GROUND_Z_THRESHOLD + 200.0,
+            )),
+        ),
+    );
+    update_with_players(
+        &mut calculator,
+        frame(100, 10.0),
+        ball(
+            glam::Vec3::new(0.0, 4500.0, 400.0),
+            glam::Vec3::new(0.0, 1600.0, 0.0),
+        ),
+        players(vec![player(
+            shooter.clone(),
+            true,
+            glam::Vec3::new(0.0, 3000.0, PLAYER_GROUND_Z_THRESHOLD + 200.0),
+        )]),
+        vec![touch(100, 10.0, shooter.clone(), true)],
+        BackboardBounceState::default(),
+    );
+
+    assert_eq!(calculator.events().len(), 1);
+    assert_eq!(calculator.events()[0].player, shooter);
+}
+
+#[test]
+fn rejects_followup_with_same_frame_other_touch() {
     let shooter = PlayerId::Steam(1);
     let defender = PlayerId::Steam(2);
     let mut calculator = DoubleTapCalculator::new();
@@ -146,8 +238,47 @@ fn counts_matching_followup_even_with_same_frame_other_touch() {
         BackboardBounceState::default(),
     );
 
-    assert_eq!(calculator.events().len(), 1);
-    assert_eq!(calculator.events()[0].player, shooter);
+    assert!(calculator.events().is_empty());
+}
+
+#[test]
+fn intervening_attributed_touch_breaks_pending_double_tap() {
+    let shooter = PlayerId::Steam(1);
+    let defender = PlayerId::Steam(2);
+    let mut calculator = DoubleTapCalculator::new();
+
+    update(
+        &mut calculator,
+        frame(10, 1.0),
+        ball(
+            glam::Vec3::new(0.0, 5000.0, 700.0),
+            glam::Vec3::new(0.0, -1000.0, 0.0),
+        ),
+        Vec::new(),
+        backboard_bounce(10, 1.0, shooter.clone(), true),
+    );
+    update(
+        &mut calculator,
+        frame(20, 2.0),
+        ball(
+            glam::Vec3::new(0.0, 4500.0, 400.0),
+            glam::Vec3::new(0.0, 1600.0, 0.0),
+        ),
+        vec![touch(20, 2.0, defender, false)],
+        BackboardBounceState::default(),
+    );
+    update(
+        &mut calculator,
+        frame(30, 3.0),
+        ball(
+            glam::Vec3::new(0.0, 4500.0, 400.0),
+            glam::Vec3::new(0.0, 1600.0, 0.0),
+        ),
+        vec![touch(30, 3.0, shooter, true)],
+        BackboardBounceState::default(),
+    );
+
+    assert!(calculator.events().is_empty());
 }
 
 #[test]
@@ -183,6 +314,72 @@ fn aggregate_followup_uses_latest_matching_touch_time() {
     assert_eq!(calculator.events()[0].player, shooter);
     assert_eq!(calculator.events()[0].frame, 25);
     assert_eq!(calculator.events()[0].time, 1.3);
+}
+
+#[test]
+fn surface_contact_breaks_pending_double_tap() {
+    for surface_position in [
+        glam::Vec3::new(0.0, 0.0, PLAYER_GROUND_Z_THRESHOLD),
+        glam::Vec3::new(3600.0, 0.0, 300.0),
+        glam::Vec3::new(0.0, 0.0, SOCCAR_CEILING_Z),
+    ] {
+        let shooter = PlayerId::Steam(1);
+        let mut calculator = DoubleTapCalculator::new();
+
+        update_with_players(
+            &mut calculator,
+            frame(10, 1.0),
+            ball(
+                glam::Vec3::new(0.0, 5000.0, 700.0),
+                glam::Vec3::new(0.0, -1000.0, 0.0),
+            ),
+            players(vec![player(
+                shooter.clone(),
+                true,
+                glam::Vec3::new(0.0, 3000.0, PLAYER_GROUND_Z_THRESHOLD + 200.0),
+            )]),
+            Vec::new(),
+            backboard_bounce_with_position(
+                10,
+                1.0,
+                shooter.clone(),
+                true,
+                Some(glam::Vec3::new(
+                    0.0,
+                    3000.0,
+                    PLAYER_GROUND_Z_THRESHOLD + 200.0,
+                )),
+            ),
+        );
+        update_with_players(
+            &mut calculator,
+            frame(20, 2.0),
+            ball(
+                glam::Vec3::new(0.0, 4800.0, 500.0),
+                glam::Vec3::new(0.0, 400.0, 0.0),
+            ),
+            players(vec![player(shooter.clone(), true, surface_position)]),
+            Vec::new(),
+            BackboardBounceState::default(),
+        );
+        update_with_players(
+            &mut calculator,
+            frame(30, 3.0),
+            ball(
+                glam::Vec3::new(0.0, 4500.0, 400.0),
+                glam::Vec3::new(0.0, 1600.0, 0.0),
+            ),
+            players(vec![player(
+                shooter.clone(),
+                true,
+                glam::Vec3::new(0.0, 3000.0, PLAYER_GROUND_Z_THRESHOLD + 200.0),
+            )]),
+            vec![touch(30, 3.0, shooter, true)],
+            BackboardBounceState::default(),
+        );
+
+        assert!(calculator.events().is_empty());
+    }
 }
 
 #[test]

--- a/src/stats/calculators/double_tap_tests.rs
+++ b/src/stats/calculators/double_tap_tests.rs
@@ -176,6 +176,35 @@ fn aggregate_followup_uses_latest_matching_touch_time() {
 }
 
 #[test]
+fn rejects_followup_touch_after_double_tap_window() {
+    let shooter = PlayerId::Steam(1);
+    let mut calculator = DoubleTapCalculator::new();
+
+    update(
+        &mut calculator,
+        frame(10, 1.0),
+        ball(
+            glam::Vec3::new(0.0, 5000.0, 700.0),
+            glam::Vec3::new(0.0, -1000.0, 0.0),
+        ),
+        Vec::new(),
+        backboard_bounce(10, 1.0, shooter.clone(), true),
+    );
+    update(
+        &mut calculator,
+        frame(40, 1.8),
+        ball(
+            glam::Vec3::new(0.0, 4500.0, 400.0),
+            glam::Vec3::new(0.0, 1600.0, 0.0),
+        ),
+        vec![touch(40, 1.8, shooter, true)],
+        BackboardBounceState::default(),
+    );
+
+    assert!(calculator.events().is_empty());
+}
+
+#[test]
 fn followup_touch_rejects_trajectory_moving_away_from_goal_line() {
     let state = ball(
         glam::Vec3::new(0.0, 4200.0, 400.0),

--- a/src/stats/calculators/double_tap_tests.rs
+++ b/src/stats/calculators/double_tap_tests.rs
@@ -48,11 +48,21 @@ fn backboard_bounce(
     player: PlayerId,
     is_team_0: bool,
 ) -> BackboardBounceState {
+    backboard_bounce_with_position(frame_number, time, player, is_team_0, None)
+}
+
+fn backboard_bounce_with_position(
+    frame_number: usize,
+    time: f32,
+    player: PlayerId,
+    is_team_0: bool,
+    player_position: Option<glam::Vec3>,
+) -> BackboardBounceState {
     let event = BackboardBounceEvent {
         time,
         frame: frame_number,
         player,
-        player_position: None,
+        player_position: player_position.map(|position| position.to_array()),
         is_team_0,
     };
     BackboardBounceState {
@@ -176,7 +186,7 @@ fn aggregate_followup_uses_latest_matching_touch_time() {
 }
 
 #[test]
-fn rejects_followup_touch_after_double_tap_window() {
+fn rejects_backboard_touch_from_grounded_player() {
     let shooter = PlayerId::Steam(1);
     let mut calculator = DoubleTapCalculator::new();
 
@@ -188,16 +198,22 @@ fn rejects_followup_touch_after_double_tap_window() {
             glam::Vec3::new(0.0, -1000.0, 0.0),
         ),
         Vec::new(),
-        backboard_bounce(10, 1.0, shooter.clone(), true),
+        backboard_bounce_with_position(
+            10,
+            1.0,
+            shooter.clone(),
+            true,
+            Some(glam::Vec3::new(0.0, 0.0, PLAYER_GROUND_Z_THRESHOLD)),
+        ),
     );
     update(
         &mut calculator,
-        frame(40, 1.8),
+        frame(20, 1.2),
         ball(
             glam::Vec3::new(0.0, 4500.0, 400.0),
             glam::Vec3::new(0.0, 1600.0, 0.0),
         ),
-        vec![touch(40, 1.8, shooter, true)],
+        vec![touch(20, 1.2, shooter, true)],
         BackboardBounceState::default(),
     );
 

--- a/src/stats/calculators/frame_components.rs
+++ b/src/stats/calculators/frame_components.rs
@@ -99,10 +99,14 @@ pub struct PlayerFrameState {
 }
 
 impl PlayerFrameState {
-    pub fn player_position(&self, player_id: &PlayerId) -> Option<[f32; 3]> {
+    pub fn player(&self, player_id: &PlayerId) -> Option<&PlayerSample> {
         self.players
             .iter()
             .find(|player| &player.player_id == player_id)
+    }
+
+    pub fn player_position(&self, player_id: &PlayerId) -> Option<[f32; 3]> {
+        self.player(player_id)
             .and_then(PlayerSample::position)
             .map(|position| position.to_array())
     }

--- a/src/stats/calculators/mod.rs
+++ b/src/stats/calculators/mod.rs
@@ -350,6 +350,9 @@ fn build_standard_soccar_boost_pad_layout() -> Vec<(glam::Vec3, BoostPadSize)> {
 static STANDARD_SOCCAR_BOOST_PAD_LAYOUT: LazyLock<Vec<(glam::Vec3, BoostPadSize)>> =
     LazyLock::new(build_standard_soccar_boost_pad_layout);
 
+const SOCCAR_CEILING_Z: f32 = 2044.0;
+const CEILING_CONTACT_MAX_GAP: f32 = 90.0;
+
 pub fn standard_soccar_boost_pad_layout() -> &'static [(glam::Vec3, BoostPadSize)] {
     STANDARD_SOCCAR_BOOST_PAD_LAYOUT.as_slice()
 }
@@ -372,6 +375,24 @@ fn player_is_on_wall(position: glam::Vec3) -> bool {
         && position.x.abs() > BACK_WALL_GOAL_MOUTH_HALF_WIDTH_X;
 
     position.z >= WALL_CONTACT_MIN_PLAYER_Z && (is_side_wall || is_back_wall)
+}
+
+fn player_is_on_ceiling(position: glam::Vec3) -> bool {
+    SOCCAR_CEILING_Z - position.z <= CEILING_CONTACT_MAX_GAP
+}
+
+fn player_sample_is_touching_surface(player: &PlayerSample) -> bool {
+    let Some(position) = player.position() else {
+        return false;
+    };
+
+    player
+        .rigid_body
+        .as_ref()
+        .is_some_and(|body| car_hitbox_touches_floor(body, player.hitbox))
+        || PlayerVerticalBand::from_height(position.z).is_grounded()
+        || player_is_on_wall(position)
+        || player_is_on_ceiling(position)
 }
 
 fn standard_soccar_boost_pad_position(index: usize) -> glam::Vec3 {

--- a/src/util/geometry.rs
+++ b/src/util/geometry.rs
@@ -677,6 +677,36 @@ pub fn car_hitbox_ball_contact_gap(
         .map(|center_distance| (center_distance - BALL_COLLISION_RADIUS).max(0.0))
 }
 
+pub fn car_hitbox_min_world_z(player_body: &boxcars::RigidBody, hitbox: CarHitbox) -> Option<f32> {
+    let car_position = vec_to_glam(&player_body.location);
+    let car_rotation = quat_to_glam(&player_body.rotation);
+    let hitbox_center = glam::Vec3::new(hitbox.offset, 0.0, hitbox.elevation);
+    let hitbox_rotation = glam::Quat::from_rotation_y(hitbox.angle.to_radians());
+    let mut min_z: Option<f32> = None;
+
+    for x in [-hitbox.length / 2.0, hitbox.length / 2.0] {
+        for y in [-hitbox.width / 2.0, hitbox.width / 2.0] {
+            for z in [-hitbox.height / 2.0, hitbox.height / 2.0] {
+                let local_corner = glam::Vec3::new(x, y, z);
+                let world_corner =
+                    car_position + car_rotation * (hitbox_center + hitbox_rotation * local_corner);
+                if !world_corner.z.is_finite() {
+                    return None;
+                }
+                min_z = Some(min_z.map_or(world_corner.z, |current| current.min(world_corner.z)));
+            }
+        }
+    }
+
+    min_z
+}
+
+pub fn car_hitbox_touches_floor(player_body: &boxcars::RigidBody, hitbox: CarHitbox) -> bool {
+    const FLOOR_CONTACT_MAX_Z: f32 = 5.0;
+
+    car_hitbox_min_world_z(player_body, hitbox).is_some_and(|min_z| min_z <= FLOOR_CONTACT_MAX_Z)
+}
+
 pub fn touch_candidate_contact_gap_rank_with_hitbox(
     ball_body: &boxcars::RigidBody,
     player_body: &boxcars::RigidBody,

--- a/src/util/geometry_tests.rs
+++ b/src/util/geometry_tests.rs
@@ -369,6 +369,17 @@ fn car_hitbox_distance_composes_car_rotation_with_hitbox_transform() {
 }
 
 #[test]
+fn car_hitbox_floor_contact_uses_hitbox_bottom() {
+    let hitbox = default_car_hitbox();
+    let grounded_car = sample_rotated_rigid_body(0.0, 0.0, 0.0, glam::Quat::IDENTITY);
+    let airborne_car = sample_rotated_rigid_body(0.0, 0.0, 100.0, glam::Quat::IDENTITY);
+
+    assert!(car_hitbox_min_world_z(&grounded_car, hitbox).unwrap() <= 5.0);
+    assert!(car_hitbox_touches_floor(&grounded_car, hitbox));
+    assert!(!car_hitbox_touches_floor(&airborne_car, hitbox));
+}
+
+#[test]
 fn car_hitbox_for_body_name_maps_known_cars_to_hitbox_families() {
     assert_eq!(
         car_hitbox_for_body_name("Fennec").map(|hitbox| hitbox.family),


### PR DESCRIPTION
## Summary

- refine double-tap detection so a pending sequence is invalidated when the player contacts ground, wall, or ceiling between the attributed touch and the follow-up touch
- remove the fixed follow-up timeout in favor of the player remaining airborne and the touches staying consecutive
- add hitbox-bottom floor contact checks and regression coverage for surface-interrupted double taps

## Context

Rocket Sense review labels exposed double-tap false positives where the player touched the ground between the setup touch and the follow-up touch. Those should not count as double taps even when the ball later bounces off the backboard and the same player scores.

The detector now carries player frame state into backboard-bounce attribution and clears attribution when the credited player contacts a surface before the backboard bounce. The double-tap calculator also clears pending backboard bounces on later surface contact before the follow-up touch.

## Validation

- `cargo test backboard_bounce --manifest-path vendor/subtr-actor/Cargo.toml`
- `cargo test double_tap --manifest-path vendor/subtr-actor/Cargo.toml`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- replay checks against the known rejected double-tap labels:
  - GarrettG `1989-2001`: no longer counted
  - Leleman24 `8538-8554`: no longer counted
  - LilRoo4 `5054-5085`: no longer counted
