### PR TITLE
Fix wall-aerial accumulator import of WALL_AERIAL_HIGH_CONFIDENCE

### DIFF
--- a/src/stats/accumulators/wall_aerial.rs
+++ b/src/stats/accumulators/wall_aerial.rs
@@ -1,5 +1,5 @@
-use super::wall_aerial::WALL_AERIAL_HIGH_CONFIDENCE;
 use super::*;
+use crate::stats::calculators::wall_aerial::WALL_AERIAL_HIGH_CONFIDENCE;
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ts_rs::TS)]
 #[ts(export)]

--- a/src/stats/accumulators/wall_aerial_shot.rs
+++ b/src/stats/accumulators/wall_aerial_shot.rs
@@ -1,5 +1,5 @@
-use super::wall_aerial::WALL_AERIAL_HIGH_CONFIDENCE;
 use super::*;
+use crate::stats::calculators::wall_aerial::WALL_AERIAL_HIGH_CONFIDENCE;
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ts_rs::TS)]
 #[ts(export)]


### PR DESCRIPTION
## Summary

`accumulators::wall_aerial` and `accumulators::wall_aerial_shot` imported `WALL_AERIAL_HIGH_CONFIDENCE` via `use super::wall_aerial::WALL_AERIAL_HIGH_CONFIDENCE;`. After the accumulator suffix-drop refactor, `super::wall_aerial` resolves to the **accumulator** module itself (`accumulators::wall_aerial`), where the constant is only privately in scope — not to its definition in `calculators::wall_aerial`.

Newer `rustc` tolerated this with warnings, but the **fenix-pinned** toolchains used by the Nix WASM build (and by downstream consumers) reject it with `E0603`, so the crate fails to compile to WebAssembly:

```
error[E0603]: constant import `WALL_AERIAL_HIGH_CONFIDENCE` is private
  --> src/stats/accumulators/wall_aerial_shot.rs:1:25
```

## Fix

Import the constant from its canonical location, `crate::stats::calculators::wall_aerial`, in both accumulator modules. Two-line change; `cargo check`/`cargo fmt` clean.

## Verification

- `cargo check --lib` passes on the pinned stable toolchain (previously E0603).
- `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)