### PR TITLE
[codex] Fix kickoff touch and approach classification

### DIFF
--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -594,23 +594,6 @@ impl KickoffCalculator {
         let boost_used = Self::boost_used(player, boost_after);
         let used_boost = player.approach_trace.boost_active_sample_count > 0
             || boost_used >= KICKOFF_APPROACH_MIN_BOOST_USED;
-        if player.first_touch_time.is_none() {
-            let boost_gain = match (player.start_boost, boost_after) {
-                (Some(start_boost), Some(boost_after)) => boost_after - start_boost,
-                _ => 0.0,
-            };
-            if matches!(
-                outcome,
-                KickoffTakerOutcome::Fake | KickoffTakerOutcome::Missed
-            ) && (used_boost
-                || boost_gain > KICKOFF_APPROACH_MIN_BOOST_USED
-                || Self::moved_distance(player) >= KICKOFF_APPROACH_MIN_FAKE_MOVE_DISTANCE)
-            {
-                return KickoffApproach::FakeGoForBoost;
-            }
-            return KickoffApproach::Other;
-        }
-
         let forward_component = player
             .approach_trace
             .first_dodge_forward_component
@@ -626,6 +609,30 @@ impl KickoffCalculator {
             if forward_component >= KICKOFF_APPROACH_FRONT_FLIP_FORWARD_COMPONENT {
                 return KickoffApproach::FrontFlip;
             }
+        }
+
+        if player.first_touch_time.is_none() {
+            let center_progress = Self::center_progress(player);
+            let low_center_progress = center_progress < KICKOFF_SUPPORT_CHEAT_MIN_CENTER_PROGRESS;
+            let moved_away_with_boost = used_boost
+                && low_center_progress
+                && Self::moved_distance(player) >= KICKOFF_APPROACH_MIN_FAKE_MOVE_DISTANCE;
+            if matches!(
+                outcome,
+                KickoffTakerOutcome::Fake | KickoffTakerOutcome::Missed
+            ) && low_center_progress
+                && (Self::boost_gain(player, boost_after)
+                    >= KICKOFF_SUPPORT_GO_FOR_BOOST_MIN_BOOST_GAIN
+                    || Self::lateral_movement(player)
+                        >= KICKOFF_SUPPORT_GO_FOR_BOOST_MIN_LATERAL_MOVE
+                    || moved_away_with_boost)
+            {
+                return KickoffApproach::FakeGoForBoost;
+            }
+            if used_boost && center_progress > 0.0 {
+                return KickoffApproach::BoostIntoBall;
+            }
+            return KickoffApproach::Other;
         }
 
         if used_boost {

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -1205,6 +1205,52 @@ fn kickoff_classifies_known_taker_approaches() {
         KickoffApproach::BoostIntoBall
     );
 
+    let missed_diagonal_flip = KickoffPlayerSnapshot {
+        first_touch_time: None,
+        first_touch_frame: None,
+        approach_trace: KickoffApproachTrace {
+            boost_active_sample_count: 3,
+            first_dodge_time: Some(0.35),
+            first_dodge_frame: Some(4),
+            first_dodge_forward_component: Some(0.55),
+            first_dodge_side_component: Some(0.75),
+            min_boost: Some(20.0),
+            last_position: Some([-800.0, -1000.0, 17.0]),
+            ..KickoffApproachTrace::default()
+        },
+        ..speed_flip.clone()
+    };
+    assert_eq!(
+        KickoffCalculator::classify_approach(
+            &missed_diagonal_flip,
+            KickoffTakerOutcome::Missed,
+            Some(20.0),
+            false,
+        ),
+        KickoffApproach::DiagonalFlip
+    );
+
+    let missed_boost_into_ball = KickoffPlayerSnapshot {
+        first_touch_time: None,
+        first_touch_frame: None,
+        approach_trace: KickoffApproachTrace {
+            boost_active_sample_count: 4,
+            min_boost: Some(20.0),
+            last_position: Some([-800.0, -1000.0, 17.0]),
+            ..KickoffApproachTrace::default()
+        },
+        ..speed_flip.clone()
+    };
+    assert_eq!(
+        KickoffCalculator::classify_approach(
+            &missed_boost_into_ball,
+            KickoffTakerOutcome::Missed,
+            Some(116.0),
+            false,
+        ),
+        KickoffApproach::BoostIntoBall
+    );
+
     let fake_go_for_boost = KickoffPlayerSnapshot {
         first_touch_time: None,
         first_touch_frame: None,

--- a/src/stats/calculators/touch_state.rs
+++ b/src/stats/calculators/touch_state.rs
@@ -466,7 +466,7 @@ impl TouchStateCalculator {
         events: &FrameEventsState,
         live_play_state: &LivePlayState,
     ) -> TouchState {
-        let touch_events = if live_play_state.is_live_play {
+        let touch_events = if live_play_state.counts_toward_player_motion() {
             self.prune_recent_touch_candidates(frame.frame_number);
             self.update_recent_touch_candidates(frame, ball, players);
             let touch_events = self.confirmed_touch_events(frame, ball, players, events);

--- a/src/stats/calculators/touch_state_tests.rs
+++ b/src/stats/calculators/touch_state_tests.rs
@@ -135,6 +135,37 @@ fn suppresses_same_player_touch_candidates_inside_cooldown() {
 }
 
 #[test]
+fn detects_touch_while_kickoff_waits_for_first_touch() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let players = players(player_id.clone());
+    let mut calculator = TouchStateCalculator::new();
+    let kickoff_waiting = LivePlayState {
+        gameplay_phase: GameplayPhase::KickoffWaitingForTouch,
+        is_live_play: false,
+    };
+
+    calculator.update(
+        &frame(0),
+        &ball(glam::Vec3::ZERO),
+        &players,
+        &FrameEventsState::default(),
+        &kickoff_waiting,
+    );
+    let touch_state = calculator.update(
+        &frame(1),
+        &ball(glam::Vec3::new(300.0, 0.0, 0.0)),
+        &players,
+        &FrameEventsState::default(),
+        &kickoff_waiting,
+    );
+
+    assert_eq!(touch_state.touch_events.len(), 1);
+    assert_eq!(touch_state.touch_events[0].player, Some(player_id.clone()));
+    assert_eq!(touch_state.touch_events[0].frame, 1);
+    assert_eq!(touch_state.last_touch_player, Some(player_id));
+}
+
+#[test]
 fn team_only_explicit_touch_events_without_physics_candidate_are_ignored() {
     let player_id = boxcars::RemoteId::Steam(1);
     let players = players(player_id.clone());


### PR DESCRIPTION
## Summary

Fix kickoff event classification in two places:

- allow touch detection while gameplay is in `KickoffWaitingForTouch`, so the first kickoff touch is not dropped before the kickoff calculator sees it
- classify no-touch taker approaches by observed approach signals first, so missed/front/diagonal/boost approaches do not get mislabeled as `fake_go_for_boost`

## Root Cause

`TouchStateCalculator` only emitted touch events when `LivePlayState::is_live_play` was true. Kickoff waiting-for-touch is intentionally not active play, but it does count toward player motion, so first kickoff touches could be suppressed.

Separately, `KickoffCalculator::classify_approach` returned `FakeGoForBoost` for many no-touch takers before checking dodge or forward boost approach evidence. That made legitimate missed kickoff attempts look like intentional fake boost grabs.

## Validation

- `cargo fmt --manifest-path vendor/subtr-actor/Cargo.toml`
- `cargo test --manifest-path vendor/subtr-actor/Cargo.toml stats::calculators::kickoff`
- `cargo test --manifest-path vendor/subtr-actor/Cargo.toml stats::calculators::touch_state`
- Reprocessed replay `019ea631-135a-72e0-9969-e06e654b90af` locally and confirmed the two suspect colonelpanic8 taker rows no longer report `fake_go_for_boost`.
