### PR TITLE
[codex] Expose modern stats APIs in Python

### DIFF
--- a/python/PYTHON-README.md
+++ b/python/PYTHON-README.md
@@ -35,8 +35,12 @@ headers = subtr_actor.get_column_headers(
 
 replay_meta = subtr_actor.get_replay_meta(replay_path)
 frames_data = subtr_actor.get_replay_frames_data(replay_path)
+stats_events = subtr_actor.get_stats_events(replay_path)
+summed_stats = subtr_actor.get_summed_stats(
+    replay_path,
+    module_names=["core", "boost", "movement"],
+)
 stats_module_names = subtr_actor.get_stats_module_names()
-stats = subtr_actor.get_stats(replay_path, module_names=["core", "boost", "movement"])
 stats_snapshot_data = subtr_actor.get_stats_snapshot_data(
     replay_path,
     module_names=["core", "boost"],
@@ -55,8 +59,9 @@ legacy_stats_timeline = subtr_actor.get_legacy_stats_timeline(
 print(ndarray.shape)
 print(headers["player_headers"][:5])
 print(replay_meta["map_name"])
+print(stats_events["boost_ledger"][-1])
+print(summed_stats["modules"]["boost"]["team_zero"]["amount_collected"])
 print(stats_module_names)
-print(stats["modules"]["core"]["team_zero"]["score"])
 print(stats_snapshot_data["frames"][-1]["modules"]["boost"]["team_zero"]["amount_collected"])
 print(stats_timeline["events"]["boost_ledger"][-1])
 print(legacy_stats_timeline["frames"][-1]["team_zero"]["boost"]["amount_collected"])
@@ -97,20 +102,31 @@ Get header information for the configured ndarray layout.
 
 Get structured frame-by-frame game state data with no FPS resampling.
 
-### `get_stats_module_names() -> list[str]`
+### `get_stats_events(filepath, frame_step_seconds=None) -> dict`
 
-List the builtin stats modules that can be selected in `get_stats`,
-`get_stats_snapshot_data`, and `get_legacy_stats_timeline`.
+Get the compact modern stats event streams for a replay.
 
-### `get_stats(filepath, module_names=None) -> dict`
+Parameters:
 
-Get aggregate replay stats for the selected builtin modules.
+- `filepath`: path to the replay file
+- `frame_step_seconds`: optional positive sampling interval in seconds for the
+  accompanying timeline collector. Events are still emitted as compact stat
+  change streams.
+
+### `get_summed_stats(filepath, module_names=None) -> dict`
+
+Get aggregate summed stats for the selected builtin modules.
 
 Parameters:
 
 - `filepath`: path to the replay file
 - `module_names`: optional list of builtin stats module names. By default all
   builtin modules are included.
+
+### `get_stats_module_names() -> list[str]`
+
+List the builtin stats modules that can be selected in `get_summed_stats`,
+`get_stats_snapshot_data`, and `get_legacy_stats_timeline`.
 
 ### `get_stats_snapshot_data(filepath, module_names=None, frame_step_seconds=None) -> dict`
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,7 +11,12 @@ requires-python = ">=3.7"
 Repository = "https://github.com/rlrml/subtr-actor"
 
 [dependency-groups]
-dev = ["wheel", "pytest", "numpy"]
+dev = [
+    "wheel",
+    "pytest",
+    "numpy",
+    "ruff>=0.15.14",
+]
 
 [tool.maturin]
 python-source = "."

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -35,7 +35,8 @@ fn subtr_actor_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_column_headers, m)?)?;
     m.add_function(wrap_pyfunction!(get_replay_frames_data, m)?)?;
     m.add_function(wrap_pyfunction!(get_stats_module_names, m)?)?;
-    m.add_function(wrap_pyfunction!(get_stats, m)?)?;
+    m.add_function(wrap_pyfunction!(get_stats_events, m)?)?;
+    m.add_function(wrap_pyfunction!(get_summed_stats, m)?)?;
     m.add_function(wrap_pyfunction!(get_stats_snapshot_data, m)?)?;
     m.add_function(wrap_pyfunction!(get_stats_timeline, m)?)?;
     m.add_function(wrap_pyfunction!(get_legacy_stats_timeline, m)?)?;
@@ -395,8 +396,25 @@ fn get_stats_module_names<'p>(py: Python<'p>) -> PyResult<Py<PyAny>> {
 
 #[allow(clippy::useless_conversion)]
 #[pyfunction]
+#[pyo3(signature = (filepath, frame_step_seconds=None))]
+fn get_stats_events<'p>(
+    py: Python<'p>,
+    filepath: PathBuf,
+    frame_step_seconds: Option<f32>,
+) -> PyResult<Py<PyAny>> {
+    let replay = replay_from_filepath(&filepath)?;
+    let timeline = build_stats_timeline_event_collector(frame_step_seconds)?
+        .get_replay_stats_timeline_scaffold(&replay)
+        .map_err(handle_subtr_actor_exception)?;
+    let events = serde_json::to_value(timeline.events).map_err(to_py_error)?;
+
+    Ok(convert_to_py(py, &events))
+}
+
+#[allow(clippy::useless_conversion)]
+#[pyfunction]
 #[pyo3(signature = (filepath, module_names=None))]
-fn get_stats<'p>(
+fn get_summed_stats<'p>(
     py: Python<'p>,
     filepath: PathBuf,
     module_names: Option<Vec<String>>,

--- a/python/subtr_actor/__init__.py
+++ b/python/subtr_actor/__init__.py
@@ -26,7 +26,7 @@ def _load_native_module():
             try:
                 spec.loader.exec_module(module)
                 return module
-            except Exception as error:  # pragma: no cover - exercised in packaging failures
+            except Exception as error:  # pragma: no cover
                 sys.modules.pop(spec.name, None)
                 load_errors.append(f"{candidate.name}: {error}")
         load_error_text = "; ".join(load_errors) if load_errors else str(initial_error)

--- a/python/tests/test_filepath_functions.py
+++ b/python/tests/test_filepath_functions.py
@@ -28,12 +28,28 @@ def test_get_stats_module_names():
     assert "movement" in module_names
 
 
-def test_get_stats_with_module_selection():
-    stats = subtr_actor.get_stats(REPLAY_PATH, module_names=["core", "boost"])
+def test_get_stats_events():
+    events = subtr_actor.get_stats_events(REPLAY_PATH)
 
-    assert set(stats["modules"]) == {"core", "boost"}
-    assert "player_stats" in stats["modules"]["core"]
-    assert "player_stats" in stats["modules"]["boost"]
+    assert "timeline" in events
+    assert "boost_ledger" in events
+    assert "core_player" in events
+
+
+def test_get_summed_stats_with_module_selection():
+    summed_stats = subtr_actor.get_summed_stats(
+        REPLAY_PATH,
+        module_names=["core", "boost"],
+    )
+
+    assert set(summed_stats["modules"]) == {"core", "boost"}
+    assert "score" in summed_stats["modules"]["core"]["team_zero"]
+    assert "amount_collected" in summed_stats["modules"]["boost"]["team_zero"]
+
+
+def test_get_summed_stats_rejects_unknown_module_name():
+    with pytest.raises(ValueError, match="Unknown builtin stats module"):
+        subtr_actor.get_summed_stats(REPLAY_PATH, module_names=["not_a_real_module"])
 
 
 def test_get_stats_snapshot_data_with_sampling():
@@ -87,8 +103,3 @@ def test_get_stats_timeline_rejects_module_filtering():
 def test_get_stats_timeline_rejects_invalid_sampling_step():
     with pytest.raises(ValueError, match="frame_step_seconds"):
         subtr_actor.get_stats_timeline(REPLAY_PATH, frame_step_seconds=0.0)
-
-
-def test_get_stats_rejects_unknown_module_name():
-    with pytest.raises(ValueError, match="Unknown builtin stats module"):
-        subtr_actor.get_stats(REPLAY_PATH, module_names=["not_a_real_module"])

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -526,8 +526,33 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
 name = "subtr-actor-py"
-version = "0.3.1"
+version = "0.12.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -541,6 +566,7 @@ dev = [
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "ruff" },
     { name = "wheel", version = "0.42.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
     { name = "wheel", version = "0.45.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
     { name = "wheel", version = "0.46.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -552,6 +578,7 @@ dev = [
 dev = [
     { name = "numpy" },
     { name = "pytest" },
+    { name = "ruff", specifier = ">=0.15.14" },
     { name = "wheel" },
 ]
 


### PR DESCRIPTION
## Summary

- add `get_stats_events(filepath, frame_step_seconds=None)` to expose compact modern stats event streams from Python
- rename the aggregate stats API to `get_summed_stats(filepath, module_names=None)` and update docs/tests
- add ruff to the Python dev dependency group and refresh `uv.lock`

## Context

This was extracted from the old `colonelpanic/python-modern-stats` worktree onto current `origin/master` so the PR contains only the Python API changes, not the stale 95-commit refactor history on that branch.

## Validation

- `cargo fmt --check`
- `uv run --with maturin maturin develop --release`
- `uv run pytest`
- `nix run nixpkgs#ruff -- check .`
- `cargo clippy --all-targets --all-features -- -D warnings` via pre-commit hook

## Notes

- `uv run ruff check .` does not run directly on this NixOS machine because the PyPI ruff wheel is dynamically linked for generic Linux; the Nix-provided ruff binary was used for validation.
