### PR TITLE
[codex] Fix stats player playback performance

### DIFF
--- a/js/stat-evaluation-player/src/eventPlaylistWindow.ts
+++ b/js/stat-evaluation-player/src/eventPlaylistWindow.ts
@@ -21,16 +21,23 @@ export class EventPlaylistWindowController {
   private activeSourceIds: Set<string> | null = null;
   private autoFollow = true;
   private lastActiveKey: string | null = null;
+  private activeItem: HTMLElement | null = null;
+  private renderedItems: { key: string; time: number; element: HTMLElement }[] = [];
 
   constructor(private readonly options: EventPlaylistWindowControllerOptions) {}
 
   reset(): void {
     this.activeSourceIds = null;
     this.lastActiveKey = null;
+    this.activeItem = null;
+    this.renderedItems = [];
   }
 
   render(): void {
     this.options.body.replaceChildren();
+    this.lastActiveKey = null;
+    this.activeItem = null;
+    this.renderedItems = [];
     const sources = this.options.getSources();
     if (sources.length === 0) {
       const empty = document.createElement("p");
@@ -168,6 +175,13 @@ export class EventPlaylistWindowController {
         button.dataset.eventKey = item.key;
         button.dataset.eventTime = `${item.event.time}`;
         button.style.setProperty("--event-color", item.color);
+        if (Number.isFinite(item.event.time)) {
+          this.renderedItems.push({
+            key: item.key,
+            time: item.event.time,
+            element: button,
+          });
+        }
         button.addEventListener("click", () => {
           this.options.cueTimelineEvent(item.event);
         });
@@ -204,23 +218,26 @@ export class EventPlaylistWindowController {
       return;
     }
 
-    const activeItem = this.getActiveItem(list, state.currentTime);
+    const activeItem = this.getActiveItem(state.currentTime);
     const activeKey = activeItem?.dataset.eventKey ?? null;
     if (activeKey === this.lastActiveKey && !options.forceScroll) {
       return;
     }
 
-    list
-      .querySelectorAll<HTMLElement>(".event-playlist-item[data-active='true']")
-      .forEach((item) => {
-        item.dataset.active = "false";
-      });
+    if (this.activeItem?.isConnected) {
+      this.activeItem.dataset.active = "false";
+    } else if (this.activeItem) {
+      this.activeItem = null;
+    }
 
     if (activeItem) {
       activeItem.dataset.active = "true";
+      this.activeItem = activeItem;
       if (this.autoFollow || options.forceScroll) {
         activeItem.scrollIntoView({ block: "nearest" });
       }
+    } else {
+      this.activeItem = null;
     }
 
     this.lastActiveKey = activeKey;
@@ -241,26 +258,31 @@ export class EventPlaylistWindowController {
     }
   }
 
-  private getActiveItem(list: HTMLElement, currentTime: number): HTMLElement | null {
-    const items = [...list.querySelectorAll<HTMLElement>(".event-playlist-item")];
+  private getActiveItem(currentTime: number): HTMLElement | null {
+    const items = this.renderedItems;
     if (items.length === 0) {
       return null;
     }
 
-    let bestItem = items[0] ?? null;
-    let bestDistance = Number.POSITIVE_INFINITY;
-    for (const item of items) {
-      const time = Number(item.dataset.eventTime);
-      if (!Number.isFinite(time)) {
-        continue;
-      }
-      const distance = Math.abs(time - currentTime);
-      if (distance < bestDistance) {
-        bestDistance = distance;
-        bestItem = item;
+    let low = 0;
+    let high = items.length - 1;
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (items[mid]!.time < currentTime) {
+        low = mid + 1;
+      } else {
+        high = mid;
       }
     }
-    return bestItem;
+
+    const right = items[low]!;
+    const left = items[low - 1] ?? null;
+    if (!left) {
+      return right.element;
+    }
+    return Math.abs(left.time - currentTime) <= Math.abs(right.time - currentTime)
+      ? left.element
+      : right.element;
   }
 }
 

--- a/js/stat-evaluation-player/src/eventTimelineSources.test.ts
+++ b/js/stat-evaluation-player/src/eventTimelineSources.test.ts
@@ -9,6 +9,7 @@ import {
 import type { StatModuleContext } from "./statModules.ts";
 import {
   buildEventPlaylistItems,
+  getEventPlaylistSelectedSourceIds,
   getEventPlaylistSources,
   getEventTimelineSources,
 } from "./eventTimelineSources.ts";
@@ -146,10 +147,16 @@ test("event playlist sources include generic stats event streams such as positio
     (source) => source.id === "stats-stream:positioning_activity",
   );
   assert.ok(playlistSource);
+  assert.equal(
+    getEventPlaylistSelectedSourceIds(playlistSources, null).has(
+      "stats-stream:positioning_activity",
+    ),
+    false,
+  );
 
   const items = buildEventPlaylistItems({
     sources: playlistSources,
-    activeSourceIds: null,
+    activeSourceIds: new Set(["stats-stream:positioning_activity"]),
     replayPlayers: replay.players,
   });
 

--- a/js/stat-evaluation-player/src/eventTimelineSources.ts
+++ b/js/stat-evaluation-player/src/eventTimelineSources.ts
@@ -15,6 +15,7 @@ import {
 import { buildMechanicTimelineRanges } from "./timelineRanges.ts";
 
 const DEFAULT_UNSELECTED_EVENT_PLAYLIST_SOURCE_IDS = new Set(["module:touch", "module:powerslide"]);
+const DEFAULT_UNSELECTED_EVENT_PLAYLIST_SOURCE_PREFIXES = ["stats-stream:"] as const;
 const CURATED_STATS_EVENT_STREAM_IDS = new Set<keyof StatsEvents>([
   "timeline",
   "mechanics",
@@ -476,7 +477,15 @@ export function getEventPlaylistSelectedSourceIds(
 ): Set<string> {
   const sourceIds = sources.map((source) => source.id);
   if (activeSourceIds === null) {
-    return new Set(sourceIds.filter((id) => !DEFAULT_UNSELECTED_EVENT_PLAYLIST_SOURCE_IDS.has(id)));
+    return new Set(
+      sourceIds.filter(
+        (id) =>
+          !DEFAULT_UNSELECTED_EVENT_PLAYLIST_SOURCE_IDS.has(id) &&
+          !DEFAULT_UNSELECTED_EVENT_PLAYLIST_SOURCE_PREFIXES.some((prefix) =>
+            id.startsWith(prefix),
+          ),
+      ),
+    );
   }
   return new Set(sourceIds.filter((id) => activeSourceIds.has(id)));
 }

--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -77,6 +77,7 @@ import {
   isStatsPlayerConfigDebugEnabled,
   type StatsPlayerConfig,
   type StatsWindowKind,
+  type SingletonWindowId,
   type WindowPlacementConfig,
 } from "./playerConfig.ts";
 import { logStatsPlayerConfigLoadDebug } from "./playerConfigRuntime.ts";
@@ -386,10 +387,18 @@ function renderEventPlaylistWindow(): void {
   eventPlaylistController?.render();
 }
 
+function isSingletonWindowVisible(id: string): boolean {
+  const windowEl = appRoot?.querySelector<HTMLElement>(`[data-window-id="${id}"]`);
+  return Boolean(windowEl && !windowEl.hidden);
+}
+
 function syncEventPlaylistTimeline(
   state: ReplayPlayerState,
   options: SyncEventPlaylistTimelineOptions = {},
 ): void {
+  if (!options.forceScroll && !isSingletonWindowVisible("event-playlist")) {
+    return;
+  }
   eventPlaylistController?.syncTimeline(state, options);
 }
 
@@ -420,7 +429,28 @@ function renderScoreboard(frameIndex = replayPlayer?.getState().frameIndex ?? 0)
 }
 
 function renderShotVisualization(state = replayPlayer?.getState() ?? null): void {
+  if (!isSingletonWindowVisible("shot-visualization")) {
+    return;
+  }
   shotVisualizationController?.render(state);
+}
+
+function toggleSingletonWindow(id: SingletonWindowId): void {
+  windowCommands.toggleWindow(id);
+  if (!isSingletonWindowVisible(id)) {
+    return;
+  }
+
+  if (id === "event-playlist") {
+    renderEventPlaylistWindow();
+    const state = replayPlayer?.getState();
+    if (state) {
+      syncEventPlaylistTimeline(state, { forceScroll: true });
+    }
+  }
+  if (id === "shot-visualization") {
+    renderShotVisualization(replayPlayer?.getState() ?? null);
+  }
 }
 
 function setTransportEnabled(enabled: boolean): void {
@@ -937,7 +967,7 @@ export function mountStatEvaluationPlayer(
     setLauncherOpen: windowCommands.setLauncherOpen,
     openReplayFilePicker: windowCommands.openReplayFilePicker,
     getElementWindowId: windowCommands.getElementWindowId,
-    toggleWindow: windowCommands.toggleWindow,
+    toggleWindow: toggleSingletonWindow,
     hideWindow: windowCommands.hideWindow,
     createStatsWindow,
     async loadReplayFile(file) {

--- a/js/stat-evaluation-player/src/shotVisualization.ts
+++ b/js/stat-evaluation-player/src/shotVisualization.ts
@@ -36,6 +36,12 @@ export class ShotVisualizationController {
   private camera: THREE.PerspectiveCamera | null = null;
   private resizeObserver: ResizeObserver | null = null;
   private selectedShotId: string | null = null;
+  private cachedReplay: ReplayPlayer["replay"] | null = null;
+  private cachedShots: ShotEvent[] = [];
+  private lastShotsSignature = "";
+  private lastListSelectionKey: string | null = null;
+  private lastSelectedShotKey: string | null = null;
+  private readonly shotButtons = new Map<string, HTMLButtonElement>();
 
   constructor(private readonly options: ShotVisualizationControllerOptions) {
     this.options.body.innerHTML = `
@@ -74,24 +80,46 @@ export class ShotVisualizationController {
   ): void {
     const shots = this.shotEvents();
     const currentTime = state?.currentTime ?? null;
-    if (!shots.some((shot) => shot.id === this.selectedShotId)) {
-      this.selectedShotId = shots[0]?.id ?? null;
+    if (!this.findSelectedShot(shots)) {
+      this.selectedShotId = shots[0] ? this.shotKey(shots[0], 0) : null;
     }
+    const selectedShot = this.findSelectedShot(shots);
+    const selectedShotKey = selectedShot?.key ?? null;
+    const shotsSignature = this.shotsSignature(shots);
+    const shotsChanged = shotsSignature !== this.lastShotsSignature;
 
     this.emptyState.hidden = shots.length > 0;
-    this.summary.textContent = this.summaryText(shots);
-    this.renderShotList(shots, currentTime);
+    if (shotsChanged) {
+      this.summary.textContent = this.summaryText(shots);
+    }
+    if (shotsChanged || selectedShotKey !== this.lastListSelectionKey) {
+      this.renderShotList(shots, currentTime, selectedShotKey);
+      this.lastListSelectionKey = selectedShotKey;
+    } else {
+      this.updateShotListActiveState(shots, currentTime);
+    }
     this.renderChart(shots, currentTime);
-    this.renderSelectedShot(shots.find((shot) => shot.id === this.selectedShotId) ?? null);
+    if (shotsChanged || selectedShotKey !== this.lastSelectedShotKey) {
+      this.renderSelectedShot(selectedShot?.shot ?? null);
+      this.lastSelectedShotKey = selectedShotKey;
+    }
+    this.lastShotsSignature = shotsSignature;
   }
 
   private shotEvents(): ShotEvent[] {
     const replay = this.options.getReplayPlayer()?.replay;
     if (!replay) {
+      this.cachedReplay = null;
+      this.cachedShots = [];
       return [];
     }
+    if (replay === this.cachedReplay) {
+      return this.cachedShots;
+    }
 
-    return replay.timelineEvents.filter(isShotEvent);
+    this.cachedReplay = replay;
+    this.cachedShots = replay.timelineEvents.filter(isShotEvent);
+    return this.cachedShots;
   }
 
   private summaryText(shots: readonly ShotEvent[]): string {
@@ -110,18 +138,22 @@ export class ShotVisualizationController {
     return `${shots.length} shots | ${saved} saved | avg ${formatSpeed(averageSpeed)}`;
   }
 
-  private renderShotList(shots: readonly ShotEvent[], currentTime: number | null): void {
+  private renderShotList(
+    shots: readonly ShotEvent[],
+    currentTime: number | null,
+    selectedShotKey: string | null,
+  ): void {
+    this.shotButtons.clear();
     this.shotList.replaceChildren(
       ...shots.map((shot, index) => {
+        const key = this.shotKey(shot, index);
         const button = document.createElement("button");
         button.type = "button";
         button.className = "shot-list-item";
-        button.dataset.selected = String(shot.id === this.selectedShotId);
-        button.dataset.active = String(
-          currentTime !== null && Math.abs(currentTime - shot.time) < 1.5,
-        );
+        button.dataset.selected = String(key === selectedShotKey);
+        button.dataset.active = String(isShotActive(shot, currentTime));
         button.addEventListener("click", () => {
-          this.selectedShotId = shot.id ?? `${shot.frame ?? index}:${shot.playerId ?? "shot"}`;
+          this.selectedShotId = key;
           this.options.cueTimelineEvent(shot);
           this.render();
         });
@@ -135,9 +167,19 @@ export class ShotVisualizationController {
           shot.shot.resulting_save ? "saved" : "unsaved"
         }`;
         button.append(title, meta);
+        this.shotButtons.set(key, button);
         return button;
       }),
     );
+  }
+
+  private updateShotListActiveState(shots: readonly ShotEvent[], currentTime: number | null): void {
+    shots.forEach((shot, index) => {
+      const button = this.shotButtons.get(this.shotKey(shot, index));
+      if (button) {
+        button.dataset.active = String(isShotActive(shot, currentTime));
+      }
+    });
   }
 
   private renderChart(shots: readonly ShotEvent[], currentTime: number | null): void {
@@ -161,12 +203,12 @@ export class ShotVisualizationController {
     context.clearRect(0, 0, cssWidth, cssHeight);
     drawField(context, cssWidth, cssHeight);
 
-    for (const shot of shots) {
+    shots.forEach((shot, index) => {
       const position = shot.shot.shot_touch_position ?? shot.shot.ball_position;
       const point = fieldToChart(position, cssWidth, cssHeight);
       const saved = Boolean(shot.shot.resulting_save);
-      const active = currentTime !== null && Math.abs(currentTime - shot.time) < 1.5;
-      const selected = shot.id === this.selectedShotId;
+      const active = isShotActive(shot, currentTime);
+      const selected = this.shotKey(shot, index) === this.selectedShotId;
       const radius = selected ? 6 : active ? 5 : 4;
 
       context.beginPath();
@@ -176,7 +218,7 @@ export class ShotVisualizationController {
       context.lineWidth = selected ? 2.5 : 1.25;
       context.strokeStyle = selected ? "#f8fafc" : active ? "#e11d48" : "rgba(4, 12, 20, 0.85)";
       context.stroke();
-    }
+    });
   }
 
   private renderSelectedShot(shot: ShotEvent | null): void {
@@ -340,7 +382,7 @@ export class ShotVisualizationController {
       }
     }
     if (nearest && nearestDistance <= 18) {
-      this.selectedShotId = nearest.id ?? null;
+      this.selectedShotId = this.shotKey(nearest, shots.indexOf(nearest));
       this.options.cueTimelineEvent(nearest);
       this.render();
     }
@@ -353,10 +395,40 @@ export class ShotVisualizationController {
     }
     return element as T;
   }
+
+  private findSelectedShot(
+    shots: readonly ShotEvent[],
+  ): { shot: ShotEvent; index: number; key: string } | null {
+    if (!this.selectedShotId) {
+      return null;
+    }
+    for (let index = 0; index < shots.length; index += 1) {
+      const shot = shots[index]!;
+      const key = this.shotKey(shot, index);
+      if (key === this.selectedShotId) {
+        return { shot, index, key };
+      }
+    }
+    return null;
+  }
+
+  private shotKey(shot: ShotEvent, index: number): string {
+    return shot.id ?? `${shot.frame ?? "time"}:${shot.time}:${shot.playerId ?? "shot"}:${index}`;
+  }
+
+  private shotsSignature(shots: readonly ShotEvent[]): string {
+    return shots
+      .map((shot, index) => `${this.shotKey(shot, index)}:${shot.time}:${shot.shot.ball_speed}`)
+      .join("|");
+  }
 }
 
 function isShotEvent(event: ReplayTimelineEvent): event is ShotEvent {
   return event.kind === "shot" && Boolean(event.shot);
+}
+
+function isShotActive(shot: ShotEvent, currentTime: number | null): boolean {
+  return currentTime !== null && Math.abs(currentTime - shot.time) < 1.5;
 }
 
 function drawField(context: CanvasRenderingContext2D, width: number, height: number): void {


### PR DESCRIPTION
## Summary

- Reduces playback-time UI work in the stats player by skipping hidden singleton window updates.
- Caches shot visualization data and avoids rebuilding list/details/Three.js content on each playback snapshot.
- Makes generic stats event streams opt-in for the event playlist default selection, preventing huge playlist materialization on replay load.
- Speeds event playlist active-item syncing with a cached sorted index instead of per-sync DOM scans.

## Root Cause

Recent stats UI additions made playback snapshots update expensive hidden or large UI surfaces. The shot chart rebuilt several UI surfaces repeatedly, and the event playlist could default-select generic stats streams that produce very large item sets.

## Validation

- npm run check:style (from js/)
- npm run check:tsc (from js/stat-evaluation-player/)
- ./node_modules/.bin/tsx --tsconfig tsconfig.test.json --test src/eventTimelineSources.test.ts
- npm test (from js/stat-evaluation-player/) passed 189/189 before the final Prettier-only formatting pass
- Browser smoke test with local replay fixture: playback, shot chart, and event playlist opened without app errors
