### PR TITLE
[codex] Expose canonical event streams in playlist

### DIFF
--- a/js/stat-evaluation-player/src/eventCountDerivation.ts
+++ b/js/stat-evaluation-player/src/eventCountDerivation.ts
@@ -16,6 +16,9 @@ export const STATS_EVENT_STREAM_COUNT_TYPES = [
   "movement",
   "positioning",
   "rotation_player",
+  "rotation_role_span",
+  "rotation_depth_span",
+  "rotation_first_man_stint",
   "rotation_team",
   "mechanics",
   "goal_context",
@@ -34,6 +37,7 @@ export const STATS_EVENT_STREAM_COUNT_TYPES = [
   "pass_last_completed",
   "ball_carry",
   "rush",
+  "flip_impulse",
   "speed_flip",
   "half_flip",
   "half_volley",
@@ -48,6 +52,11 @@ export const STATS_EVENT_STREAM_COUNT_TYPES = [
   "boost_state",
   "bump",
 ] as const satisfies readonly (keyof StatsEvents)[];
+
+type AssertNever<T extends never> = T;
+type _StatsEventStreamCountTypesCoverAll = AssertNever<
+  Exclude<keyof StatsEvents, (typeof STATS_EVENT_STREAM_COUNT_TYPES)[number]>
+>;
 
 export const STATS_MECHANIC_EVENT_COUNT_TYPES = [
   "air_dribble",

--- a/js/stat-evaluation-player/src/eventPlaylistWindow.ts
+++ b/js/stat-evaluation-player/src/eventPlaylistWindow.ts
@@ -154,7 +154,10 @@ export class EventPlaylistWindowController {
     if (items.length === 0) {
       const empty = document.createElement("p");
       empty.className = "stat-window-empty";
-      empty.textContent = "No event types selected.";
+      empty.textContent =
+        selectedSourceIds.size === 0
+          ? "No event types selected."
+          : "No events in selected event types.";
       list.append(empty);
     } else {
       for (const item of items) {

--- a/js/stat-evaluation-player/src/eventTimelineSources.test.ts
+++ b/js/stat-evaluation-player/src/eventTimelineSources.test.ts
@@ -1,0 +1,195 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { ReplayModel } from "@rlrml/player";
+import {
+  STATS_EVENT_STREAM_COUNT_TYPES,
+  STATS_MECHANIC_EVENT_COUNT_TYPES,
+} from "./eventCountDerivation.ts";
+import type { StatModuleContext } from "./statModules.ts";
+import {
+  buildEventPlaylistItems,
+  getEventPlaylistSources,
+  getEventTimelineSources,
+} from "./eventTimelineSources.ts";
+import { createStatsTimeline } from "./testStatsTimeline.ts";
+
+function createSourceTestContext(): {
+  ctx: StatModuleContext;
+  replay: ReplayModel;
+} {
+  const replay = {
+    frames: Array.from({ length: 13 }, (_, frame) => ({ time: frame === 12 ? 1.25 : frame })),
+    players: [{ id: "Steam:blue-id", name: "Blue" }],
+    timelineEvents: [],
+  } as ReplayModel;
+  return {
+    replay,
+    ctx: {
+      replay,
+      statsTimeline: createStatsTimeline(),
+    } as StatModuleContext,
+  };
+}
+
+function getTestTimelineSources(ctx: StatModuleContext) {
+  return getEventTimelineSources({
+    ctx,
+    modules: [],
+    activeTimelineEventSourceIds: new Set(),
+    activeMechanicTimelineKinds: new Set(),
+    toggleEventSource() {},
+    setMechanicTimelineKind() {},
+  });
+}
+
+test("event timeline sources include empty canonical stats streams", () => {
+  const { ctx } = createSourceTestContext();
+  const timelineSources = getTestTimelineSources(ctx);
+  const sourceIds = new Set(timelineSources.map((source) => source.id));
+
+  assert.ok(sourceIds.has("stats-stream:positioning"));
+  assert.ok(sourceIds.has("stats-stream:backboard"));
+  assert.ok(sourceIds.has("stats-stream:rotation_role_span"));
+  assert.ok(sourceIds.has("stats-stream:flip_impulse"));
+  assert.ok(sourceIds.has("mechanic:speed_flip"));
+
+  const streamSources = timelineSources.filter((source) => source.id.startsWith("stats-stream:"));
+  for (const streamId of STATS_EVENT_STREAM_COUNT_TYPES) {
+    assert.ok(sourceIds.has(`stats-stream:${streamId}`), `missing stats stream ${streamId}`);
+  }
+
+  for (const mechanicKind of STATS_MECHANIC_EVENT_COUNT_TYPES.filter(
+    (kind) => kind !== "wavedash",
+  )) {
+    assert.ok(sourceIds.has(`mechanic:${mechanicKind}`), `missing mechanic ${mechanicKind}`);
+  }
+
+  assert.equal(
+    streamSources.every((source) => source.count === 0),
+    true,
+  );
+});
+
+test("event playlist filters include empty canonical stats streams", () => {
+  const { ctx } = createSourceTestContext();
+  const playlistSources = getEventPlaylistSources(ctx, getTestTimelineSources(ctx));
+  const playlistSourceIds = new Set(playlistSources.map((source) => source.id));
+
+  assert.ok(playlistSourceIds.has("stats-stream:positioning"));
+  assert.ok(playlistSourceIds.has("stats-stream:backboard"));
+  assert.ok(playlistSourceIds.has("mechanic:speed_flip"));
+  assert.equal(
+    playlistSources.find((source) => source.id === "stats-stream:positioning")?.events.length,
+    0,
+  );
+});
+
+test("event playlist sources include generic stats event streams such as positioning", () => {
+  const replay = {
+    frames: Array.from({ length: 13 }, (_, frame) => ({ time: frame === 12 ? 1.25 : frame })),
+    players: [{ id: "Steam:blue-id", name: "Blue" }],
+    timelineEvents: [],
+  } as ReplayModel;
+  const statsTimeline = createStatsTimeline({
+    events: {
+      positioning: [
+        {
+          time: 1.2,
+          frame: 11,
+          end_time: 1.25,
+          end_frame: 12,
+          duration: 0.05,
+          player: { Steam: "blue-id" },
+          is_team_0: true,
+          active: true,
+          tracked: true,
+          distance_to_teammates: 1000,
+          distance_to_ball: 2000,
+          possession_state: "has_possession",
+          demolished: false,
+          no_teammates: false,
+          teammate_role: "most_back",
+          defensive_zone_fraction: 0.5,
+          neutral_zone_fraction: 0.5,
+          offensive_zone_fraction: 0,
+          defensive_half_fraction: 0.8,
+          offensive_half_fraction: 0.2,
+          closest_to_ball: true,
+          farthest_from_ball: false,
+          behind_ball_fraction: 0.6,
+          level_with_ball_fraction: 0.4,
+          in_front_of_ball_fraction: 0,
+          caught_ahead_of_play_on_conceded_goal: false,
+        },
+      ],
+    },
+  });
+  const toggled: Array<{ id: string; enabled: boolean }> = [];
+  const ctx = {
+    replay,
+    statsTimeline,
+  } as StatModuleContext;
+
+  const timelineSources = getEventTimelineSources({
+    ctx,
+    modules: [],
+    activeTimelineEventSourceIds: new Set(),
+    activeMechanicTimelineKinds: new Set(),
+    toggleEventSource(id, enabled) {
+      toggled.push({ id, enabled });
+    },
+    setMechanicTimelineKind() {
+      throw new Error("unexpected mechanic toggle");
+    },
+  });
+
+  const positioningSource = timelineSources.find(
+    (source) => source.id === "stats-stream:positioning",
+  );
+  assert.ok(positioningSource);
+  assert.equal(positioningSource.group, "Event streams");
+  assert.equal(positioningSource.label, "Positioning");
+  assert.equal(positioningSource.count, 1);
+  assert.equal(positioningSource.active, false);
+
+  positioningSource.setActive(true);
+  assert.deepEqual(toggled, [{ id: "stats-stream:positioning", enabled: true }]);
+
+  const playlistSources = getEventPlaylistSources(ctx, timelineSources);
+  const playlistSource = playlistSources.find((source) => source.id === "stats-stream:positioning");
+  assert.ok(playlistSource);
+
+  const items = buildEventPlaylistItems({
+    sources: playlistSources,
+    activeSourceIds: null,
+    replayPlayers: replay.players,
+  });
+
+  assert.deepEqual(
+    items.map((item) => ({
+      sourceId: item.sourceId,
+      sourceLabel: item.sourceLabel,
+      time: item.event.time,
+      frame: item.event.frame,
+      label: item.event.label,
+      shortLabel: item.event.shortLabel,
+      playerId: item.event.playerId,
+      playerName: item.event.playerName,
+      isTeamZero: item.event.isTeamZero,
+    })),
+    [
+      {
+        sourceId: "stats-stream:positioning",
+        sourceLabel: "Positioning",
+        time: 1.25,
+        frame: 12,
+        label: "Blue positioning",
+        shortLabel: "P",
+        playerId: "Steam:blue-id",
+        playerName: "Blue",
+        isTeamZero: true,
+      },
+    ],
+  );
+});

--- a/js/stat-evaluation-player/src/eventTimelineSources.ts
+++ b/js/stat-evaluation-player/src/eventTimelineSources.ts
@@ -1,14 +1,47 @@
 import type { ReplayPlayerTrack, ReplayTimelineEvent, ReplayTimelineRange } from "@rlrml/player";
+import {
+  STATS_EVENT_STREAM_COUNT_TYPES,
+  STATS_MECHANIC_EVENT_COUNT_TYPES,
+} from "./eventCountDerivation.ts";
 import type { StatModule, StatModuleContext } from "./statModules.ts";
+import type { StatsEvents } from "./statsTimeline.ts";
 import {
   buildMechanicPlaylistEvents,
   buildMechanicTimelineEvents,
   formatMechanicKind,
   getMechanicKinds,
+  isVisibleMechanicKind,
 } from "./timelineMarkers.ts";
 import { buildMechanicTimelineRanges } from "./timelineRanges.ts";
 
 const DEFAULT_UNSELECTED_EVENT_PLAYLIST_SOURCE_IDS = new Set(["module:touch", "module:powerslide"]);
+const CURATED_STATS_EVENT_STREAM_IDS = new Set<keyof StatsEvents>([
+  "timeline",
+  "mechanics",
+  "backboard",
+  "ceiling_shot",
+  "wall_aerial",
+  "wall_aerial_shot",
+  "center",
+  "flick",
+  "musty_flick",
+  "dodge_reset",
+  "double_tap",
+  "fifty_fifty",
+  "one_timer",
+  "pass",
+  "ball_carry",
+  "rush",
+  "flip_impulse",
+  "speed_flip",
+  "half_flip",
+  "half_volley",
+  "wavedash",
+  "whiff",
+  "powerslide",
+  "touch",
+  "bump",
+]);
 const EVENT_PLAYLIST_PLAYER_COLORS = [
   "#3b82f6",
   "#06b6d4",
@@ -93,6 +126,202 @@ const REPLAY_EVENT_SOURCE_DEFINITIONS: EventWindowSourceDefinition[] = [
 
 const EXTRA_EVENT_SOURCE_DEFINITIONS: EventWindowSourceDefinition[] = [];
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function boolField(record: Record<string, unknown>, key: string): boolean | undefined {
+  const value = record[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function remoteIdToString(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const [kind, id] = Object.entries(value)[0] ?? [];
+  if (!kind || id == null) {
+    return null;
+  }
+  if (typeof id === "string" || typeof id === "number") {
+    return `${kind}:${id}`;
+  }
+  return `${kind}:${JSON.stringify(id)}`;
+}
+
+function getGenericEventTiming(
+  event: Record<string, unknown>,
+): { time: number; frame?: number } | null {
+  const timing = event.timing;
+  if (isRecord(timing)) {
+    const time =
+      numberField(timing, "end_time") ??
+      numberField(timing, "time") ??
+      numberField(timing, "start_time");
+    if (time != null) {
+      return {
+        time,
+        frame:
+          numberField(timing, "end_frame") ??
+          numberField(timing, "frame") ??
+          numberField(timing, "start_frame"),
+      };
+    }
+  }
+
+  const time =
+    numberField(event, "end_time") ??
+    numberField(event, "resolve_time") ??
+    numberField(event, "time") ??
+    numberField(event, "start_time");
+  if (time == null) {
+    return null;
+  }
+  return {
+    time,
+    frame:
+      numberField(event, "end_frame") ??
+      numberField(event, "resolve_frame") ??
+      numberField(event, "frame") ??
+      numberField(event, "start_frame"),
+  };
+}
+
+function getGenericEventPlayerId(event: Record<string, unknown>): string | null {
+  return (
+    remoteIdToString(event.player) ??
+    remoteIdToString(event.player_id) ??
+    remoteIdToString(event.initiator) ??
+    remoteIdToString(event.scorer)
+  );
+}
+
+function getGenericEventTeam(event: Record<string, unknown>): boolean | null {
+  return (
+    boolField(event, "is_team_0") ??
+    boolField(event, "initiator_is_team_0") ??
+    boolField(event, "scoring_team_is_team_0") ??
+    boolField(event, "team_is_team_0") ??
+    null
+  );
+}
+
+function eventStreamShortLabel(streamId: string): string {
+  return (
+    streamId
+      .split(/[_-]+/)
+      .filter((part) => part.length > 0)
+      .map((part) => part.slice(0, 1).toUpperCase())
+      .join("")
+      .slice(0, 3) || "E"
+  );
+}
+
+function buildGenericStatsEventTimelineEvents(
+  ctx: StatModuleContext,
+  streamId: keyof StatsEvents,
+  events: readonly unknown[],
+): ReplayTimelineEvent[] {
+  const streamLabel = formatMechanicKind(streamId);
+  const playerNames = new Map(ctx.replay.players.map((player) => [player.id, player.name]));
+
+  return events.flatMap((event, index) => {
+    if (!isRecord(event)) {
+      return [];
+    }
+    const timing = getGenericEventTiming(event);
+    if (!timing) {
+      return [];
+    }
+
+    const playerId = getGenericEventPlayerId(event);
+    const playerName = playerId ? (playerNames.get(playerId) ?? playerId) : null;
+    const isTeamZero = getGenericEventTeam(event);
+    const eventId =
+      stringField(event, "id") ?? `${streamId}:${timing.frame ?? timing.time}:${index}`;
+
+    return [
+      {
+        id: `stats-stream:${eventId}`,
+        time: ctx.replay.frames[timing.frame ?? -1]?.time ?? timing.time,
+        frame: timing.frame,
+        kind: streamId,
+        label: playerName ? `${playerName} ${streamLabel.toLowerCase()}` : streamLabel,
+        shortLabel: eventStreamShortLabel(streamId),
+        playerId,
+        playerName,
+        isTeamZero,
+        color:
+          isTeamZero == null
+            ? EVENT_PLAYLIST_NEUTRAL_COLOR
+            : isTeamZero
+              ? EVENT_PLAYLIST_PLAYER_COLORS[0]
+              : EVENT_PLAYLIST_PLAYER_COLORS[4],
+      },
+    ];
+  });
+}
+
+function buildGenericStatsEventSources(
+  ctx: StatModuleContext,
+  activeTimelineEventSourceIds: ReadonlySet<string>,
+  toggleEventSource: (id: string, enabled: boolean) => void,
+): EventTimelineSource[] {
+  return STATS_EVENT_STREAM_COUNT_TYPES.flatMap((streamId) => {
+    const events = ctx.statsTimeline.events[streamId] ?? [];
+    if (CURATED_STATS_EVENT_STREAM_IDS.has(streamId) && events.length > 0) {
+      return [];
+    }
+
+    const timelineEvents = buildGenericStatsEventTimelineEvents(ctx, streamId, events);
+
+    return [
+      {
+        id: `stats-stream:${streamId}`,
+        playlistId: `stats-stream:${streamId}`,
+        timelineKey: `stats-stream:${streamId}`,
+        timelineId: `stats-stream:${streamId}`,
+        group: "Event streams",
+        label: formatMechanicKind(streamId),
+        count: timelineEvents.length,
+        active: activeTimelineEventSourceIds.has(`stats-stream:${streamId}`),
+        buildTimelineEvents() {
+          return timelineEvents;
+        },
+        buildPlaylistEvents() {
+          return timelineEvents;
+        },
+        setActive(enabled) {
+          toggleEventSource(`stats-stream:${streamId}`, enabled);
+        },
+      },
+    ];
+  });
+}
+
+function getEventTimelineMechanicKinds(ctx: StatModuleContext): string[] {
+  return [
+    ...new Set([
+      ...STATS_MECHANIC_EVENT_COUNT_TYPES.filter(isVisibleMechanicKind),
+      ...getMechanicKinds(ctx.statsTimeline),
+    ]),
+  ].sort((left, right) => formatMechanicKind(left).localeCompare(formatMechanicKind(right)));
+}
+
 export function getEventTimelineSources({
   ctx,
   modules,
@@ -109,9 +338,6 @@ export function getEventTimelineSources({
   for (const source of REPLAY_EVENT_SOURCE_DEFINITIONS) {
     const events = source.buildEvents(ctx);
     const count = events.length;
-    if (count === 0) {
-      continue;
-    }
     sources.push({
       id: source.id,
       playlistId: `replay:${source.id}`,
@@ -136,9 +362,6 @@ export function getEventTimelineSources({
   for (const mod of modules.filter((module) => module.getTimelineEvents)) {
     const events = mod.getTimelineEvents?.(ctx) ?? [];
     const count = events.length;
-    if (count === 0) {
-      continue;
-    }
     sources.push({
       id: mod.id,
       playlistId: `module:${mod.id}`,
@@ -163,9 +386,6 @@ export function getEventTimelineSources({
   for (const source of EXTRA_EVENT_SOURCE_DEFINITIONS) {
     const events = source.buildEvents(ctx);
     const count = events.length;
-    if (count === 0) {
-      continue;
-    }
     sources.push({
       id: source.id,
       playlistId: `extra:${source.id}`,
@@ -187,14 +407,15 @@ export function getEventTimelineSources({
     });
   }
 
-  for (const kind of getMechanicKinds(ctx.statsTimeline)) {
+  sources.push(
+    ...buildGenericStatsEventSources(ctx, activeTimelineEventSourceIds, toggleEventSource),
+  );
+
+  for (const kind of getEventTimelineMechanicKinds(ctx)) {
     const timelineEvents = buildMechanicTimelineEvents(ctx.statsTimeline, ctx.replay, [kind]);
     const playlistEvents = buildMechanicPlaylistEvents(ctx.statsTimeline, ctx.replay, [kind]);
     const timelineRanges = buildMechanicTimelineRanges(ctx.statsTimeline, ctx.replay, [kind]);
     const count = timelineEvents.length + timelineRanges.length;
-    if (count === 0) {
-      continue;
-    }
     sources.push({
       id: `mechanic:${kind}`,
       playlistId: `mechanic:${kind}`,
@@ -237,16 +458,14 @@ export function getEventPlaylistSources(
       label: "Goals",
       events: ctx.replay.timelineEvents.filter((event) => event.kind === "goal"),
     },
-  ].filter((source) => source.events.length > 0);
+  ];
 
-  const timelineSources = eventSources
-    .map((source) => ({
-      id: source.playlistId,
-      group: source.group,
-      label: source.label,
-      events: source.buildPlaylistEvents(),
-    }))
-    .filter((source) => source.events.length > 0);
+  const timelineSources = eventSources.map((source) => ({
+    id: source.playlistId,
+    group: source.group,
+    label: source.label,
+    events: source.buildPlaylistEvents(),
+  }));
 
   return [...replaySources, ...timelineSources];
 }


### PR DESCRIPTION
## Summary

Expose a canonical event-stream source list in the stats player so every serialized stats event stream can appear in the event playlist and timeline controls, including empty streams.

## Why

The event playlist was assembled from hand-curated timeline sources and omitted serialized streams such as `positioning`. That made it easy for new event streams to be invisible unless somebody also remembered to add UI source wiring.

## Changes

- Complete the TS-side stats event stream index and add a compile-time exhaustiveness check against `keyof StatsEvents`.
- Add generic stats event stream sources for streams without curated timeline adapters.
- Keep empty replay, module, stats stream, and mechanic sources visible with count `0`.
- Update the playlist empty-state copy for selected event types that contain no events.
- Add tests for empty canonical stream visibility and positioning stream fallback mapping.

## Validation

- `./scripts/with-clean-npm-env.sh npm run lint` from `js/`
- `./scripts/with-clean-npm-env.sh npm run format:check` from `js/`
- `../scripts/with-clean-npm-env.sh npx tsx --tsconfig tsconfig.test.json --test src/eventTimelineSources.test.ts` from `js/stat-evaluation-player/`
- `../scripts/with-clean-npm-env.sh node --run=check:tsc` from `js/stat-evaluation-player/`
- pre-commit hook: `cargo clippy --all-targets --all-features -- -D warnings`
