### PR TITLE
Credit the losing challenger on contested 50/50 touches

### DIFF
--- a/crates/subtr-actor-tools/src/bin/kickoff_touch_audit.rs
+++ b/crates/subtr-actor-tools/src/bin/kickoff_touch_audit.rs
@@ -1,0 +1,331 @@
+//! Audit kickoffs for the "contested 50/50 but only one player credited a touch" bug.
+//!
+//! For each kickoff we measure, frame by frame, how close each team's closest car
+//! gets to the ball (contact gap). If both teams physically reach the ball
+//! (small contact gap) around the kickoff contact, but the attribution pipeline
+//! only credits a touch to one team, we flag the kickoff as suspicious.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::{Path, PathBuf};
+use subtr_actor::{
+    ball_trajectory_deviation_with_gravity, touch_candidate_contact_gap_rank_with_hitbox,
+    vec_to_glam, Collector, EventPayload, PlayerId, ProcessorView, StatsTimelineCollector,
+    TimeAdvance,
+};
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[arg(required = true)]
+    replay_paths: Vec<PathBuf>,
+    /// Contact-gap threshold (uu) below which a team is considered to have physically reached the ball.
+    #[arg(long, default_value_t = 40.0)]
+    contact_gap_threshold: f32,
+    /// Frames before/after the kickoff contact frame to inspect.
+    #[arg(long, default_value_t = 6)]
+    window_frames: usize,
+    /// Print a line for every kickoff, not just suspicious ones.
+    #[arg(long, default_value_t = false)]
+    verbose: bool,
+    /// Dump per-frame both-team gap/deviation/marker detail around this frame (first replay only).
+    #[arg(long)]
+    detail_around: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+struct FrameGap {
+    frame: usize,
+    time: f32,
+    ball_speed: f32,
+    ball_pos_deviation: Option<f32>,
+    ball_vel_deviation: Option<f32>,
+    marker_teams: Vec<bool>,
+    team0: Option<(f32, PlayerId, Option<String>)>,
+    team1: Option<(f32, PlayerId, Option<String>)>,
+}
+
+#[derive(Debug, Default)]
+struct GapCollector {
+    frames: Vec<FrameGap>,
+    previous_ball: Option<(boxcars::RigidBody, f32)>,
+    previous_time: Option<f32>,
+}
+
+impl GapCollector {
+    fn best_team_gap(
+        processor: &dyn ProcessorView,
+        ball_body: &boxcars::RigidBody,
+        team_is_team_0: bool,
+        current_time: f32,
+    ) -> Option<(f32, PlayerId, Option<String>)> {
+        processor
+            .iter_player_ids_in_order()
+            .filter(|player_id| {
+                processor.get_player_is_team_0(player_id).ok() == Some(team_is_team_0)
+            })
+            .filter_map(|player_id| {
+                let player_body = processor
+                    .get_velocity_applied_player_rigid_body(player_id, current_time)
+                    .ok()?;
+                let (closest_gap, _current_gap) = touch_candidate_contact_gap_rank_with_hitbox(
+                    ball_body,
+                    &player_body,
+                    processor.get_player_car_hitbox(player_id),
+                )?;
+                Some((
+                    closest_gap,
+                    player_id.clone(),
+                    processor.get_player_name(player_id).ok(),
+                ))
+            })
+            .min_by(|left, right| left.0.total_cmp(&right.0))
+    }
+}
+
+impl Collector for GapCollector {
+    fn process_frame(
+        &mut self,
+        processor: &dyn ProcessorView,
+        _frame: &boxcars::Frame,
+        frame_number: usize,
+        current_time: f32,
+    ) -> subtr_actor::SubtrActorResult<TimeAdvance> {
+        if let Some(ball_body) = processor
+            .get_velocity_applied_ball_rigid_body(current_time)
+            .ok()
+        {
+            let ball_speed = ball_body
+                .linear_velocity
+                .map(|v| vec_to_glam(&v).length())
+                .unwrap_or(0.0);
+            let deviation = self
+                .previous_ball
+                .as_ref()
+                .zip(self.previous_time)
+                .and_then(|((prev, _), prev_time)| {
+                    ball_trajectory_deviation_with_gravity(
+                        prev,
+                        prev_time,
+                        &ball_body,
+                        current_time,
+                        -650.0,
+                    )
+                });
+            let marker_teams = processor
+                .current_frame_touch_events()
+                .iter()
+                .map(|event| event.team_is_team_0)
+                .collect();
+            self.frames.push(FrameGap {
+                frame: frame_number,
+                time: current_time,
+                ball_speed,
+                ball_pos_deviation: deviation.map(|d| d.position_deviation),
+                ball_vel_deviation: deviation.map(|d| d.velocity_deviation),
+                marker_teams,
+                team0: Self::best_team_gap(processor, &ball_body, true, current_time),
+                team1: Self::best_team_gap(processor, &ball_body, false, current_time),
+            });
+            self.previous_ball = Some((ball_body, current_time));
+            self.previous_time = Some(current_time);
+        }
+        Ok(TimeAdvance::NextFrame)
+    }
+}
+
+fn parse_replay(path: &Path) -> Result<boxcars::Replay> {
+    let data = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    boxcars::ParserBuilder::new(&data)
+        .must_parse_network_data()
+        .on_error_check_crc()
+        .parse()
+        .with_context(|| format!("parsing {}", path.display()))
+}
+
+struct KickoffInfo {
+    start_time: f32,
+    first_touch_frame: Option<usize>,
+    first_touch_time: Option<f32>,
+    kickoff_type: String,
+    kickoff_direction: String,
+    team0_taker_touch_time: Option<f32>,
+    team1_taker_touch_time: Option<f32>,
+    team0_taker: Option<(String, bool)>, // (player name-ish, has_first_touch)
+    team1_taker: Option<(String, bool)>,
+}
+
+fn audit(label: &str, args: &Args, replay: &boxcars::Replay) -> Result<()> {
+    // Pass 1: geometric gaps per frame.
+    let gaps = GapCollector::default()
+        .process_replay(replay)
+        .map_err(|e| anyhow::anyhow!("gap pass {label}: {e:?}"))?
+        .frames;
+
+    // Pass 2: high-level timeline kickoff events + touch events.
+    let timeline = StatsTimelineCollector::new()
+        .get_legacy_replay_stats_timeline(replay)
+        .map_err(|e| anyhow::anyhow!("timeline {label}: {e:?}"))?;
+
+    // Collect touch events (frame, team).
+    let touches: Vec<(usize, f32, Option<bool>)> = timeline
+        .events
+        .events
+        .iter()
+        .filter(|event| matches!(event.payload, EventPayload::Touch(_)))
+        .map(|event| {
+            let (frame, time) = event.meta.timing.start();
+            (frame, time, event.meta.team_is_team_0)
+        })
+        .collect();
+
+    let kickoffs: Vec<KickoffInfo> = timeline
+        .events
+        .events
+        .iter()
+        .filter_map(|event| match &event.payload {
+            EventPayload::Kickoff(kickoff) => Some(KickoffInfo {
+                start_time: kickoff.start_time,
+                first_touch_frame: kickoff.first_touch_frame,
+                first_touch_time: kickoff.first_touch_time,
+                kickoff_type: format!("{:?}", kickoff.kickoff_type),
+                kickoff_direction: format!("{:?}", kickoff.kickoff_direction),
+                team0_taker_touch_time: kickoff.team_zero_taker_touch_time,
+                team1_taker_touch_time: kickoff.team_one_taker_touch_time,
+                team0_taker: kickoff
+                    .team_zero_taker
+                    .as_ref()
+                    .map(|t| (format!("{:?}", t.player), t.first_touch_time.is_some())),
+                team1_taker: kickoff
+                    .team_one_taker
+                    .as_ref()
+                    .map(|t| (format!("{:?}", t.player), t.first_touch_time.is_some())),
+            }),
+            _ => None,
+        })
+        .collect();
+
+    if let Some(center) = args.detail_around {
+        let lo = center.saturating_sub(12);
+        let hi = center + 12;
+        println!("== detail around frame {center} ({label}) ==");
+        println!(
+            "frame time | t0_gap t0_who | t1_gap t1_who | ball_speed pos_dev vel_dev | markers"
+        );
+        for f in gaps.iter().filter(|f| f.frame >= lo && f.frame <= hi) {
+            let fmt = |t: &Option<(f32, PlayerId, Option<String>)>| match t {
+                Some((g, _, name)) => {
+                    format!("{:>6.1} {:<14}", g, name.clone().unwrap_or_default())
+                }
+                None => format!("{:>6} {:<14}", "-", ""),
+            };
+            println!(
+                "{:>6} {:>6.2} | {} | {} | {:>7.0} {:>6.0} {:>7.0} | {:?}",
+                f.frame,
+                f.time,
+                fmt(&f.team0),
+                fmt(&f.team1),
+                f.ball_speed,
+                f.ball_pos_deviation.unwrap_or(0.0),
+                f.ball_vel_deviation.unwrap_or(0.0),
+                f.marker_teams,
+            );
+        }
+        println!();
+    }
+
+    let mut flagged = 0usize;
+    for (i, k) in kickoffs.iter().enumerate() {
+        let Some(ft_frame) = k.first_touch_frame else {
+            continue;
+        };
+        // Window of frames around the contact.
+        let lo = ft_frame.saturating_sub(args.window_frames);
+        let hi = ft_frame + args.window_frames;
+        let mut team0_min = f32::INFINITY;
+        let mut team1_min = f32::INFINITY;
+        let mut team0_who = None;
+        let mut team1_who = None;
+        for f in gaps.iter().filter(|f| f.frame >= lo && f.frame <= hi) {
+            if let Some((g, _, name)) = &f.team0 {
+                if *g < team0_min {
+                    team0_min = *g;
+                    team0_who = name.clone();
+                }
+            }
+            if let Some((g, _, name)) = &f.team1 {
+                if *g < team1_min {
+                    team1_min = *g;
+                    team1_who = name.clone();
+                }
+            }
+        }
+
+        let both_reached =
+            team0_min <= args.contact_gap_threshold && team1_min <= args.contact_gap_threshold;
+
+        // Which teams got credited a touch in the contest window?
+        let ft_time = k.first_touch_time.unwrap_or(k.start_time);
+        let window_end = ft_time + 0.8;
+        let mut t0_touch = false;
+        let mut t1_touch = false;
+        for (tf, tt, team) in &touches {
+            if *tt >= k.start_time - 0.1 && *tt <= window_end && tf.abs_diff(ft_frame) <= 60 {
+                match team {
+                    Some(true) => t0_touch = true,
+                    Some(false) => t1_touch = true,
+                    None => {}
+                }
+            }
+        }
+        let credited_teams = t0_touch as u8 + t1_touch as u8;
+
+        let suspicious = both_reached && credited_teams < 2;
+
+        if suspicious {
+            flagged += 1;
+        }
+        if suspicious || args.verbose {
+            let tag = if suspicious { "** SUSPICIOUS **" } else { "" };
+            println!(
+                "  kickoff#{i} t={:.1} type={}/{} ft_frame={ft_frame} | gap_min team0={:.0}({:?}) team1={:.0}({:?}) both_reached={both_reached} | touch_credited team0={t0_touch} team1={t1_touch} | taker_touch_time t0={:?} t1={:?} | taker_has_touch t0={:?} t1={:?} {tag}",
+                k.start_time,
+                k.kickoff_type,
+                k.kickoff_direction,
+                team0_min,
+                team0_who,
+                team1_min,
+                team1_who,
+                k.team0_taker_touch_time,
+                k.team1_taker_touch_time,
+                k.team0_taker.as_ref().map(|t| t.1),
+                k.team1_taker.as_ref().map(|t| t.1),
+            );
+        }
+    }
+
+    println!(
+        "== {label}: {} kickoffs, {flagged} suspicious ==",
+        kickoffs.len()
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    for path in &args.replay_paths {
+        let label = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("<replay>")
+            .to_owned();
+        match parse_replay(path) {
+            Ok(replay) => {
+                if let Err(e) = audit(&label, &args, &replay) {
+                    eprintln!("error {label}: {e:?}");
+                }
+            }
+            Err(e) => eprintln!("parse error {label}: {e:?}"),
+        }
+    }
+    Ok(())
+}

--- a/src/stats/calculators/touch_state.rs
+++ b/src/stats/calculators/touch_state.rs
@@ -25,6 +25,29 @@ const TOUCH_CANDIDATE_WINDOW_FRAMES: usize = 4;
 const CONTESTED_TOUCH_WINDOW_FRAMES: usize = 1;
 const BALL_GRAVITY_Z: f32 = -650.0;
 
+/// Maximum contact gap (uu) at which a replay-reported team touch marker may be
+/// attributed to that team's closest player using current-frame geometry alone.
+///
+/// A `BallHitTeamNum` marker is authoritative that the team touched the ball, but
+/// on a contested 50/50 the losing challenger frequently contacts the ball a frame
+/// before any detectable trajectory deviation, so it never enters the candidate
+/// cache and the marker would otherwise be dropped. When the cache cannot resolve
+/// the marker, the closest same-team car sitting on the ball is the touch. Kept
+/// within the system's relaxed contact boundary so every emitted touch still
+/// reflects a genuine hitbox contact.
+const MARKER_CONTACT_ATTRIBUTION_MAX_GAP: f32 = TOUCH_SCORING.relaxed_contact_gap_threshold;
+
+/// Maximum contact gap (uu) for a car to be credited a *geometric contested touch*:
+/// a car that is physically on the ball but is never accepted as a deviation
+/// candidate because its tight contact lands a frame off the ball's measurable
+/// trajectory deviation (the other car in the 50/50 already redirected the ball).
+const GEOMETRIC_CONTEST_MAX_GAP: f32 = 5.0;
+
+/// How recently (frames / seconds) an opposing-team touch must have been confirmed
+/// for a car now sitting on the ball to be credited a geometric contested touch.
+const GEOMETRIC_CONTEST_WINDOW_FRAMES: usize = 4;
+const GEOMETRIC_CONTEST_WINDOW_SECONDS: f32 = 0.2;
+
 fn accepted_contact_gap(closest_contact_gap: f32, ball_deviation: BallTrajectoryDeviation) -> bool {
     TOUCH_SCORING.accepts_contact_gap(
         closest_contact_gap,
@@ -91,12 +114,20 @@ fn primary_touch_event(touch_events: &[TouchEvent]) -> Option<&TouchEvent> {
         .min_by(|left, right| touch_event_ordering(left, right))
 }
 
+#[derive(Debug, Clone)]
+struct RecentTeamTouch {
+    frame: usize,
+    time: f32,
+    team_is_team_0: bool,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TouchStateCalculator {
     previous_ball_rigid_body: Option<(boxcars::RigidBody, f32)>,
     current_last_touch: Option<TouchEvent>,
     recent_touch_candidates: HashMap<PlayerId, TouchEvent>,
     last_touch_times: HashMap<TouchCooldownKey, f32>,
+    recent_team_touches: Vec<RecentTeamTouch>,
 }
 
 impl TouchStateCalculator {
@@ -232,8 +263,87 @@ impl TouchStateCalculator {
             .cloned()
     }
 
-    fn enrich_team_touch_event_from_recent_cache(&self, event: &TouchEvent) -> Option<TouchEvent> {
-        let candidate = self.best_candidate_for_team(event.team_is_team_0)?;
+    /// Finds the closest same-team car to the ball at the current frame, used to
+    /// attribute a replay touch marker that the candidate cache cannot resolve.
+    fn current_frame_touch_candidate_for_team(
+        &self,
+        event: &TouchEvent,
+        ball: &BallFrameState,
+        players: &PlayerFrameState,
+    ) -> Option<TouchEvent> {
+        let ball = ball.sample()?;
+
+        players
+            .players
+            .iter()
+            .filter(|player| player.is_team_0 == event.team_is_team_0)
+            .filter_map(|player| {
+                let rigid_body = player.rigid_body.as_ref()?;
+                let (closest_contact_gap, _current_contact_gap) =
+                    touch_candidate_contact_gap_rank_with_hitbox(
+                        &ball.rigid_body,
+                        rigid_body,
+                        player.hitbox,
+                    )?;
+                Some((closest_contact_gap, player, rigid_body))
+            })
+            .min_by(|left, right| left.0.total_cmp(&right.0))
+            .filter(|(closest_contact_gap, _, _)| {
+                *closest_contact_gap <= MARKER_CONTACT_ATTRIBUTION_MAX_GAP
+            })
+            .map(|(closest_contact_gap, player, rigid_body)| TouchEvent {
+                time: event.time,
+                frame: event.frame,
+                team_is_team_0: event.team_is_team_0,
+                player: Some(player.player_id.clone()),
+                player_position: Some(rigid_body.location),
+                closest_approach_distance: Some(closest_contact_gap),
+                dodge_contact: player.dodge_active,
+            })
+    }
+
+    /// Attributes a team-only replay touch marker to a concrete player.
+    ///
+    /// Prefers whichever of the recent candidate cache or the current frame's
+    /// geometry puts a car closest to the ball. The cache covers the normal case
+    /// where a trajectory deviation already identified the toucher; the
+    /// current-frame fallback recovers contested 50/50 touches where the
+    /// challenger contacted the ball before any deviation was detectable (so it
+    /// never cached) yet is still sitting on the ball at the marker frame.
+    fn enrich_team_touch_event_from_recent_cache(
+        &self,
+        event: &TouchEvent,
+        ball: &BallFrameState,
+        players: &PlayerFrameState,
+    ) -> Option<TouchEvent> {
+        let gap_of =
+            |candidate: &TouchEvent| candidate.closest_approach_distance.unwrap_or(f32::INFINITY);
+
+        // Current-frame geometry is only trustworthy during continuous live play,
+        // where a previous ball frame establishes a real trajectory. Without that
+        // baseline (e.g. the very first frame after a reset) a car merely parked on
+        // a stationary ball must not be credited from a bare team marker.
+        let current_frame_candidate = if self.previous_ball_rigid_body.is_some() {
+            self.current_frame_touch_candidate_for_team(event, ball, players)
+        } else {
+            None
+        };
+
+        let candidate = match (
+            self.best_candidate_for_team(event.team_is_team_0),
+            current_frame_candidate,
+        ) {
+            (Some(cache_candidate), Some(current_candidate)) => {
+                if gap_of(&current_candidate) < gap_of(&cache_candidate) {
+                    current_candidate
+                } else {
+                    cache_candidate
+                }
+            }
+            (Some(cache_candidate), None) => cache_candidate,
+            (None, Some(current_candidate)) => current_candidate,
+            (None, None) => return None,
+        };
 
         Some(TouchEvent {
             time: event.time,
@@ -316,7 +426,7 @@ impl TouchStateCalculator {
         if event.player.is_some() {
             Some(self.enrich_explicit_touch_event_from_current_frame(event, ball, players))
         } else if allow_team_only_cache_attribution {
-            self.enrich_team_touch_event_from_recent_cache(event)
+            self.enrich_team_touch_event_from_recent_cache(event, ball, players)
         } else {
             None
         }
@@ -346,6 +456,62 @@ impl TouchStateCalculator {
         opposing_candidates.sort_by(touch_event_ordering);
 
         opposing_candidates
+    }
+
+    /// Credits cars that are physically on the ball but were never accepted as a
+    /// deviation candidate, when an opposing-team touch was confirmed in the recent
+    /// window. This recovers the losing side of a contested 50/50: the challenger
+    /// reaches the ball a frame off the measurable trajectory deviation (which the
+    /// winning car already produced), so it never caches and is otherwise dropped.
+    fn geometric_contested_touches(
+        &self,
+        frame: &FrameInfo,
+        ball: &BallFrameState,
+        players: &PlayerFrameState,
+        confirmed_players: &HashSet<PlayerId>,
+    ) -> Vec<TouchEvent> {
+        if self.previous_ball_rigid_body.is_none() {
+            return Vec::new();
+        }
+        let Some(ball) = ball.sample() else {
+            return Vec::new();
+        };
+
+        players
+            .players
+            .iter()
+            .filter(|player| !confirmed_players.contains(&player.player_id))
+            .filter(|player| self.has_recent_opposing_team_touch(frame, player.is_team_0))
+            .filter_map(|player| {
+                let rigid_body = player.rigid_body.as_ref()?;
+                let (closest_contact_gap, _current_contact_gap) =
+                    touch_candidate_contact_gap_rank_with_hitbox(
+                        &ball.rigid_body,
+                        rigid_body,
+                        player.hitbox,
+                    )?;
+                if closest_contact_gap > GEOMETRIC_CONTEST_MAX_GAP {
+                    return None;
+                }
+                Some(TouchEvent {
+                    time: frame.time,
+                    frame: frame.frame_number,
+                    team_is_team_0: player.is_team_0,
+                    player: Some(player.player_id.clone()),
+                    player_position: Some(rigid_body.location),
+                    closest_approach_distance: Some(closest_contact_gap),
+                    dodge_contact: player.dodge_active,
+                })
+            })
+            .collect()
+    }
+
+    fn has_recent_opposing_team_touch(&self, frame: &FrameInfo, team_is_team_0: bool) -> bool {
+        self.recent_team_touches.iter().any(|touch| {
+            touch.team_is_team_0 != team_is_team_0
+                && frame.frame_number.saturating_sub(touch.frame) <= GEOMETRIC_CONTEST_WINDOW_FRAMES
+                && frame.time - touch.time <= GEOMETRIC_CONTEST_WINDOW_SECONDS
+        })
     }
 
     fn confirmed_touch_events(
@@ -424,7 +590,29 @@ impl TouchStateCalculator {
             ));
         }
 
+        for contested in self.geometric_contested_touches(frame, ball, players, &confirmed_players)
+        {
+            if let Some(player_id) = contested.player.clone() {
+                if !confirmed_players.insert(player_id) {
+                    continue;
+                }
+            }
+            touch_events.push(contested);
+        }
+
         touch_events
+    }
+
+    fn record_recent_team_touches(&mut self, frame: usize, touch_events: &[TouchEvent]) {
+        self.recent_team_touches
+            .retain(|touch| frame.saturating_sub(touch.frame) <= GEOMETRIC_CONTEST_WINDOW_FRAMES);
+        for event in touch_events {
+            self.recent_team_touches.push(RecentTeamTouch {
+                frame: event.frame,
+                time: event.time,
+                team_is_team_0: event.team_is_team_0,
+            });
+        }
     }
 
     fn touch_cooldown_key(event: &TouchEvent) -> TouchCooldownKey {
@@ -470,11 +658,14 @@ impl TouchStateCalculator {
             self.prune_recent_touch_candidates(frame.frame_number);
             self.update_recent_touch_candidates(frame, ball, players);
             let touch_events = self.confirmed_touch_events(frame, ball, players, events);
-            self.apply_touch_cooldown(touch_events)
+            let touch_events = self.apply_touch_cooldown(touch_events);
+            self.record_recent_team_touches(frame.frame_number, &touch_events);
+            touch_events
         } else {
             self.current_last_touch = None;
             self.recent_touch_candidates.clear();
             self.last_touch_times.clear();
+            self.recent_team_touches.clear();
             Vec::new()
         };
 

--- a/tests/contested_kickoff_touch_test.rs
+++ b/tests/contested_kickoff_touch_test.rs
@@ -1,0 +1,124 @@
+//! Regression test for contested 50/50 kickoff touch attribution.
+//!
+//! On a contested kickoff both cars reach the ball at essentially the same
+//! instant, but the losing challenger's contact lands a frame off the ball's
+//! measurable trajectory deviation (the winning car already redirected it), and
+//! the replay frequently reports only the winning team's `BallHitTeamNum` marker.
+//! Previously the challenger was credited no touch at all: `expected_taker_by_team`
+//! had no first-touch tiebreak, the taker fell back to an unrelated geometric
+//! heuristic, and `kickoff_type`/`kickoff_direction` collapsed to `unknown`.
+//!
+//! `assets/post-eac-ranked-doubles-2026-04-28.replay` contains two such kickoffs
+//! (verified frame-by-frame): `Ragnar` reaches the ball a frame before the
+//! deviation while only blue's marker fires, and `2Fum2Tastic` reaches it a frame
+//! after the deviation with no orange marker at all. Both challengers must now be
+//! credited a touch, which resolves the kickoff type for both teams.
+
+mod common;
+
+use subtr_actor::{EventPayload, KickoffEvent, KickoffType, PlayerId, StatsTimelineCollector};
+
+const DOUBLES_REPLAY: &str = "assets/post-eac-ranked-doubles-2026-04-28.replay";
+
+struct ContestedKickoffCase {
+    /// Inclusive window (seconds) used to locate the kickoff regardless of small
+    /// timing shifts.
+    start_time_range: (f32, f32),
+    /// The losing challenger who previously lost their touch on this 50/50.
+    challenger_name: &'static str,
+}
+
+const CONTESTED_KICKOFFS: [ContestedKickoffCase; 2] = [
+    ContestedKickoffCase {
+        start_time_range: (84.0, 87.0),
+        challenger_name: "Ragnar",
+    },
+    ContestedKickoffCase {
+        start_time_range: (153.0, 156.0),
+        challenger_name: "2Fum2Tastic",
+    },
+];
+
+#[test]
+#[ignore = "replay-backed kickoff touch parity is slow; run explicitly when changing touch attribution"]
+fn contested_kickoff_credits_both_fifty_fifty_challengers() {
+    let replay = common::parse_replay(DOUBLES_REPLAY);
+    let timeline = StatsTimelineCollector::new()
+        .get_legacy_replay_stats_timeline(&replay)
+        .expect("expected a stats timeline for the doubles replay");
+
+    let name_of = |player_id: &PlayerId| -> Option<String> {
+        timeline
+            .replay_meta
+            .player_order()
+            .find(|player| &player.remote_id == player_id)
+            .map(|player| player.name.clone())
+    };
+
+    let kickoffs: Vec<&KickoffEvent> = timeline
+        .events
+        .events
+        .iter()
+        .filter_map(|event| match &event.payload {
+            EventPayload::Kickoff(kickoff) => Some(kickoff.as_ref()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !kickoffs.is_empty(),
+        "expected kickoff events in the replay"
+    );
+
+    for case in &CONTESTED_KICKOFFS {
+        let (lo, hi) = case.start_time_range;
+        let kickoff = kickoffs
+            .iter()
+            .find(|kickoff| kickoff.start_time >= lo && kickoff.start_time <= hi)
+            .unwrap_or_else(|| panic!("expected a kickoff with start_time in [{lo}, {hi}]"));
+
+        let team_zero_taker = kickoff
+            .team_zero_taker
+            .as_ref()
+            .expect("contested kickoff should resolve a team-zero taker");
+        let team_one_taker = kickoff
+            .team_one_taker
+            .as_ref()
+            .expect("contested kickoff should resolve a team-one taker");
+
+        // Both sides of the 50/50 must be credited a kickoff touch.
+        assert!(
+            team_zero_taker.first_touch_time.is_some(),
+            "team-zero taker should be credited a touch on the {} kickoff",
+            case.challenger_name
+        );
+        assert!(
+            team_one_taker.first_touch_time.is_some(),
+            "the contesting challenger {} should be credited a touch (was dropped before the fix)",
+            case.challenger_name
+        );
+
+        // Once both challengers are credited, the kickoff type/direction resolve
+        // instead of collapsing to `unknown`.
+        assert_ne!(
+            kickoff.kickoff_type,
+            KickoffType::Unknown,
+            "kickoff type should resolve for the {} contested kickoff",
+            case.challenger_name
+        );
+
+        // The named challenger is one of the credited takers.
+        let taker_names: Vec<Option<String>> = vec![
+            name_of(&team_zero_taker.player),
+            name_of(&team_one_taker.player),
+        ];
+        assert!(
+            taker_names
+                .iter()
+                .flatten()
+                .any(|name| name == case.challenger_name),
+            "expected {} to be a credited kickoff taker, got {:?}",
+            case.challenger_name,
+            taker_names
+        );
+    }
+}


### PR DESCRIPTION
## Problem

On a contested 50/50 kickoff both cars reach the ball at nearly the same instant, but the **losing challenger was frequently credited no touch at all**. With no recorded touch, `expected_taker_by_team` lost its first-touch tiebreak and `kickoff_type`/`kickoff_direction` collapsed to `unknown` — the same symptom [#106](https://github.com/rlrml/subtr-actor/pull/106) worked around defensively.

This is the deeper root-cause fix for that case. An audit of `post-eac-ranked-doubles-2026-04-28.replay` found **2–3 of 9 kickoffs** affected.

## Root cause (frame-level ground truth)

`accepted_contact_gap` requires a tight contact gap **and** a measurable ball-trajectory deviation **on the same frame**. On a 50/50 the winning car redirects the ball, so by the time the loser is physically on it the deviation has already dissipated:

```
f=4053 dev=(pos40)  luhbalenci gap 0.0 (accepted)   2Fum2Tastic gap 25.5 (just misses)
f=4054 dev=(pos6)   luhbalenci gap 0.0              2Fum2Tastic gap 0.0  ← on the ball, deviation gone
```

So the loser never enters the candidate cache and is dropped. The replay's `BallHitTeamNum` marker also reports only the winning team (or reports the loser a frame before any deviation, which the empty cache cannot resolve).

Two flavors, both fixed:
- **Ragnar** — reaches the ball a frame *before* the deviation; only his team's marker fires and it gets dropped.
- **2Fum2Tastic** — reaches it a frame *after* the deviation, with **no marker at all** (the #106 case).

## Fix — `src/stats/calculators/touch_state.rs`

Two complementary mechanisms, both gated on a live trajectory baseline so the existing "don't credit a car parked on a stationary ball" cases still hold:

1. **Marker geometry fallback** — attribute a team-only `BallHitTeamNum` marker to the closest same-team car within the relaxed contact gap when the candidate cache can't resolve it.
2. **`geometric_contested_touches`** — credit a car sitting on the ball (gap ≤ strict threshold) when an opposing-team touch was confirmed in the last few frames.

After the fix, **every kickoff in the doubles fixture credits both takers** and the kickoff type resolves.

## Tests

- `tests/contested_kickoff_touch_test.rs` (ignored/slow) asserts `Ragnar` and `2Fum2Tastic` are both credited and the kickoff types resolve.
- New `kickoff_touch_audit` diagnostic (`crates/subtr-actor-tools/src/bin/`) scans replays for kickoffs crediting only one side of a 50/50.
- Validated: 575 lib tests, touch_state (32), kickoff (39), hitbox, stats_export, stats_timeline, replay_data all pass. The unrelated `sustained_pressure_goal` failures in `post_eac`/`stats_frame_resolution` are pre-existing on the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)