### PR TITLE
Use car hitboxes for bump proximity

### DIFF
--- a/js/stat-evaluation-player/src/eventPlaylistWindow.ts
+++ b/js/stat-evaluation-player/src/eventPlaylistWindow.ts
@@ -154,10 +154,11 @@ export class EventPlaylistWindowController {
     if (items.length === 0) {
       const empty = document.createElement("p");
       empty.className = "stat-window-empty";
-      empty.textContent =
-        selectedSourceIds.size === 0
-          ? "No event types selected."
-          : "No events in selected event types.";
+      if (selectedSourceIds.size === 0) {
+        empty.textContent = "No event types selected.";
+      } else {
+        empty.textContent = "No events in selected event types.";
+      }
       list.append(empty);
     } else {
       for (const item of items) {

--- a/src/stats/calculators/bump.rs
+++ b/src/stats/calculators/bump.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 const BUMP_MAX_SAMPLE_DT: f32 = 0.18;
-const BUMP_MAX_CONTACT_DISTANCE: f32 = 230.0;
-const BUMP_MAX_VERTICAL_GAP: f32 = 190.0;
+const BUMP_MAX_CONTACT_GAP: f32 = 35.0;
+const BUMP_CONTACT_GAP_SAMPLES: usize = 8;
 const BUMP_MIN_CLOSING_SPEED: f32 = 420.0;
 const BUMP_MIN_VICTIM_IMPULSE: f32 = 180.0;
 const BUMP_MIN_INITIATOR_SLOWDOWN: f32 = 100.0;
@@ -186,20 +186,15 @@ impl BumpCalculator {
         let left_position = vec_to_glam(&left_body.location);
         let right_position = vec_to_glam(&right_body.location);
 
-        let contact_distance = swept_horizontal_distance(
-            left_previous_position,
-            left_position,
-            right_previous_position,
-            right_position,
-        );
-        if contact_distance > BUMP_MAX_CONTACT_DISTANCE {
-            return None;
-        }
-
-        let vertical_gap = (left_position.z - right_position.z)
-            .abs()
-            .min((left_previous_position.z - right_previous_position.z).abs());
-        if vertical_gap > BUMP_MAX_VERTICAL_GAP {
+        let contact_distance = swept_car_hitbox_contact_gap(
+            previous_left_body,
+            left_body,
+            left.hitbox,
+            previous_right_body,
+            right_body,
+            right.hitbox,
+        )?;
+        if contact_distance > BUMP_MAX_CONTACT_GAP {
             return None;
         }
 
@@ -254,8 +249,7 @@ impl BumpCalculator {
             return None;
         }
 
-        let distance_factor =
-            (1.0 - (contact_distance / BUMP_MAX_CONTACT_DISTANCE)).clamp(0.0, 1.0);
+        let distance_factor = (1.0 - (contact_distance / BUMP_MAX_CONTACT_GAP)).clamp(0.0, 1.0);
         let score_factor = ((candidate.score - BUMP_MIN_DIRECTIONAL_SCORE) / 900.0).clamp(0.0, 1.0);
         let margin_factor =
             ((candidate.score - reverse_score - BUMP_MIN_SCORE_MARGIN) / 500.0).clamp(0.0, 1.0);
@@ -389,25 +383,44 @@ fn vec3_to_array(v: glam::Vec3) -> [f32; 3] {
     [v.x, v.y, v.z]
 }
 
-fn horizontal(v: glam::Vec3) -> glam::Vec2 {
-    glam::Vec2::new(v.x, v.y)
+fn swept_car_hitbox_contact_gap(
+    left_previous: &boxcars::RigidBody,
+    left_current: &boxcars::RigidBody,
+    left_hitbox: CarHitbox,
+    right_previous: &boxcars::RigidBody,
+    right_current: &boxcars::RigidBody,
+    right_hitbox: CarHitbox,
+) -> Option<f32> {
+    let mut closest_gap =
+        car_hitbox_pair_contact_gap(left_current, left_hitbox, right_current, right_hitbox)?;
+
+    for sample_index in 0..=BUMP_CONTACT_GAP_SAMPLES {
+        let sample_fraction = sample_index as f32 / BUMP_CONTACT_GAP_SAMPLES as f32;
+        let left_sample = interpolate_rigid_body(left_previous, left_current, sample_fraction);
+        let right_sample = interpolate_rigid_body(right_previous, right_current, sample_fraction);
+        let sample_gap =
+            car_hitbox_pair_contact_gap(&left_sample, left_hitbox, &right_sample, right_hitbox)?;
+        closest_gap = closest_gap.min(sample_gap);
+    }
+
+    Some(closest_gap)
 }
 
-fn swept_horizontal_distance(
-    left_previous: glam::Vec3,
-    left_current: glam::Vec3,
-    right_previous: glam::Vec3,
-    right_current: glam::Vec3,
-) -> f32 {
-    let relative_start = horizontal(left_previous - right_previous);
-    let relative_delta =
-        horizontal((left_current - left_previous) - (right_current - right_previous));
-    let closest_t = if relative_delta.length_squared() > f32::EPSILON {
-        (-relative_start.dot(relative_delta) / relative_delta.length_squared()).clamp(0.0, 1.0)
-    } else {
-        0.0
-    };
-    (relative_start + relative_delta * closest_t).length()
+fn interpolate_rigid_body(
+    previous: &boxcars::RigidBody,
+    current: &boxcars::RigidBody,
+    fraction: f32,
+) -> boxcars::RigidBody {
+    let fraction = fraction.clamp(0.0, 1.0);
+    let previous_position = vec_to_glam(&previous.location);
+    let current_position = vec_to_glam(&current.location);
+    let previous_rotation = quat_to_glam(&previous.rotation);
+    let current_rotation = quat_to_glam(&current.rotation);
+
+    let mut interpolated = *current;
+    interpolated.location = glam_to_vec(&previous_position.lerp(current_position, fraction));
+    interpolated.rotation = glam_to_quat(&previous_rotation.slerp(current_rotation, fraction));
+    interpolated
 }
 
 fn contact_normal(

--- a/src/stats/calculators/bump_tests.rs
+++ b/src/stats/calculators/bump_tests.rs
@@ -113,7 +113,7 @@ fn bump_detector_credits_player_with_clear_directional_impulse() {
                 player(
                     2,
                     false,
-                    glam::Vec3::new(300.0, 0.0, 17.0),
+                    glam::Vec3::new(245.0, 0.0, 17.0),
                     glam::Vec3::new(700.0, 0.0, 0.0),
                 ),
             ]),
@@ -187,7 +187,7 @@ fn bump_detector_requires_clear_victim_impulse() {
                 player(
                     2,
                     false,
-                    glam::Vec3::new(280.0, 0.0, 17.0),
+                    glam::Vec3::new(235.0, 0.0, 17.0),
                     glam::Vec3::new(150.0, 0.0, 0.0),
                 ),
             ]),
@@ -235,6 +235,58 @@ fn bump_detector_requires_initiator_slowdown() {
                     true,
                     glam::Vec3::new(120.0, 0.0, 17.0),
                     glam::Vec3::new(1200.0, 0.0, 0.0),
+                ),
+                player(
+                    2,
+                    false,
+                    glam::Vec3::new(245.0, 0.0, 17.0),
+                    glam::Vec3::new(700.0, 0.0, 0.0),
+                ),
+            ]),
+            &FrameEventsState::default(),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    assert!(calculator.events().is_empty());
+    assert!(calculator.player_stats().is_empty());
+}
+
+#[test]
+fn bump_detector_rejects_center_near_cars_with_separated_hitboxes() {
+    let mut calculator = BumpCalculator::new();
+
+    calculator
+        .update(
+            &frame(0, 0.0),
+            &players(vec![
+                player(
+                    1,
+                    true,
+                    glam::Vec3::new(0.0, 0.0, 17.0),
+                    glam::Vec3::new(1200.0, 0.0, 0.0),
+                ),
+                player(
+                    2,
+                    false,
+                    glam::Vec3::new(260.0, 0.0, 17.0),
+                    glam::Vec3::ZERO,
+                ),
+            ]),
+            &FrameEventsState::default(),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    calculator
+        .update(
+            &frame(1, 0.1),
+            &players(vec![
+                player(
+                    1,
+                    true,
+                    glam::Vec3::new(120.0, 0.0, 17.0),
+                    glam::Vec3::new(650.0, 0.0, 0.0),
                 ),
                 player(
                     2,
@@ -294,7 +346,7 @@ fn bump_detector_suppresses_active_fifty_fifty_pair() {
                 player(
                     2,
                     false,
-                    glam::Vec3::new(300.0, 0.0, 17.0),
+                    glam::Vec3::new(245.0, 0.0, 17.0),
                     glam::Vec3::new(700.0, 0.0, 0.0),
                 ),
             ]),
@@ -374,13 +426,13 @@ fn bump_detector_suppresses_same_pair_repeats() {
         (
             glam::Vec3::new(120.0, 0.0, 17.0),
             glam::Vec3::new(1200.0, 0.0, 0.0),
-            glam::Vec3::new(300.0, 0.0, 17.0),
+            glam::Vec3::new(245.0, 0.0, 17.0),
             glam::Vec3::new(700.0, 0.0, 0.0),
         ),
         (
             glam::Vec3::new(240.0, 0.0, 17.0),
             glam::Vec3::new(650.0, 0.0, 0.0),
-            glam::Vec3::new(420.0, 0.0, 17.0),
+            glam::Vec3::new(365.0, 0.0, 17.0),
             glam::Vec3::new(1400.0, 0.0, 0.0),
         ),
     ];

--- a/src/util/geometry.rs
+++ b/src/util/geometry.rs
@@ -677,6 +677,211 @@ pub fn car_hitbox_ball_contact_gap(
         .map(|center_distance| (center_distance - BALL_COLLISION_RADIUS).max(0.0))
 }
 
+#[derive(Debug, Clone, Copy)]
+struct OrientedCarHitbox {
+    center: glam::Vec3,
+    axes: [glam::Vec3; 3],
+    half_extents: glam::Vec3,
+}
+
+impl OrientedCarHitbox {
+    fn corners(self) -> [glam::Vec3; 8] {
+        let x = self.axes[0] * self.half_extents.x;
+        let y = self.axes[1] * self.half_extents.y;
+        let z = self.axes[2] * self.half_extents.z;
+
+        [
+            self.center - x - y - z,
+            self.center - x - y + z,
+            self.center - x + y - z,
+            self.center - x + y + z,
+            self.center + x - y - z,
+            self.center + x - y + z,
+            self.center + x + y - z,
+            self.center + x + y + z,
+        ]
+    }
+
+    fn edge_segments(self) -> [(glam::Vec3, glam::Vec3); 12] {
+        let corners = self.corners();
+        [
+            (corners[0], corners[1]),
+            (corners[0], corners[2]),
+            (corners[0], corners[4]),
+            (corners[3], corners[1]),
+            (corners[3], corners[2]),
+            (corners[3], corners[7]),
+            (corners[5], corners[1]),
+            (corners[5], corners[4]),
+            (corners[5], corners[7]),
+            (corners[6], corners[2]),
+            (corners[6], corners[4]),
+            (corners[6], corners[7]),
+        ]
+    }
+}
+
+fn oriented_car_hitbox(
+    player_body: &boxcars::RigidBody,
+    hitbox: CarHitbox,
+) -> Option<OrientedCarHitbox> {
+    let car_position = vec_to_glam(&player_body.location);
+    let car_rotation = quat_to_glam(&player_body.rotation);
+    let hitbox_center = glam::Vec3::new(hitbox.offset, 0.0, hitbox.elevation);
+    let hitbox_rotation = glam::Quat::from_rotation_y(hitbox.angle.to_radians());
+    let rotation = car_rotation * hitbox_rotation;
+    let center = car_position + car_rotation * hitbox_center;
+    let axes = [
+        rotation * glam::Vec3::X,
+        rotation * glam::Vec3::Y,
+        rotation * glam::Vec3::Z,
+    ];
+    let half_extents =
+        glam::Vec3::new(hitbox.length / 2.0, hitbox.width / 2.0, hitbox.height / 2.0);
+
+    if center.is_finite() && axes.iter().all(|axis| axis.is_finite()) && half_extents.is_finite() {
+        Some(OrientedCarHitbox {
+            center,
+            axes,
+            half_extents,
+        })
+    } else {
+        None
+    }
+}
+
+fn point_oriented_box_distance(point: glam::Vec3, hitbox: OrientedCarHitbox) -> f32 {
+    let delta = point - hitbox.center;
+    let mut closest = hitbox.center;
+    for (axis, half_extent) in hitbox.axes.into_iter().zip([
+        hitbox.half_extents.x,
+        hitbox.half_extents.y,
+        hitbox.half_extents.z,
+    ]) {
+        let distance_on_axis = delta.dot(axis).clamp(-half_extent, half_extent);
+        closest += axis * distance_on_axis;
+    }
+    (point - closest).length()
+}
+
+fn segment_segment_distance(
+    left_start: glam::Vec3,
+    left_end: glam::Vec3,
+    right_start: glam::Vec3,
+    right_end: glam::Vec3,
+) -> f32 {
+    let left_delta = left_end - left_start;
+    let right_delta = right_end - right_start;
+    let offset = left_start - right_start;
+    let left_length_sq = left_delta.length_squared();
+    let right_length_sq = right_delta.length_squared();
+    let left_right_dot = left_delta.dot(right_delta);
+    let left_offset_dot = left_delta.dot(offset);
+    let right_offset_dot = right_delta.dot(offset);
+    let denominator = left_length_sq * right_length_sq - left_right_dot * left_right_dot;
+
+    let mut left_t;
+    let mut right_t;
+    if denominator.abs() > f32::EPSILON {
+        left_t = ((left_right_dot * right_offset_dot - right_length_sq * left_offset_dot)
+            / denominator)
+            .clamp(0.0, 1.0);
+    } else {
+        left_t = 0.0;
+    }
+
+    right_t = (left_right_dot * left_t + right_offset_dot) / right_length_sq;
+    if right_t < 0.0 {
+        right_t = 0.0;
+        left_t = (-left_offset_dot / left_length_sq).clamp(0.0, 1.0);
+    } else if right_t > 1.0 {
+        right_t = 1.0;
+        left_t = ((left_right_dot - left_offset_dot) / left_length_sq).clamp(0.0, 1.0);
+    }
+
+    let left_closest = left_start + left_delta * left_t;
+    let right_closest = right_start + right_delta * right_t;
+    (left_closest - right_closest).length()
+}
+
+fn projected_interval(points: &[glam::Vec3; 8], axis: glam::Vec3) -> (f32, f32) {
+    points
+        .iter()
+        .map(|point| point.dot(axis))
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), value| {
+            (min.min(value), max.max(value))
+        })
+}
+
+fn separated_on_axis(
+    left_corners: &[glam::Vec3; 8],
+    right_corners: &[glam::Vec3; 8],
+    axis: glam::Vec3,
+) -> bool {
+    if axis.length_squared() <= f32::EPSILON {
+        return false;
+    }
+    let axis = axis.normalize();
+    let (left_min, left_max) = projected_interval(left_corners, axis);
+    let (right_min, right_max) = projected_interval(right_corners, axis);
+    left_max < right_min || right_max < left_min
+}
+
+fn oriented_boxes_intersect(left: OrientedCarHitbox, right: OrientedCarHitbox) -> bool {
+    let left_corners = left.corners();
+    let right_corners = right.corners();
+    let face_axes = left.axes.into_iter().chain(right.axes);
+    let edge_axes = left
+        .axes
+        .into_iter()
+        .flat_map(|left_axis| right.axes.map(|right_axis| left_axis.cross(right_axis)));
+
+    face_axes
+        .chain(edge_axes)
+        .all(|axis| !separated_on_axis(&left_corners, &right_corners, axis))
+}
+
+fn oriented_box_distance(left: OrientedCarHitbox, right: OrientedCarHitbox) -> f32 {
+    if oriented_boxes_intersect(left, right) {
+        return 0.0;
+    }
+
+    let left_corners = left.corners();
+    let right_corners = right.corners();
+    let mut distance = f32::INFINITY;
+
+    for corner in left_corners {
+        distance = distance.min(point_oriented_box_distance(corner, right));
+    }
+    for corner in right_corners {
+        distance = distance.min(point_oriented_box_distance(corner, left));
+    }
+    for (left_start, left_end) in left.edge_segments() {
+        for (right_start, right_end) in right.edge_segments() {
+            distance = distance.min(segment_segment_distance(
+                left_start,
+                left_end,
+                right_start,
+                right_end,
+            ));
+        }
+    }
+
+    distance
+}
+
+pub fn car_hitbox_pair_contact_gap(
+    left_body: &boxcars::RigidBody,
+    left_hitbox: CarHitbox,
+    right_body: &boxcars::RigidBody,
+    right_hitbox: CarHitbox,
+) -> Option<f32> {
+    let left = oriented_car_hitbox(left_body, left_hitbox)?;
+    let right = oriented_car_hitbox(right_body, right_hitbox)?;
+    let distance = oriented_box_distance(left, right);
+    distance.is_finite().then_some(distance)
+}
+
 pub fn car_hitbox_min_world_z(player_body: &boxcars::RigidBody, hitbox: CarHitbox) -> Option<f32> {
     let car_position = vec_to_glam(&player_body.location);
     let car_rotation = quat_to_glam(&player_body.rotation);

--- a/src/util/geometry_tests.rs
+++ b/src/util/geometry_tests.rs
@@ -336,6 +336,52 @@ fn car_hitbox_ball_contact_gap_subtracts_ball_radius() {
 }
 
 #[test]
+fn car_hitbox_pair_contact_gap_returns_zero_for_touching_cars() {
+    let hitbox = default_car_hitbox();
+    let left = sample_rotated_rigid_body(0.0, 0.0, 17.0, glam::Quat::IDENTITY);
+    let right = sample_rotated_rigid_body(118.0, 0.0, 17.0, glam::Quat::IDENTITY);
+
+    let gap = car_hitbox_pair_contact_gap(&left, hitbox, &right, hitbox).unwrap();
+
+    assert!(gap <= 0.001);
+}
+
+#[test]
+fn car_hitbox_pair_contact_gap_measures_separation_between_hitboxes() {
+    let hitbox = default_car_hitbox();
+    let left = sample_rotated_rigid_body(0.0, 0.0, 17.0, glam::Quat::IDENTITY);
+    let right = sample_rotated_rigid_body(128.0, 0.0, 17.0, glam::Quat::IDENTITY);
+
+    let gap = car_hitbox_pair_contact_gap(&left, hitbox, &right, hitbox).unwrap();
+
+    assert!(
+        gap > 9.0 && gap < 10.0,
+        "expected a small positive oriented-hitbox gap, got {gap:?}"
+    );
+}
+
+#[test]
+fn car_hitbox_pair_contact_gap_uses_car_orientation() {
+    let hitbox = default_car_hitbox();
+    let left = sample_rotated_rigid_body(0.0, 0.0, 17.0, glam::Quat::IDENTITY);
+    let forward_right = sample_rotated_rigid_body(155.0, 0.0, 17.0, glam::Quat::IDENTITY);
+    let sideways_right = sample_rotated_rigid_body(
+        155.0,
+        0.0,
+        17.0,
+        glam::Quat::from_rotation_z(std::f32::consts::FRAC_PI_2),
+    );
+
+    let forward_gap = car_hitbox_pair_contact_gap(&left, hitbox, &forward_right, hitbox).unwrap();
+    let sideways_gap = car_hitbox_pair_contact_gap(&left, hitbox, &sideways_right, hitbox).unwrap();
+
+    assert!(
+        forward_gap < sideways_gap,
+        "expected the forward-facing car's long axis to be closer: {forward_gap:?} !< {sideways_gap:?}"
+    );
+}
+
+#[test]
 fn car_hitbox_distance_applies_hitbox_offset_elevation_and_slope() {
     let hitbox = default_car_hitbox();
     let car = sample_rotated_rigid_body(0.0, 0.0, 0.0, glam::Quat::IDENTITY);


### PR DESCRIPTION
## Summary
- add oriented car-hitbox pair distance support in geometry utilities
- make bump detection gate proximity on swept car-hitbox contact gap instead of center distance and vertical gap
- update bump fixtures and add a regression test for center-near but hitbox-separated cars

## Validation
- nix develop -c cargo fmt
- nix develop -c cargo test car_hitbox_pair
- nix develop -c cargo test stats::calculators::bump
- nix develop -c cargo clippy -p subtr-actor -- -D warnings
