### PR TITLE
Classify movement events as other

### DIFF
--- a/docs/event-definitions.md
+++ b/docs/event-definitions.md
@@ -596,7 +596,7 @@ _None documented._
 
 ### Movement (`movement`)
 
-- Category: `movement`
+- Category: `other`
 - Confidence:
   - Approach: `unknown`
   - True positive evidence: `not_evaluated`

--- a/src/stats/calculators/event_definition.rs
+++ b/src/stats/calculators/event_definition.rs
@@ -49,6 +49,7 @@ pub enum EventCategory {
     Contact,
     Movement,
     Annotation,
+    Other,
 }
 
 /// Multi-dimensional confidence metadata for an event detector.
@@ -655,7 +656,7 @@ define_stats_event!(
     MOVEMENT_EVENT_DEFINITION,
     "movement",
     "Movement",
-    EventCategory::Movement
+    EventCategory::Other
 );
 define_stats_event!(
     PositioningActivityEvent,


### PR DESCRIPTION
## Summary
- add an `other` event category to event-definition metadata
- classify the generic continuous `movement` event as `other`
- update the generated event definitions doc entry for `movement`

## Why
The movement stream is a generic accumulator/event bucket rather than a semantic movement mechanic. It should be grouped as `other` in event-definition metadata.

## Validation
- `cargo test event_definition`
- pre-commit: `cargo clippy --all-targets --all-features -- -D warnings`
