### PR TITLE
Add postMessage hook to activate a review clip from an embedding page

### DIFF
--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -1010,6 +1010,31 @@ export function mountStatEvaluationPlayer(
   recordingWindowController?.installEventListeners(listeners.signal);
   cameraControlsController?.installEventListeners(listeners.signal);
 
+  // Allow an embedding parent window (e.g. the Rocket Sense stats UI) to drive
+  // the active review clip without reloading the replay, so hovering a goal can
+  // scrub the player to that goal's clip. Messages are only honored from the
+  // same origin to avoid cross-site control of the player.
+  window.addEventListener(
+    "message",
+    (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) {
+        return;
+      }
+      const data = event.data as { source?: unknown; type?: unknown; index?: unknown } | null;
+      if (!data || typeof data !== "object" || data.source !== "rocket-sense") {
+        return;
+      }
+      if (
+        data.type === "activateReviewItem" &&
+        typeof data.index === "number" &&
+        Number.isInteger(data.index)
+      ) {
+        void mechanicsReviewController?.activateItem(data.index);
+      }
+    },
+    { signal: listeners.signal },
+  );
+
   renderModuleSummary();
   renderModuleSettings();
   renderScoreboard();


### PR DESCRIPTION
## Summary

Adds a same-origin `message` listener to the stat-evaluation player so an embedding parent page can scrub the player to a specific review-playlist clip **without reloading the replay**.

The motivating use case (in `rocket-sense`) is a goals list where hovering a goal should preview that goal's clip. Re-pointing the iframe `src` per clip would reload the entire replay/WASM — far too heavy for a hover. Instead the parent posts a small message and the player reuses its existing clip navigator.

## How it works

- Listens for `window` `message` events, scoped to the mount's existing `listeners` `AbortSignal`.
- Honors only same-origin messages of the shape `{ source: "rocket-sense", type: "activateReviewItem", index: number }`.
- Maps that onto the existing `MechanicsReviewWindowController.activateItem(index)`.

Because `activateItem` only loads a replay when the target clip belongs to a *different* replay (`currentReplayId !== item.replay`), scrubbing between clips of the already-loaded replay is instant. Out-of-range indices are a safe no-op (the controller bounds-checks `manifest.items[index]`).

## Notes

- No behavior change for standalone/non-embedded use — the listener simply never fires without a matching message.
- The message `source` discriminator (`"rocket-sense"`) keeps this from colliding with other postMessage traffic; happy to generalize the namespace if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)