### PR TITLE
Add pressure_duration_before_goal to goal context

### DIFF
--- a/bakkesmod/rust/src/lib_tests/abi_layout.rs
+++ b/bakkesmod/rust/src/lib_tests/abi_layout.rs
@@ -563,6 +563,7 @@ fn goal_context_event(frame: usize, time: f32) -> GoalContextEvent {
         }),
         ball_air_time_before_goal: Some(1.25),
         ball_speed_at_goal: None,
+        pressure_duration_before_goal: None,
         goal_buildup: GoalBuildupKind::CounterAttack,
         scorer_last_touch: None,
         players: Vec::new(),

--- a/js/stat-evaluation-player/src/generated/GoalContextEvent.ts
+++ b/js/stat-evaluation-player/src/generated/GoalContextEvent.ts
@@ -6,4 +6,11 @@ import type { GoalTag } from "./GoalTag.ts";
 import type { GoalTouchContext } from "./GoalTouchContext.ts";
 import type { RemoteIdTs } from "./RemoteIdTs.ts";
 
-export type GoalContextEvent = { time: number, frame: number, scoring_team_is_team_0: boolean, scorer: RemoteIdTs | null, scoring_team_most_back_player: RemoteIdTs | null, defending_team_most_back_player: RemoteIdTs | null, ball_position: GoalContextPosition | null, ball_speed_at_goal?: number | null, ball_air_time_before_goal: number | null, goal_buildup: GoalBuildupKind, scorer_last_touch: GoalTouchContext | null, players: Array<GoalPlayerContext>, tags?: Array<GoalTag>, };
+export type GoalContextEvent = { time: number, frame: number, scoring_team_is_team_0: boolean, scorer: RemoteIdTs | null, scoring_team_most_back_player: RemoteIdTs | null, defending_team_most_back_player: RemoteIdTs | null, ball_position: GoalContextPosition | null, ball_speed_at_goal?: number | null, ball_air_time_before_goal: number | null,
+/**
+ * How long the scoring team's established territorial-pressure session had
+ * been running when the goal was scored (goal_time - session.start_time).
+ * None for goals scored with no active pressure session (e.g. clean
+ * counter-attacks). Filled in at finish once pressure sessions are final.
+ */
+pressure_duration_before_goal?: number | null, goal_buildup: GoalBuildupKind, scorer_last_touch: GoalTouchContext | null, players: Array<GoalPlayerContext>, tags?: Array<GoalTag>, };

--- a/src/collector/stats/playback_event_parsers.rs
+++ b/src/collector/stats/playback_event_parsers.rs
@@ -595,6 +595,9 @@ pub(in crate::collector::stats::playback) fn parse_goal_context_event(
         ball_position: json_optional_goal_context_position(object.get("ball_position"))?,
         ball_speed_at_goal: json_optional_f32(object.get("ball_speed_at_goal"))?,
         ball_air_time_before_goal: json_optional_f32(object.get("ball_air_time_before_goal"))?,
+        pressure_duration_before_goal: json_optional_f32(
+            object.get("pressure_duration_before_goal"),
+        )?,
         goal_buildup: object
             .get("goal_buildup")
             .map(|value| decode_json_value(value.clone()))

--- a/src/stats/analysis_graph/nodes/match_stats.rs
+++ b/src/stats/analysis_graph/nodes/match_stats.rs
@@ -14,19 +14,60 @@ impl MatchStatsNode {
     }
 }
 
-impl_analysis_node! {
-    node = MatchStatsNode,
-    state = MatchStatsCalculator,
-    name = "match_stats",
-    dependencies = [
-        frame_info_dependency() => FrameInfo,
-        gameplay_state_dependency() => GameplayState,
-        ball_frame_state_dependency() => BallFrameState,
-        player_frame_state_dependency() => PlayerFrameState,
-        frame_events_state_dependency() => FrameEventsState,
-        live_play_dependency() => LivePlayState,
-        touch_state_dependency() => TouchState,
-    ],
-    call = calculator.update_parts,
-    finish = calculator.finish,
+impl Default for MatchStatsNode {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AnalysisNode for MatchStatsNode {
+    type State = MatchStatsCalculator;
+
+    fn name(&self) -> &'static str {
+        "match_stats"
+    }
+
+    fn dependencies(&self) -> Vec<AnalysisDependency> {
+        vec![
+            frame_info_dependency(),
+            gameplay_state_dependency(),
+            ball_frame_state_dependency(),
+            player_frame_state_dependency(),
+            frame_events_state_dependency(),
+            live_play_dependency(),
+            touch_state_dependency(),
+            // Not consumed per-frame; needed at finish to attach per-goal pressure.
+            territorial_pressure_dependency(),
+        ]
+    }
+
+    fn evaluate(&mut self, ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
+        self.calculator.update_parts(
+            ctx.get::<FrameInfo>()?,
+            ctx.get::<GameplayState>()?,
+            ctx.get::<BallFrameState>()?,
+            ctx.get::<PlayerFrameState>()?,
+            ctx.get::<FrameEventsState>()?,
+            ctx.get::<LivePlayState>()?,
+            ctx.get::<TouchState>()?,
+        )
+    }
+
+    fn finish(&mut self, ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
+        // Finalize goal contexts first, then attach pressure duration from the
+        // now-final territorial-pressure sessions.
+        self.calculator.finish()?;
+        let territorial_pressure = ctx.get::<TerritorialPressureCalculator>()?;
+        self.calculator
+            .attach_goal_pressure_durations(&territorial_pressure.projected_events());
+        Ok(())
+    }
+
+    fn state(&self) -> &Self::State {
+        &self.calculator
+    }
+}
+
+pub(crate) fn boxed_default() -> Box<dyn AnalysisNodeDyn> {
+    Box::new(MatchStatsNode::new())
 }

--- a/src/stats/calculators/goal_tags_tests.rs
+++ b/src/stats/calculators/goal_tags_tests.rs
@@ -55,6 +55,7 @@ fn goal_with_touch(
         ball_position: Some(touch_position),
         ball_speed_at_goal: None,
         ball_air_time_before_goal: None,
+        pressure_duration_before_goal: None,
         goal_buildup: GoalBuildupKind::Other,
         scorer_last_touch: Some(scorer_touch(touch_position, players.clone())),
         players,

--- a/src/stats/calculators/match_stats.rs
+++ b/src/stats/calculators/match_stats.rs
@@ -161,6 +161,12 @@ pub struct GoalContextEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ball_speed_at_goal: Option<f32>,
     pub ball_air_time_before_goal: Option<f32>,
+    /// How long the scoring team's established territorial-pressure session had
+    /// been running when the goal was scored (goal_time - session.start_time).
+    /// None for goals scored with no active pressure session (e.g. clean
+    /// counter-attacks). Filled in at finish once pressure sessions are final.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pressure_duration_before_goal: Option<f32>,
     #[serde(default)]
     pub goal_buildup: GoalBuildupKind,
     pub scorer_last_touch: Option<GoalTouchContext>,
@@ -858,6 +864,8 @@ impl MatchStatsCalculator {
                 ball_position,
                 ball_speed_at_goal,
                 ball_air_time_before_goal,
+                // Filled in at finish once territorial-pressure sessions are final.
+                pressure_duration_before_goal: None,
                 goal_buildup,
                 scorer_last_touch,
                 players: self.goal_player_contexts(
@@ -1000,6 +1008,32 @@ impl MatchStatsCalculator {
             GoalBuildupKind::SustainedPressure
         } else {
             GoalBuildupKind::Other
+        }
+    }
+
+    /// Attach to each recorded goal how long the scoring team's established
+    /// territorial-pressure session had been running when the goal was scored
+    /// (`goal_time - session.start_time`). The session is the scoring team's
+    /// pressure session that spans the goal frame. Goals scored with no active
+    /// pressure session (e.g. clean counter-attacks) are left as None.
+    ///
+    /// Runs at finish, after territorial-pressure sessions are finalized, so it
+    /// must be fed the pressure calculator's projected (final) sessions.
+    pub fn attach_goal_pressure_durations(
+        &mut self,
+        pressure_sessions: &[TerritorialPressureEvent],
+    ) {
+        for goal in self.goal_context_events.iter_mut() {
+            let goal_time = goal.time;
+            let scoring_team_is_team_0 = goal.scoring_team_is_team_0;
+            goal.pressure_duration_before_goal = pressure_sessions
+                .iter()
+                .find(|session| {
+                    session.team_is_team_0 == scoring_team_is_team_0
+                        && session.start_time <= goal_time
+                        && goal_time <= session.end_time
+                })
+                .map(|session| (goal_time - session.start_time).max(0.0));
         }
     }
 }


### PR DESCRIPTION
## What

Adds a new optional field `pressure_duration_before_goal` to `GoalContextEvent`: how long the scoring team's **established territorial-pressure session** had been running at the moment they scored (`goal_time − session.start_time`).

## Why

We want a per-goal "how much pressure led to this goal" stat. Raw "ball in the attacking half" is too coarse — it counts brief midfield touches and clears. The existing territorial-pressure state machine is a better signal: pressure only counts once *established* (past a 200uu neutral zone for 2s in the half / 0.75s in the third) and persists through short relief windows. Unlike the 12s goal-buildup buffer, this value is uncapped, so long sustained buildups read accurately.

Goals scored with no active pressure session for the scoring team (e.g. clean counter-attacks) are left as `None`.

## How

- `match_stats` node now declares a dependency on the `territorial_pressure` node and is implemented as a manual `AnalysisNode` (instead of the macro) so it can read pressure at `finish`.
- At `finish`, after pressure sessions are finalized, `MatchStatsCalculator::attach_goal_pressure_durations` joins each recorded goal to the scoring team's pressure session spanning the goal frame (using `projected_events()` so the final in-progress session is included).
- Round-tripped in the playback event parser.

## Verification

Ran the stats timeline over fixture replays. Sample `pressure_duration_before_goal` values: 1.0–6.7s for quick strikes, 13–25s for sustained-pressure goals. Every goal in the fixtures resolved to a session; counter-attack goals would be `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
