### PR TITLE
Fix kickoff taker selection when the challenger isn't credited a touch

### DIFF
--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -540,11 +540,35 @@ impl KickoffCalculator {
                     })
             })
             .or_else(|| {
+                // No tied candidate touched the ball (the team was beaten to the
+                // kickoff). Distance and first-touch can't disambiguate, so prefer
+                // the player who actually committed to the ball: greatest advance
+                // toward center, then most boost burned. The static left-side
+                // tiebreak is only a last resort for genuinely identical approaches.
                 tied_candidates.min_by(|(_, left), (_, right)| {
-                    Self::relative_left_value(left).total_cmp(&Self::relative_left_value(right))
+                    Self::center_progress(right)
+                        .total_cmp(&Self::center_progress(left))
+                        .then_with(|| {
+                            Self::boost_committed(right).total_cmp(&Self::boost_committed(left))
+                        })
+                        .then_with(|| {
+                            Self::relative_left_value(left)
+                                .total_cmp(&Self::relative_left_value(right))
+                        })
                 })
             })
             .map(|(index, _)| index)
+    }
+
+    /// Boost spent during the kickoff approach (`start_boost - min_boost`). A
+    /// player charging the ball burns boost; a teammate peeling off for a pad
+    /// does not, so this separates the true taker from support when neither
+    /// player touched the ball.
+    fn boost_committed(player: &KickoffPlayerSnapshot) -> f32 {
+        match (player.start_boost, player.approach_trace.min_boost) {
+            (Some(start_boost), Some(min_boost)) => (start_boost - min_boost).max(0.0),
+            _ => 0.0,
+        }
     }
 
     fn taker_outcome(

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -1531,6 +1531,60 @@ fn kickoff_tie_breaks_expected_taker_by_actual_touch_then_left_goes() {
 }
 
 #[test]
+fn kickoff_taker_prefers_ball_committer_when_no_touch() {
+    // Regression for a real 2v2 kickoff (a contested 50/50). The orange
+    // challenger drove in and contacted the ball, but the replay only emitted
+    // the opposing team's BallHitTeamNum marker, so subtr-actor recorded no
+    // touch for either orange player. Both orange players spawn on mirrored
+    // diagonals at equal distance from the ball, so the distance tie and the
+    // first-touch tiebreak can't disambiguate. The legacy fallback then picked
+    // the geometrically leftmost player (index 0) -- a back/cheat player that
+    // stayed ~3400uu from the ball -- instead of the challenger who drove from
+    // spawn into the ball and burned all boost (index 1). Selection must follow
+    // the commitment signal (advance toward the ball, then boost burned), not
+    // the static left-side tiebreak.
+    let kept_boost_player = PlayerId::Epic("kept-boost".to_owned());
+    let ball_committer = PlayerId::Epic("ball-committer".to_owned());
+
+    let players = [
+        KickoffPlayerSnapshot {
+            player: kept_boost_player,
+            is_team_0: false,
+            start_position: [2048.0, 2560.0, 17.0],
+            spawn_position: KickoffSpawnPosition::DiagonalLeft,
+            start_boost: Some(85.0),
+            first_touch_time: None,
+            first_touch_frame: None,
+            approach_trace: KickoffApproachTrace {
+                min_boost: Some(85.0),
+                last_position: Some([1900.0, 2400.0, 17.0]),
+                ..KickoffApproachTrace::default()
+            },
+        },
+        KickoffPlayerSnapshot {
+            player: ball_committer,
+            is_team_0: false,
+            start_position: [-2048.0, 2560.0, 17.0],
+            spawn_position: KickoffSpawnPosition::DiagonalRight,
+            start_boost: Some(85.0),
+            first_touch_time: None,
+            first_touch_frame: None,
+            approach_trace: KickoffApproachTrace {
+                min_boost: Some(0.0),
+                last_position: Some([-300.0, 700.0, 17.0]),
+                ..KickoffApproachTrace::default()
+            },
+        },
+    ];
+
+    // Legacy `relative_left_value` tiebreak would have returned Some(0).
+    assert_eq!(
+        KickoffCalculator::expected_taker_by_team(&players, false),
+        Some(1)
+    );
+}
+
+#[test]
 fn kickoff_stats_accumulate_boost_strength_fake_and_miss_counts() {
     let player_id = PlayerId::Steam(1);
     let event = KickoffEvent {


### PR DESCRIPTION
## Problem (verified against a real replay)

A 2v2 kickoff that is a **contested 50/50**: the orange challenger drives in and contacts the ball, but the replay emitted **only the blue team's `BallHitTeamNum` marker**, so subtr-actor recorded **no touch for either orange player**.

Ground truth at the contact frame (reconstructed from car/ball positions):

```
f=2905 t=169.818  ball=(3,-16,102) | trple t lovr(O)=164  Black-Biscuit89(B)=164  colonelpanic8(O)=3481
```

`trple t lovr` (orange) is dead-even with blue on the ball (164uu each). `colonelpanic8` (the other orange player) is **3481uu away** and never challenges.

With no *recorded* orange touch, `expected_taker_by_team` can't use its first-touch tiebreak, and the two orange players spawn on mirrored diagonals at ~equal distance (≈3278uu), so they also tie on distance. The fallback then used `relative_left_value` — the geometrically **leftmost** player — and selected `colonelpanic8` (the back/cheat player) as the taker. Because his spawn (diagonal-left) no longer matches the opponent taker's (diagonal-right), `kickoff_type`/`kickoff_direction` collapse to `unknown`.

## Fix

In the no-recorded-touch fallback, prefer the player who **committed to the ball**:

1. greatest `center_progress` (advance toward center) — `trple` ≈ 3278→164 ≈ **3114**, `colonelpanic8` ≈ **0** (stayed back);
2. then most boost burned (`start_boost − min_boost`, new `boost_committed` helper);
3. then the existing `relative_left_value` tiebreak as a last resort.

Symmetric/identical inputs still resolve via the left-side tiebreak, so prior behavior is preserved (the existing `*_left_goes` assertion is unchanged).

## Deeper root cause (not addressed here)

The more fundamental issue is that the challenger's **contested touch is never recorded**: the contested-touch path in `touch_state.rs` only fires when ball-trajectory deviation is detected at that frame; otherwise it falls back to the single replay team marker (blue only), dropping the orange side of the 50/50. Recording that touch would fix the taker via the normal first-touch path *and* correct possession/outcome. This PR is the defensive selection fix; the touch-attribution fix can follow separately.

## Tests

- `kickoff_taker_prefers_ball_committer_when_no_touch` reproduces this exact scenario (mirrored diagonals, no recorded touch, one player drives in and burns boost while the other stays back) and asserts the committer is chosen where the legacy tiebreak returned the leftmost.
- Full kickoff suite passes (`cargo test --lib kickoff`, 40 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)