### PR TITLE
Uniform in-flight event lifecycle (InFlightLedger) + 7 calculator migrations

### DIFF
--- a/src/stats/analysis_graph/nodes/kickoff.rs
+++ b/src/stats/analysis_graph/nodes/kickoff.rs
@@ -53,6 +53,11 @@ impl AnalysisNode for KickoffNode {
             })
     }
 
+    fn finish(&mut self, _ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
+        self.calculator.finish();
+        Ok(())
+    }
+
     fn state(&self) -> &Self::State {
         &self.calculator
     }

--- a/src/stats/analysis_graph/nodes/touch.rs
+++ b/src/stats/analysis_graph/nodes/touch.rs
@@ -55,7 +55,7 @@ impl AnalysisNode for TouchNode {
     }
 
     fn finish(&mut self, _ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
-        self.calculator.flush_pending_ball_movement_credit();
+        self.calculator.finish();
         Ok(())
     }
 

--- a/src/stats/analysis_graph/nodes/whiff.rs
+++ b/src/stats/analysis_graph/nodes/whiff.rs
@@ -47,6 +47,11 @@ impl AnalysisNode for WhiffNode {
         )
     }
 
+    fn finish(&mut self, _ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
+        self.calculator.finish();
+        Ok(())
+    }
+
     fn state(&self) -> &Self::State {
         &self.calculator
     }

--- a/src/stats/calculators/controlled_play.rs
+++ b/src/stats/calculators/controlled_play.rs
@@ -119,10 +119,26 @@ impl ActiveControlledPlay {
     }
 }
 
+impl InFlightItem for ActiveControlledPlay {
+    fn recognition(&self) -> Recognition {
+        // Speculative until the chain accumulates enough to be a real
+        // controlled play; only then does it count as having "happened".
+        Recognition::new(self.start_time, self.start_frame, self.is_valid())
+    }
+
+    fn on_boundary(&mut self, boundary: Boundary) -> Disposition {
+        if self.is_valid() {
+            Disposition::Finalize(FinalizeReason::Boundary(boundary))
+        } else {
+            Disposition::Discard
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ControlledPlayCalculator {
     events: EventStream<ControlledPlayEvent>,
-    active: Option<ActiveControlledPlay>,
+    active: InFlightLedger<ActiveControlledPlay>,
     previous_ball_position: Option<glam::Vec3>,
 }
 
@@ -139,11 +155,27 @@ impl ControlledPlayCalculator {
         self.events.new_events()
     }
 
+    /// Natural finalization (touch-chain gap or a superseding player): emit the
+    /// run if it qualifies, otherwise discard it.
     fn finish_active(&mut self) {
-        let Some(active) = self.active.take() else {
-            return;
-        };
-        if active.is_valid() {
+        let valid = self
+            .active
+            .in_flight()
+            .first()
+            .is_some_and(ActiveControlledPlay::is_valid);
+        if valid {
+            for (active, _reason) in self.active.finalize_all(FinalizeReason::Completed) {
+                self.events.push(active.into_event());
+            }
+        } else {
+            self.active.clear();
+        }
+    }
+
+    /// Resolve any in-flight run against a game-flow boundary, emitting it only
+    /// if it qualifies (handled uniformly via the ledger).
+    fn finish_active_at_boundary(&mut self, boundary: Boundary) {
+        for (active, _reason) in self.active.apply_boundary(boundary) {
             self.events.push(active.into_event());
         }
     }
@@ -167,7 +199,7 @@ impl ControlledPlayCalculator {
         ball_position: Option<glam::Vec3>,
         players: &PlayerFrameState,
     ) {
-        let Some(active) = self.active.as_mut() else {
+        let Some(active) = self.active.in_flight_mut().first_mut() else {
             self.previous_ball_position = ball_position;
             return;
         };
@@ -190,7 +222,7 @@ impl ControlledPlayCalculator {
     }
 
     fn expire_stale_candidate(&mut self, frame: &FrameInfo) {
-        let Some(active) = self.active.as_ref() else {
+        let Some(active) = self.active.in_flight().first() else {
             return;
         };
         if frame.time - active.last_touch_time > MAX_TOUCH_CHAIN_GAP_SECONDS {
@@ -205,17 +237,19 @@ impl ControlledPlayCalculator {
 
         let same_player = self
             .active
-            .as_ref()
+            .in_flight()
+            .first()
             .is_some_and(|active| active.player_id == player_id);
         if same_player {
-            if let Some(active) = self.active.as_mut() {
+            if let Some(active) = self.active.in_flight_mut().first_mut() {
                 active.record_touch(touch);
             }
             return;
         }
 
         self.finish_active();
-        self.active = Some(ActiveControlledPlay::from_touch(touch, player_id));
+        self.active
+            .arm(ActiveControlledPlay::from_touch(touch, player_id));
     }
 
     pub fn update(
@@ -228,7 +262,7 @@ impl ControlledPlayCalculator {
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
         if !live_play_state.is_live_play {
-            self.finish_active();
+            self.finish_active_at_boundary(Boundary::LivePlayEnded);
             self.previous_ball_position = ball.position();
             return Ok(());
         }
@@ -243,7 +277,7 @@ impl ControlledPlayCalculator {
     }
 
     pub fn finish(&mut self) {
-        self.finish_active();
+        self.finish_active_at_boundary(Boundary::ReplayEnded);
     }
 }
 

--- a/src/stats/calculators/double_tap.rs
+++ b/src/stats/calculators/double_tap.rs
@@ -22,6 +22,19 @@ struct PendingBackboardBounce {
     frame: usize,
 }
 
+impl InFlightItem for PendingBackboardBounce {
+    fn recognition(&self) -> Recognition {
+        // Speculative: a backboard bounce only becomes a double tap if the same
+        // player makes a goal-bound follow-up touch; otherwise it is discarded.
+        Recognition::speculative(self.time, self.frame)
+    }
+
+    fn on_boundary(&mut self, _boundary: Boundary) -> Disposition {
+        // A pending bounce that survives to a boundary never resolved.
+        Disposition::Discard
+    }
+}
+
 /// Detects double taps from a backboard-bounce sequence.
 ///
 /// Current heuristic:
@@ -42,7 +55,7 @@ struct PendingBackboardBounce {
 #[derive(Debug, Clone, Default)]
 pub struct DoubleTapCalculator {
     events: EventStream<DoubleTapEvent>,
-    pending_backboard_bounces: Vec<PendingBackboardBounce>,
+    pending_backboard_bounces: KeyedInFlightLedger<PlayerId, PendingBackboardBounce>,
 }
 
 impl DoubleTapCalculator {
@@ -64,25 +77,17 @@ impl DoubleTapCalculator {
                 continue;
             }
 
-            if let Some(existing) = self
-                .pending_backboard_bounces
-                .iter_mut()
-                .find(|pending| pending.player_id == event.player)
-            {
-                *existing = PendingBackboardBounce {
+            // Arming with the player key replaces any existing pending bounce
+            // for that player.
+            self.pending_backboard_bounces.arm(
+                event.player.clone(),
+                PendingBackboardBounce {
                     player_id: event.player.clone(),
                     is_team_0: event.is_team_0,
                     time: event.time,
                     frame: event.frame,
-                };
-            } else {
-                self.pending_backboard_bounces.push(PendingBackboardBounce {
-                    player_id: event.player.clone(),
-                    is_team_0: event.is_team_0,
-                    time: event.time,
-                    frame: event.frame,
-                });
-            }
+                },
+            );
         }
     }
 
@@ -93,7 +98,7 @@ impl DoubleTapCalculator {
     }
 
     fn prune_surface_contacts(&mut self, players: &PlayerFrameState) {
-        self.pending_backboard_bounces.retain(|pending| {
+        self.pending_backboard_bounces.retain(|_, pending| {
             !players
                 .player(&pending.player_id)
                 .is_some_and(player_sample_is_touching_surface)
@@ -114,36 +119,36 @@ impl DoubleTapCalculator {
             return;
         };
 
-        let mut completed_events = Vec::new();
-        self.pending_backboard_bounces.retain(|pending| {
-            if touch.time <= pending.time {
-                return true;
-            }
+        let resolved = self
+            .pending_backboard_bounces
+            .advance(frame.time, |_player, pending| {
+                if touch.time <= pending.time {
+                    return Disposition::Keep;
+                }
+                let is_matching_followup = touch.team_is_team_0 == pending.is_team_0
+                    && touch.player.as_ref() == Some(&pending.player_id);
+                if !is_matching_followup {
+                    return Disposition::Discard;
+                }
+                if Self::followup_touch_projects_on_goal_mouth(ball, pending.is_team_0) {
+                    Disposition::Finalize(FinalizeReason::Completed)
+                } else {
+                    Disposition::Discard
+                }
+            });
 
-            let is_matching_followup = touch.team_is_team_0 == pending.is_team_0
-                && touch.player.as_ref() == Some(&pending.player_id);
-            if !is_matching_followup {
-                return false;
-            }
-
-            if Self::followup_touch_projects_on_goal_mouth(ball, pending.is_team_0) {
-                completed_events.push(DoubleTapEvent {
-                    time: touch.time,
-                    frame: touch.frame,
-                    player: pending.player_id.clone(),
-                    player_position: touch
-                        .player_position
-                        .map(|position| vec_to_glam(&position).to_array()),
-                    is_team_0: pending.is_team_0,
-                    backboard_time: pending.time,
-                    backboard_frame: pending.frame,
-                });
-            }
-
-            false
-        });
-
-        for event in completed_events {
+        for (_player, pending, _reason) in resolved {
+            let event = DoubleTapEvent {
+                time: touch.time,
+                frame: touch.frame,
+                player: pending.player_id.clone(),
+                player_position: touch
+                    .player_position
+                    .map(|position| vec_to_glam(&position).to_array()),
+                is_team_0: pending.is_team_0,
+                backboard_time: pending.time,
+                backboard_frame: pending.frame,
+            };
             self.record_double_tap(frame, event);
         }
     }
@@ -196,7 +201,8 @@ impl DoubleTapCalculator {
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
         if !live_play_state.is_live_play {
-            self.pending_backboard_bounces.clear();
+            self.pending_backboard_bounces
+                .apply_boundary(Boundary::LivePlayEnded);
         }
 
         self.record_backboard_bounces(backboard_bounce_state);

--- a/src/stats/calculators/flip_impulse.rs
+++ b/src/stats/calculators/flip_impulse.rs
@@ -61,10 +61,24 @@ struct ActiveFlipImpulseCandidate {
     boost_sample_count: u32,
 }
 
+impl InFlightItem for ActiveFlipImpulseCandidate {
+    fn recognition(&self) -> Recognition {
+        // Speculative until it survives the evaluation window: a candidate can
+        // be pruned (stale) or discarded at a boundary before emitting.
+        Recognition::speculative(self.start_time, self.start_frame)
+    }
+
+    fn on_boundary(&mut self, _boundary: Boundary) -> Disposition {
+        // Candidates in flight at a boundary are dropped (matching the previous
+        // clear-on-stoppage / drop-at-end behavior).
+        Disposition::Discard
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct FlipImpulseCalculator {
     events: EventStream<DodgeEvent>,
-    active_candidates: HashMap<PlayerId, ActiveFlipImpulseCandidate>,
+    active_candidates: KeyedInFlightLedger<PlayerId, ActiveFlipImpulseCandidate>,
     previous_dodge_active: HashMap<PlayerId, bool>,
 }
 
@@ -147,7 +161,7 @@ impl FlipImpulseCalculator {
         };
 
         let rotation = quat_to_glam(&rigid_body.rotation);
-        self.active_candidates.insert(
+        self.active_candidates.arm(
             player.player_id.clone(),
             ActiveFlipImpulseCandidate {
                 is_team_0: player.is_team_0,
@@ -263,7 +277,7 @@ impl FlipImpulseCalculator {
     fn finalize_candidates(&mut self, frame: &FrameInfo, force_all: bool) {
         let mut finished_candidates = Vec::new();
 
-        for (player_id, candidate) in &self.active_candidates {
+        for (player_id, candidate) in self.active_candidates.iter() {
             let duration = frame.time - candidate.start_time;
             if force_all || duration >= FLIP_IMPULSE_EVALUATION_SECONDS {
                 finished_candidates.push((
@@ -283,7 +297,10 @@ impl FlipImpulseCalculator {
         });
 
         for (_, _, _, player_id) in finished_candidates {
-            let Some(candidate) = self.active_candidates.remove(&player_id) else {
+            let Some(candidate) = self
+                .active_candidates
+                .finalize(&player_id, FinalizeReason::Completed)
+            else {
                 continue;
             };
             let event = Self::candidate_event(&player_id, candidate);
@@ -300,7 +317,7 @@ impl FlipImpulseCalculator {
         self.events.begin_update();
 
         if !live_play_state.counts_toward_player_motion() {
-            self.active_candidates.clear();
+            self.active_candidates.apply_boundary(Boundary::LivePlayEnded);
             return Ok(());
         }
 
@@ -308,7 +325,7 @@ impl FlipImpulseCalculator {
             self.maybe_start_candidate(frame, player);
         }
 
-        for (player_id, candidate) in &mut self.active_candidates {
+        for (player_id, candidate) in self.active_candidates.iter_mut() {
             let Some(player) = Self::player_by_id(players, player_id) else {
                 continue;
             };

--- a/src/stats/calculators/flip_impulse.rs
+++ b/src/stats/calculators/flip_impulse.rs
@@ -317,7 +317,8 @@ impl FlipImpulseCalculator {
         self.events.begin_update();
 
         if !live_play_state.counts_toward_player_motion() {
-            self.active_candidates.apply_boundary(Boundary::LivePlayEnded);
+            self.active_candidates
+                .apply_boundary(Boundary::LivePlayEnded);
             return Ok(());
         }
 

--- a/src/stats/calculators/in_flight.rs
+++ b/src/stats/calculators/in_flight.rs
@@ -211,6 +211,20 @@ impl<C: InFlightItem> InFlightLedger<C> {
         self.apply_boundary(Boundary::ReplayEnded)
     }
 
+    /// Imperatively finalize every in-flight item with `reason`, returning them
+    /// for the caller to convert into events. For calculators that drive
+    /// finalization from specific code paths (e.g. emit-early, patch-in-place)
+    /// rather than a per-frame step or a [`Boundary`].
+    pub fn finalize_all(&mut self, reason: FinalizeReason) -> Vec<(C, FinalizeReason)> {
+        let mut finalized = Vec::with_capacity(self.active.len());
+        for item in std::mem::take(&mut self.active) {
+            self.log_finalized(&item);
+            finalized.push((item, reason));
+        }
+        self.prune_history();
+        finalized
+    }
+
     fn resolve_each(
         &mut self,
         mut decide: impl FnMut(&mut C) -> Disposition,
@@ -236,6 +250,10 @@ impl<C: InFlightItem> InFlightLedger<C> {
     fn log_finalized(&mut self, item: &C) {
         let mut recognition = item.recognition();
         recognition.committed = true;
+        // Keep `last_time` roughly current even for imperative flows that don't
+        // go through `advance`, so the history still prunes (recognition time is
+        // a lower bound on the current time).
+        self.last_time = self.last_time.max(recognition.time);
         self.finalized.push_back(recognition);
     }
 

--- a/src/stats/calculators/in_flight.rs
+++ b/src/stats/calculators/in_flight.rs
@@ -428,6 +428,16 @@ impl<K: Eq + Hash + Clone, C> KeyedInFlightLedger<K, C> {
         self.active.iter()
     }
 
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut C)> + '_ {
+        self.active.iter_mut()
+    }
+
+    /// Keep only the items for which `keep` returns true, discarding the rest
+    /// without finalizing them (e.g. pruning stale candidates).
+    pub fn retain(&mut self, mut keep: impl FnMut(&K, &C) -> bool) {
+        self.active.retain(|key, item| keep(key, item));
+    }
+
     /// Remove the item for `key` without recording it as having happened (it is
     /// abandoned, not finalized).
     pub fn discard(&mut self, key: &K) -> Option<C> {

--- a/src/stats/calculators/in_flight.rs
+++ b/src/stats/calculators/in_flight.rs
@@ -1,0 +1,283 @@
+//! Uniform lifecycle for *in-flight events* — analysis results that are
+//! recognized on one frame but only finalized later, once enough subsequent
+//! frames have been observed.
+//!
+//! Many calculators share the same shape: arm a pending/"active" candidate when
+//! something is first recognized, fold in metadata over subsequent frames, then
+//! emit a finalized event once a completion condition is met. Historically each
+//! calculator hand-rolled this, including the easy-to-forget part: making sure a
+//! candidate that is still in flight when a *boundary* occurs (a goal, play
+//! leaving the live phase, or the end of the replay) is finalized or discarded
+//! rather than silently leaking or absorbing data across the boundary.
+//!
+//! [`InFlightLedger`] centralizes that lifecycle:
+//!   * boundary handling is uniform and exhaustive ([`InFlightLedger::apply_boundary`],
+//!     [`InFlightLedger::finish`]), so a calculator cannot forget a boundary;
+//!   * every recognition is logged so other nodes can ask "did this happen
+//!     recently?" *latently* — including events that are recognized but not yet
+//!     finalized ([`InFlightLedger::happened_within`]).
+
+use std::collections::VecDeque;
+
+/// Default span, in seconds, over which finalized recognitions are retained for
+/// latent queries. Generous enough for "did X happen recently" questions while
+/// keeping the history bounded.
+pub const DEFAULT_HISTORY_WINDOW_SECONDS: f32 = 10.0;
+
+/// A coarse game-flow boundary at which pending analysis work must resolve.
+///
+/// The set is deliberately limited to boundaries the replay model can actually
+/// express. (There is no period/half/overtime concept in the data, so none is
+/// offered here.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Boundary {
+    /// Play left the live ("active") phase: a goal, a whistle, or a kickoff
+    /// reset. Derived from `LivePlayState::is_live_play` going false.
+    LivePlayEnded,
+    /// A goal was scored. Derived from `FrameEventsState::goal_events`.
+    GoalScored,
+    /// The replay stream ended; nothing more will ever be observed. Delivered
+    /// from each node's `finish`.
+    ReplayEnded,
+}
+
+/// Why an in-flight item was finalized into an event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FinalizeReason {
+    /// Reached its natural completion condition (window elapsed, follow-up
+    /// observed, possession resolved, ...).
+    Completed,
+    /// Replaced by a newer candidate for the same subject before completing.
+    Superseded,
+    /// Cut short by a game-flow [`Boundary`] before natural completion. The
+    /// resulting event's measured window is truncated at the boundary.
+    Boundary(Boundary),
+}
+
+/// A cheap, early record that an event has been recognized.
+///
+/// A recognition is available from the moment a candidate is armed — before the
+/// full event payload exists. This is what lets other analysis nodes ask
+/// whether an event happened *recently* even when it is still in flight.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Recognition {
+    pub time: f32,
+    pub frame: usize,
+    /// `false` while the candidate is still speculative (it may yet be
+    /// discarded rather than finalized); `true` once it is certain to emit.
+    pub committed: bool,
+}
+
+impl Recognition {
+    pub fn new(time: f32, frame: usize, committed: bool) -> Self {
+        Self {
+            time,
+            frame,
+            committed,
+        }
+    }
+
+    /// A committed recognition (certain to produce an event).
+    pub fn committed(time: f32, frame: usize) -> Self {
+        Self::new(time, frame, true)
+    }
+
+    /// A speculative recognition (may still be discarded).
+    pub fn speculative(time: f32, frame: usize) -> Self {
+        Self::new(time, frame, false)
+    }
+}
+
+/// What should happen to an in-flight item, as decided either by a per-frame
+/// step or by a [`Boundary`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Disposition {
+    /// Keep accumulating; the item stays in flight.
+    Keep,
+    /// Finalize now, for the given reason. The item is removed and handed back
+    /// to the caller to convert into an event.
+    Finalize(FinalizeReason),
+    /// Abandon the item without emitting anything.
+    Discard,
+}
+
+/// An item that can be held in flight by an [`InFlightLedger`].
+///
+/// The per-frame accumulation logic stays in the owning calculator (its inputs
+/// are calculator-specific); the trait only covers what the ledger must do
+/// uniformly: expose a [`Recognition`] for latent queries, and decide how to
+/// respond when a [`Boundary`] forces resolution.
+pub trait InFlightItem {
+    fn recognition(&self) -> Recognition;
+
+    /// How this item responds to `boundary`. Committed items that have earned
+    /// an event typically return `Finalize(FinalizeReason::Boundary(boundary))`;
+    /// speculative candidates that have not yet earned one typically `Discard`.
+    fn on_boundary(&mut self, boundary: Boundary) -> Disposition;
+}
+
+/// Holds zero or more in-flight items, drives their lifecycle uniformly, and
+/// records recognitions so finalized and in-flight events alike can be queried
+/// latently.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InFlightLedger<C> {
+    active: Vec<C>,
+    /// Recognitions of items that have finalized, retained for latent queries
+    /// up to `history_window` seconds before the most recently observed time.
+    finalized: VecDeque<Recognition>,
+    history_window: f32,
+    last_time: f32,
+}
+
+impl<C> Default for InFlightLedger<C> {
+    fn default() -> Self {
+        Self::with_history_window(DEFAULT_HISTORY_WINDOW_SECONDS)
+    }
+}
+
+impl<C> InFlightLedger<C> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_history_window(history_window: f32) -> Self {
+        Self {
+            active: Vec::new(),
+            finalized: VecDeque::new(),
+            history_window,
+            last_time: 0.0,
+        }
+    }
+
+    /// Arm a new in-flight item.
+    pub fn arm(&mut self, item: C) {
+        self.active.push(item);
+    }
+
+    /// The items currently in flight.
+    pub fn in_flight(&self) -> &[C] {
+        &self.active
+    }
+
+    /// Mutable access to the items currently in flight, for per-frame
+    /// accumulation that does not change the in-flight set.
+    pub fn in_flight_mut(&mut self) -> &mut [C] {
+        &mut self.active
+    }
+
+    pub fn any_in_flight(&self) -> bool {
+        !self.active.is_empty()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.active.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.active.len()
+    }
+}
+
+impl<C: InFlightItem> InFlightLedger<C> {
+    /// Advance every in-flight item with `step`, which folds in this frame's
+    /// data and returns a [`Disposition`]. Finalized and discarded items are
+    /// removed; finalized items are logged for latent queries and returned with
+    /// their reason for the caller to turn into events. `now` is the current
+    /// frame time, used to bound the latent-query history.
+    pub fn advance(
+        &mut self,
+        now: f32,
+        mut step: impl FnMut(&mut C) -> Disposition,
+    ) -> Vec<(C, FinalizeReason)> {
+        self.last_time = now;
+        let finalized = self.resolve_each(|item| step(item));
+        self.prune_history();
+        finalized
+    }
+
+    /// Apply `boundary` to every in-flight item via [`InFlightItem::on_boundary`].
+    /// This is the uniform replacement for hand-placed flush calls: a single
+    /// call resolves *every* pending item against the boundary, so none can be
+    /// forgotten.
+    pub fn apply_boundary(&mut self, boundary: Boundary) -> Vec<(C, FinalizeReason)> {
+        let finalized = self.resolve_each(|item| item.on_boundary(boundary));
+        self.prune_history();
+        finalized
+    }
+
+    /// Finalize everything still in flight at end of stream. Calling this from a
+    /// node's `finish` guarantees no in-flight item is ever silently dropped.
+    pub fn finish(&mut self) -> Vec<(C, FinalizeReason)> {
+        self.apply_boundary(Boundary::ReplayEnded)
+    }
+
+    fn resolve_each(
+        &mut self,
+        mut decide: impl FnMut(&mut C) -> Disposition,
+    ) -> Vec<(C, FinalizeReason)> {
+        let mut finalized = Vec::new();
+        let mut i = 0;
+        while i < self.active.len() {
+            match decide(&mut self.active[i]) {
+                Disposition::Keep => i += 1,
+                Disposition::Discard => {
+                    self.active.remove(i);
+                }
+                Disposition::Finalize(reason) => {
+                    let item = self.active.remove(i);
+                    self.log_finalized(&item);
+                    finalized.push((item, reason));
+                }
+            }
+        }
+        finalized
+    }
+
+    fn log_finalized(&mut self, item: &C) {
+        let mut recognition = item.recognition();
+        recognition.committed = true;
+        self.finalized.push_back(recognition);
+    }
+
+    fn prune_history(&mut self) {
+        let cutoff = self.last_time - self.history_window;
+        while self.finalized.front().is_some_and(|rec| rec.time < cutoff) {
+            self.finalized.pop_front();
+        }
+    }
+
+    /// Whether an event was recognized within `window` seconds before `now`,
+    /// counting both finalized events and items still in flight.
+    ///
+    /// With `committed_only`, speculative (not-yet-committed) in-flight items
+    /// are ignored — use it for "did X *happen*?" questions that must not be
+    /// fooled by a candidate that may still be discarded. Without it, the query
+    /// is fully latent: a just-recognized, not-yet-finalized candidate counts.
+    pub fn happened_within(&self, now: f32, window: f32, committed_only: bool) -> bool {
+        self.recognitions_within(now, window, committed_only)
+            .next()
+            .is_some()
+    }
+
+    /// All recognitions within `window` seconds before `now`, across in-flight
+    /// and finalized items. See [`happened_within`](Self::happened_within) for
+    /// the meaning of `committed_only`.
+    pub fn recognitions_within(
+        &self,
+        now: f32,
+        window: f32,
+        committed_only: bool,
+    ) -> impl Iterator<Item = Recognition> + '_ {
+        let active = self.active.iter().map(C::recognition).filter(move |rec| {
+            rec.time <= now && now - rec.time <= window && (!committed_only || rec.committed)
+        });
+        let finalized = self.finalized.iter().copied().filter(move |rec| {
+            rec.time <= now && now - rec.time <= window && (!committed_only || rec.committed)
+        });
+        active.chain(finalized)
+    }
+}
+
+#[cfg(test)]
+#[path = "in_flight_tests.rs"]
+mod tests;

--- a/src/stats/calculators/in_flight.rs
+++ b/src/stats/calculators/in_flight.rs
@@ -10,14 +10,22 @@
 //! leaving the live phase, or the end of the replay) is finalized or discarded
 //! rather than silently leaking or absorbing data across the boundary.
 //!
-//! [`InFlightLedger`] centralizes that lifecycle:
-//!   * boundary handling is uniform and exhaustive ([`InFlightLedger::apply_boundary`],
-//!     [`InFlightLedger::finish`]), so a calculator cannot forget a boundary;
-//!   * every recognition is logged so other nodes can ask "did this happen
-//!     recently?" *latently* — including events that are recognized but not yet
-//!     finalized ([`InFlightLedger::happened_within`]).
+//! Two containers are offered, sharing the same vocabulary ([`Boundary`],
+//! [`FinalizeReason`], [`Recognition`], [`Disposition`], [`InFlightItem`]) and
+//! the same latent-query semantics:
+//!   * [`InFlightLedger`] holds an unordered set of in-flight items;
+//!   * [`KeyedInFlightLedger`] holds at most one in-flight item per key (e.g.
+//!     per player), for calculators that look candidates up by subject.
+//!
+//! Both centralize boundary handling ([`apply_boundary`](InFlightLedger::apply_boundary),
+//! `finish`) so a calculator cannot forget a boundary, and both log every
+//! recognition so other nodes can ask "did this happen recently?" *latently* —
+//! counting events that are recognized but not yet finalized, with a
+//! `committed_only` gate so speculative candidates don't give false positives.
 
-use std::collections::VecDeque;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
 
 /// Default span, in seconds, over which finalized recognitions are retained for
 /// latent queries. Generous enough for "did X happen recently" questions while
@@ -101,10 +109,10 @@ pub enum Disposition {
     Discard,
 }
 
-/// An item that can be held in flight by an [`InFlightLedger`].
+/// An item that can be held in flight by a ledger.
 ///
 /// The per-frame accumulation logic stays in the owning calculator (its inputs
-/// are calculator-specific); the trait only covers what the ledger must do
+/// are calculator-specific); the trait only covers what a ledger must do
 /// uniformly: expose a [`Recognition`] for latent queries, and decide how to
 /// respond when a [`Boundary`] forces resolution.
 pub trait InFlightItem {
@@ -116,17 +124,69 @@ pub trait InFlightItem {
     fn on_boundary(&mut self, boundary: Boundary) -> Disposition;
 }
 
-/// Holds zero or more in-flight items, drives their lifecycle uniformly, and
-/// records recognitions so finalized and in-flight events alike can be queried
-/// latently.
+/// Bounded, time-indexed record of finalized recognitions, shared by both
+/// ledgers to answer latent "did X happen recently?" queries.
 #[derive(Debug, Clone, PartialEq)]
-pub struct InFlightLedger<C> {
-    active: Vec<C>,
-    /// Recognitions of items that have finalized, retained for latent queries
-    /// up to `history_window` seconds before the most recently observed time.
+struct RecognitionLog {
     finalized: VecDeque<Recognition>,
     history_window: f32,
     last_time: f32,
+}
+
+impl RecognitionLog {
+    fn with_history_window(history_window: f32) -> Self {
+        Self {
+            finalized: VecDeque::new(),
+            history_window,
+            last_time: 0.0,
+        }
+    }
+
+    fn observe_time(&mut self, now: f32) {
+        self.last_time = self.last_time.max(now);
+    }
+
+    fn log(&mut self, item: &impl InFlightItem) {
+        let mut recognition = item.recognition();
+        recognition.committed = true;
+        // Keep `last_time` roughly current even for imperative flows that don't
+        // observe a frame time, so the history still prunes (recognition time is
+        // a lower bound on the current time).
+        self.last_time = self.last_time.max(recognition.time);
+        self.finalized.push_back(recognition);
+    }
+
+    fn prune(&mut self) {
+        let cutoff = self.last_time - self.history_window;
+        while self.finalized.front().is_some_and(|rec| rec.time < cutoff) {
+            self.finalized.pop_front();
+        }
+    }
+
+    fn finalized_within(
+        &self,
+        now: f32,
+        window: f32,
+        committed_only: bool,
+    ) -> impl Iterator<Item = Recognition> + '_ {
+        self.finalized
+            .iter()
+            .copied()
+            .filter(move |rec| in_window(rec, now, window, committed_only))
+    }
+}
+
+fn in_window(rec: &Recognition, now: f32, window: f32, committed_only: bool) -> bool {
+    rec.time <= now && now - rec.time <= window && (!committed_only || rec.committed)
+}
+
+/// Holds an unordered set of in-flight items, drives their lifecycle uniformly,
+/// and records recognitions so finalized and in-flight events alike can be
+/// queried latently.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InFlightLedger<C> {
+    active: Vec<C>,
+    log: RecognitionLog,
 }
 
 impl<C> Default for InFlightLedger<C> {
@@ -143,9 +203,7 @@ impl<C> InFlightLedger<C> {
     pub fn with_history_window(history_window: f32) -> Self {
         Self {
             active: Vec::new(),
-            finalized: VecDeque::new(),
-            history_window,
-            last_time: 0.0,
+            log: RecognitionLog::with_history_window(history_window),
         }
     }
 
@@ -189,9 +247,9 @@ impl<C: InFlightItem> InFlightLedger<C> {
         now: f32,
         mut step: impl FnMut(&mut C) -> Disposition,
     ) -> Vec<(C, FinalizeReason)> {
-        self.last_time = now;
+        self.log.observe_time(now);
         let finalized = self.resolve_each(|item| step(item));
-        self.prune_history();
+        self.log.prune();
         finalized
     }
 
@@ -201,7 +259,7 @@ impl<C: InFlightItem> InFlightLedger<C> {
     /// forgotten.
     pub fn apply_boundary(&mut self, boundary: Boundary) -> Vec<(C, FinalizeReason)> {
         let finalized = self.resolve_each(|item| item.on_boundary(boundary));
-        self.prune_history();
+        self.log.prune();
         finalized
     }
 
@@ -218,10 +276,10 @@ impl<C: InFlightItem> InFlightLedger<C> {
     pub fn finalize_all(&mut self, reason: FinalizeReason) -> Vec<(C, FinalizeReason)> {
         let mut finalized = Vec::with_capacity(self.active.len());
         for item in std::mem::take(&mut self.active) {
-            self.log_finalized(&item);
+            self.log.log(&item);
             finalized.push((item, reason));
         }
-        self.prune_history();
+        self.log.prune();
         finalized
     }
 
@@ -239,29 +297,12 @@ impl<C: InFlightItem> InFlightLedger<C> {
                 }
                 Disposition::Finalize(reason) => {
                     let item = self.active.remove(i);
-                    self.log_finalized(&item);
+                    self.log.log(&item);
                     finalized.push((item, reason));
                 }
             }
         }
         finalized
-    }
-
-    fn log_finalized(&mut self, item: &C) {
-        let mut recognition = item.recognition();
-        recognition.committed = true;
-        // Keep `last_time` roughly current even for imperative flows that don't
-        // go through `advance`, so the history still prunes (recognition time is
-        // a lower bound on the current time).
-        self.last_time = self.last_time.max(recognition.time);
-        self.finalized.push_back(recognition);
-    }
-
-    fn prune_history(&mut self) {
-        let cutoff = self.last_time - self.history_window;
-        while self.finalized.front().is_some_and(|rec| rec.time < cutoff) {
-            self.finalized.pop_front();
-        }
     }
 
     /// Whether an event was recognized within `window` seconds before `now`,
@@ -286,13 +327,196 @@ impl<C: InFlightItem> InFlightLedger<C> {
         window: f32,
         committed_only: bool,
     ) -> impl Iterator<Item = Recognition> + '_ {
-        let active = self.active.iter().map(C::recognition).filter(move |rec| {
-            rec.time <= now && now - rec.time <= window && (!committed_only || rec.committed)
-        });
-        let finalized = self.finalized.iter().copied().filter(move |rec| {
-            rec.time <= now && now - rec.time <= window && (!committed_only || rec.committed)
-        });
-        active.chain(finalized)
+        let active = self
+            .active
+            .iter()
+            .map(C::recognition)
+            .filter(move |rec| in_window(rec, now, window, committed_only));
+        active.chain(self.log.finalized_within(now, window, committed_only))
+    }
+}
+
+/// Holds at most one in-flight item per key, drives their lifecycle uniformly,
+/// and records recognitions for latent queries. The keyed analogue of
+/// [`InFlightLedger`], for calculators that track a candidate per subject (e.g.
+/// per player).
+#[derive(Debug, Clone)]
+pub struct KeyedInFlightLedger<K, C> {
+    active: HashMap<K, C>,
+    log: RecognitionLog,
+}
+
+impl<K: Eq + Hash, C: PartialEq> PartialEq for KeyedInFlightLedger<K, C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.active == other.active && self.log == other.log
+    }
+}
+
+impl<K, C> Default for KeyedInFlightLedger<K, C> {
+    fn default() -> Self {
+        Self::with_history_window(DEFAULT_HISTORY_WINDOW_SECONDS)
+    }
+}
+
+impl<K, C> KeyedInFlightLedger<K, C> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_history_window(history_window: f32) -> Self {
+        Self {
+            active: HashMap::new(),
+            log: RecognitionLog::with_history_window(history_window),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.active.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.active.len()
+    }
+}
+
+impl<K: Eq + Hash + Clone, C> KeyedInFlightLedger<K, C> {
+    /// Arm (or replace) the in-flight item for `key`.
+    pub fn arm(&mut self, key: K, item: C) {
+        self.active.insert(key, item);
+    }
+
+    pub fn contains(&self, key: &K) -> bool {
+        self.active.contains_key(key)
+    }
+
+    pub fn get(&self, key: &K) -> Option<&C> {
+        self.active.get(key)
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut C> {
+        self.active.get_mut(key)
+    }
+
+    /// Access the in-flight item for `key`, inserting one produced by `default`
+    /// if absent. Mirrors `HashMap::entry(..).or_insert_with(..)`.
+    pub fn entry_or_insert_with(&mut self, key: K, default: impl FnOnce() -> C) -> &mut C {
+        match self.active.entry(key) {
+            Entry::Occupied(occupied) => occupied.into_mut(),
+            Entry::Vacant(vacant) => vacant.insert(default()),
+        }
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &K> + '_ {
+        self.active.keys()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &C> + '_ {
+        self.active.values()
+    }
+
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut C> + '_ {
+        self.active.values_mut()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &C)> + '_ {
+        self.active.iter()
+    }
+
+    /// Remove the item for `key` without recording it as having happened (it is
+    /// abandoned, not finalized).
+    pub fn discard(&mut self, key: &K) -> Option<C> {
+        self.active.remove(key)
+    }
+
+    /// Discard every in-flight item without finalizing any (e.g. abandoning all
+    /// candidates when their precondition no longer holds).
+    pub fn clear(&mut self) {
+        self.active.clear();
+    }
+}
+
+impl<K: Eq + Hash + Clone, C: InFlightItem> KeyedInFlightLedger<K, C> {
+    /// Finalize the item for `key`, logging it for latent queries and returning
+    /// it for the caller to convert into an event.
+    pub fn finalize(&mut self, key: &K, _reason: FinalizeReason) -> Option<C> {
+        let item = self.active.remove(key)?;
+        self.log.log(&item);
+        Some(item)
+    }
+
+    /// Advance every in-flight item with `step`, which receives the key and a
+    /// mutable item and returns a [`Disposition`]. `now` bounds the latent-query
+    /// history. Finalized items are returned with their key and reason.
+    pub fn advance(
+        &mut self,
+        now: f32,
+        mut step: impl FnMut(&K, &mut C) -> Disposition,
+    ) -> Vec<(K, C, FinalizeReason)> {
+        self.log.observe_time(now);
+        let finalized = self.resolve_each(|key, item| step(key, item));
+        self.log.prune();
+        finalized
+    }
+
+    /// Apply `boundary` to every in-flight item via [`InFlightItem::on_boundary`].
+    pub fn apply_boundary(&mut self, boundary: Boundary) -> Vec<(K, C, FinalizeReason)> {
+        let finalized = self.resolve_each(|_key, item| item.on_boundary(boundary));
+        self.log.prune();
+        finalized
+    }
+
+    /// Finalize everything still in flight at end of stream.
+    pub fn finish(&mut self) -> Vec<(K, C, FinalizeReason)> {
+        self.apply_boundary(Boundary::ReplayEnded)
+    }
+
+    fn resolve_each(
+        &mut self,
+        mut decide: impl FnMut(&K, &mut C) -> Disposition,
+    ) -> Vec<(K, C, FinalizeReason)> {
+        let mut finalized = Vec::new();
+        let mut remove_finalize: Vec<(K, FinalizeReason)> = Vec::new();
+        let mut remove_discard: Vec<K> = Vec::new();
+        for (key, item) in self.active.iter_mut() {
+            match decide(key, item) {
+                Disposition::Keep => {}
+                Disposition::Discard => remove_discard.push(key.clone()),
+                Disposition::Finalize(reason) => remove_finalize.push((key.clone(), reason)),
+            }
+        }
+        for key in remove_discard {
+            self.active.remove(&key);
+        }
+        for (key, reason) in remove_finalize {
+            if let Some(item) = self.active.remove(&key) {
+                self.log.log(&item);
+                finalized.push((key, item, reason));
+            }
+        }
+        finalized
+    }
+
+    /// See [`InFlightLedger::happened_within`].
+    pub fn happened_within(&self, now: f32, window: f32, committed_only: bool) -> bool {
+        self.recognitions_within(now, window, committed_only)
+            .next()
+            .is_some()
+    }
+
+    /// All recognitions within `window` seconds before `now`, across in-flight
+    /// and finalized items.
+    pub fn recognitions_within(
+        &self,
+        now: f32,
+        window: f32,
+        committed_only: bool,
+    ) -> impl Iterator<Item = Recognition> + '_ {
+        let active = self
+            .active
+            .values()
+            .map(C::recognition)
+            .filter(move |rec| in_window(rec, now, window, committed_only));
+        active.chain(self.log.finalized_within(now, window, committed_only))
     }
 }
 

--- a/src/stats/calculators/in_flight.rs
+++ b/src/stats/calculators/in_flight.rs
@@ -212,6 +212,12 @@ impl<C> InFlightLedger<C> {
         self.active.push(item);
     }
 
+    /// Discard every in-flight item without finalizing any (e.g. abandoning a
+    /// candidate that never earned an event).
+    pub fn clear(&mut self) {
+        self.active.clear();
+    }
+
     /// The items currently in flight.
     pub fn in_flight(&self) -> &[C] {
         &self.active

--- a/src/stats/calculators/in_flight_tests.rs
+++ b/src/stats/calculators/in_flight_tests.rs
@@ -1,0 +1,190 @@
+use super::*;
+
+/// A minimal in-flight candidate for exercising the ledger. It accumulates a
+/// count, commits once that count crosses a threshold, and decides its boundary
+/// response based on whether it has committed.
+#[derive(Debug, Clone, PartialEq)]
+struct TestCandidate {
+    label: &'static str,
+    start_time: f32,
+    start_frame: usize,
+    samples: u32,
+    committed: bool,
+    /// Whether this candidate survives a `LivePlayEnded` boundary instead of
+    /// resolving to it (used to exercise `Disposition::Keep` from a boundary).
+    survives_live_play_end: bool,
+}
+
+impl TestCandidate {
+    fn new(label: &'static str, start_time: f32, start_frame: usize) -> Self {
+        Self {
+            label,
+            start_time,
+            start_frame,
+            samples: 0,
+            committed: false,
+            survives_live_play_end: false,
+        }
+    }
+}
+
+impl InFlightItem for TestCandidate {
+    fn recognition(&self) -> Recognition {
+        Recognition::new(self.start_time, self.start_frame, self.committed)
+    }
+
+    fn on_boundary(&mut self, boundary: Boundary) -> Disposition {
+        if boundary == Boundary::LivePlayEnded && self.survives_live_play_end {
+            return Disposition::Keep;
+        }
+        if self.committed {
+            Disposition::Finalize(FinalizeReason::Boundary(boundary))
+        } else {
+            Disposition::Discard
+        }
+    }
+}
+
+#[test]
+fn advance_keeps_finalizes_and_discards_in_one_pass() {
+    let mut ledger = InFlightLedger::<TestCandidate>::new();
+    ledger.arm(TestCandidate::new("keep", 0.0, 0));
+    ledger.arm(TestCandidate::new("finalize", 0.0, 0));
+    ledger.arm(TestCandidate::new("discard", 0.0, 0));
+
+    let finalized = ledger.advance(1.0, |candidate| match candidate.label {
+        "finalize" => Disposition::Finalize(FinalizeReason::Completed),
+        "discard" => Disposition::Discard,
+        _ => Disposition::Keep,
+    });
+
+    assert_eq!(finalized.len(), 1);
+    assert_eq!(finalized[0].0.label, "finalize");
+    assert_eq!(finalized[0].1, FinalizeReason::Completed);
+    // Only the kept candidate remains in flight.
+    assert_eq!(ledger.len(), 1);
+    assert_eq!(ledger.in_flight()[0].label, "keep");
+}
+
+#[test]
+fn advance_can_mutate_in_flight_state() {
+    let mut ledger = InFlightLedger::<TestCandidate>::new();
+    ledger.arm(TestCandidate::new("a", 0.0, 0));
+
+    let finalized = ledger.advance(0.5, |candidate| {
+        candidate.samples += 1;
+        Disposition::Keep
+    });
+    assert!(finalized.is_empty());
+    assert_eq!(ledger.in_flight()[0].samples, 1);
+}
+
+#[test]
+fn apply_boundary_finalizes_committed_and_discards_speculative() {
+    let mut ledger = InFlightLedger::<TestCandidate>::new();
+    let mut committed = TestCandidate::new("committed", 0.0, 0);
+    committed.committed = true;
+    ledger.arm(committed);
+    ledger.arm(TestCandidate::new("speculative", 0.0, 0));
+
+    let finalized = ledger.apply_boundary(Boundary::GoalScored);
+
+    assert_eq!(finalized.len(), 1);
+    assert_eq!(finalized[0].0.label, "committed");
+    assert_eq!(
+        finalized[0].1,
+        FinalizeReason::Boundary(Boundary::GoalScored)
+    );
+    // The speculative candidate was discarded; nothing is left in flight.
+    assert!(ledger.is_empty());
+}
+
+#[test]
+fn apply_boundary_can_keep_surviving_items() {
+    let mut ledger = InFlightLedger::<TestCandidate>::new();
+    let mut survivor = TestCandidate::new("survivor", 0.0, 0);
+    survivor.committed = true;
+    survivor.survives_live_play_end = true;
+    ledger.arm(survivor);
+
+    let finalized = ledger.apply_boundary(Boundary::LivePlayEnded);
+    assert!(finalized.is_empty());
+    assert_eq!(ledger.len(), 1);
+
+    // A different boundary still resolves it.
+    let finalized = ledger.apply_boundary(Boundary::ReplayEnded);
+    assert_eq!(finalized.len(), 1);
+    assert!(ledger.is_empty());
+}
+
+#[test]
+fn finish_flushes_everything_still_in_flight() {
+    let mut ledger = InFlightLedger::<TestCandidate>::new();
+    let mut committed = TestCandidate::new("committed", 0.0, 0);
+    committed.committed = true;
+    ledger.arm(committed);
+    ledger.arm(TestCandidate::new("speculative", 0.0, 0));
+
+    let finalized = ledger.finish();
+    assert_eq!(finalized.len(), 1);
+    assert_eq!(
+        finalized[0].1,
+        FinalizeReason::Boundary(Boundary::ReplayEnded)
+    );
+    assert!(ledger.is_empty(), "finish must leave nothing in flight");
+}
+
+#[test]
+fn happened_within_counts_finalized_events_by_recognition_time() {
+    let mut ledger = InFlightLedger::<TestCandidate>::new();
+    let mut candidate = TestCandidate::new("c", 1.0, 10);
+    candidate.committed = true;
+    ledger.arm(candidate);
+    // Finalizes at a later "now"; the recognition time (1.0) is what's logged.
+    let finalized = ledger.advance(2.0, |_| Disposition::Finalize(FinalizeReason::Completed));
+    assert_eq!(finalized.len(), 1);
+
+    // Recently after recognition: counts.
+    assert!(ledger.happened_within(2.0, 5.0, true));
+    // Window that excludes the recognition time: does not count.
+    assert!(!ledger.happened_within(9.0, 1.0, true));
+}
+
+#[test]
+fn happened_within_is_latent_for_in_flight_candidates() {
+    let mut ledger = InFlightLedger::<TestCandidate>::new();
+    ledger.arm(TestCandidate::new("speculative", 1.0, 10));
+
+    // Without committed_only, an in-flight (not yet finalized) candidate counts.
+    assert!(ledger.happened_within(1.5, 2.0, false));
+    // With committed_only, a speculative candidate must not count.
+    assert!(!ledger.happened_within(1.5, 2.0, true));
+
+    // Once it commits, the committed query sees it.
+    ledger.in_flight_mut()[0].committed = true;
+    assert!(ledger.happened_within(1.5, 2.0, true));
+}
+
+#[test]
+fn history_is_pruned_outside_the_window() {
+    let mut ledger = InFlightLedger::<TestCandidate>::with_history_window(3.0);
+    let mut candidate = TestCandidate::new("old", 0.0, 0);
+    candidate.committed = true;
+    ledger.arm(candidate);
+    ledger.advance(0.0, |_| Disposition::Finalize(FinalizeReason::Completed));
+    assert!(ledger.happened_within(0.0, 5.0, true));
+
+    // Advancing time well past the window prunes the old recognition.
+    ledger.advance(100.0, |_| Disposition::Keep);
+    assert!(!ledger.happened_within(100.0, 50.0, true));
+}
+
+#[test]
+fn discarded_items_do_not_appear_in_history() {
+    let mut ledger = InFlightLedger::<TestCandidate>::new();
+    ledger.arm(TestCandidate::new("speculative", 1.0, 10));
+    let finalized = ledger.advance(1.5, |_| Disposition::Discard);
+    assert!(finalized.is_empty());
+    // A discarded candidate never "happened".
+    assert!(!ledger.happened_within(1.5, 5.0, false));
+}

--- a/src/stats/calculators/in_flight_tests.rs
+++ b/src/stats/calculators/in_flight_tests.rs
@@ -202,3 +202,89 @@ fn discarded_items_do_not_appear_in_history() {
     // A discarded candidate never "happened".
     assert!(!ledger.happened_within(1.5, 5.0, false));
 }
+
+#[test]
+fn keyed_arm_replaces_and_looks_up_by_key() {
+    let mut ledger = KeyedInFlightLedger::<u32, TestCandidate>::new();
+    ledger.arm(7, TestCandidate::new("first", 0.0, 0));
+    assert!(ledger.contains(&7));
+    assert_eq!(ledger.get(&7).unwrap().label, "first");
+
+    // Arming the same key replaces the item.
+    ledger.arm(7, TestCandidate::new("second", 1.0, 1));
+    assert_eq!(ledger.len(), 1);
+    assert_eq!(ledger.get(&7).unwrap().label, "second");
+
+    ledger.get_mut(&7).unwrap().samples += 3;
+    assert_eq!(ledger.get(&7).unwrap().samples, 3);
+}
+
+#[test]
+fn keyed_advance_resolves_per_key() {
+    let mut ledger = KeyedInFlightLedger::<u32, TestCandidate>::new();
+    ledger.arm(1, TestCandidate::new("keep", 0.0, 0));
+    ledger.arm(2, TestCandidate::new("finalize", 0.0, 0));
+    ledger.arm(3, TestCandidate::new("discard", 0.0, 0));
+
+    let finalized = ledger.advance(1.0, |_key, candidate| match candidate.label {
+        "finalize" => Disposition::Finalize(FinalizeReason::Completed),
+        "discard" => Disposition::Discard,
+        _ => Disposition::Keep,
+    });
+
+    assert_eq!(finalized.len(), 1);
+    assert_eq!(finalized[0].0, 2);
+    assert_eq!(finalized[0].1.label, "finalize");
+    assert_eq!(finalized[0].2, FinalizeReason::Completed);
+    assert_eq!(ledger.len(), 1);
+    assert!(ledger.contains(&1));
+}
+
+#[test]
+fn keyed_finalize_logs_and_boundary_flushes() {
+    let mut ledger = KeyedInFlightLedger::<u32, TestCandidate>::new();
+    let mut committed = TestCandidate::new("c", 1.0, 10);
+    committed.committed = true;
+    ledger.arm(1, committed);
+
+    // Imperative finalize removes, logs, and returns the item.
+    let item = ledger.finalize(&1, FinalizeReason::Completed);
+    assert!(item.is_some());
+    assert!(ledger.is_empty());
+    assert!(ledger.happened_within(1.0, 1.0, true));
+
+    // Boundary handling mirrors the unkeyed ledger.
+    let mut committed2 = TestCandidate::new("c2", 2.0, 21);
+    committed2.committed = true;
+    ledger.arm(2, TestCandidate::new("speculative", 2.0, 20));
+    ledger.arm(3, committed2);
+    let finalized = ledger.apply_boundary(Boundary::GoalScored);
+    assert_eq!(finalized.len(), 1);
+    assert_eq!(finalized[0].0, 3);
+    assert!(ledger.is_empty(), "speculative discarded, committed finalized");
+}
+
+#[test]
+fn keyed_entry_or_insert_with_inserts_once() {
+    let mut ledger = KeyedInFlightLedger::<u32, TestCandidate>::new();
+    ledger
+        .entry_or_insert_with(5, || TestCandidate::new("created", 0.0, 0))
+        .samples += 1;
+    ledger
+        .entry_or_insert_with(5, || TestCandidate::new("not-created", 9.0, 9))
+        .samples += 1;
+    assert_eq!(ledger.len(), 1);
+    let candidate = ledger.get(&5).unwrap();
+    assert_eq!(candidate.label, "created");
+    assert_eq!(candidate.samples, 2);
+}
+
+#[test]
+fn keyed_clear_discards_without_logging() {
+    let mut ledger = KeyedInFlightLedger::<u32, TestCandidate>::new();
+    ledger.arm(1, TestCandidate::new("a", 1.0, 10));
+    ledger.arm(2, TestCandidate::new("b", 1.0, 11));
+    ledger.clear();
+    assert!(ledger.is_empty());
+    assert!(!ledger.happened_within(1.0, 5.0, false));
+}

--- a/src/stats/calculators/in_flight_tests.rs
+++ b/src/stats/calculators/in_flight_tests.rs
@@ -142,7 +142,9 @@ fn finalize_all_drains_and_logs_every_item() {
 
     let finalized = ledger.finalize_all(FinalizeReason::Superseded);
     assert_eq!(finalized.len(), 2);
-    assert!(finalized.iter().all(|(_, reason)| *reason == FinalizeReason::Superseded));
+    assert!(finalized
+        .iter()
+        .all(|(_, reason)| *reason == FinalizeReason::Superseded));
     assert!(ledger.is_empty());
     // Both are now queryable as having happened (committed, by recognition time).
     assert!(ledger.happened_within(1.0, 1.0, true));
@@ -261,7 +263,10 @@ fn keyed_finalize_logs_and_boundary_flushes() {
     let finalized = ledger.apply_boundary(Boundary::GoalScored);
     assert_eq!(finalized.len(), 1);
     assert_eq!(finalized[0].0, 3);
-    assert!(ledger.is_empty(), "speculative discarded, committed finalized");
+    assert!(
+        ledger.is_empty(),
+        "speculative discarded, committed finalized"
+    );
 }
 
 #[test]

--- a/src/stats/calculators/in_flight_tests.rs
+++ b/src/stats/calculators/in_flight_tests.rs
@@ -135,6 +135,20 @@ fn finish_flushes_everything_still_in_flight() {
 }
 
 #[test]
+fn finalize_all_drains_and_logs_every_item() {
+    let mut ledger = InFlightLedger::<TestCandidate>::new();
+    ledger.arm(TestCandidate::new("a", 1.0, 10));
+    ledger.arm(TestCandidate::new("b", 1.0, 11));
+
+    let finalized = ledger.finalize_all(FinalizeReason::Superseded);
+    assert_eq!(finalized.len(), 2);
+    assert!(finalized.iter().all(|(_, reason)| *reason == FinalizeReason::Superseded));
+    assert!(ledger.is_empty());
+    // Both are now queryable as having happened (committed, by recognition time).
+    assert!(ledger.happened_within(1.0, 1.0, true));
+}
+
+#[test]
 fn happened_within_counts_finalized_events_by_recognition_time() {
     let mut ledger = InFlightLedger::<TestCandidate>::new();
     let mut candidate = TestCandidate::new("c", 1.0, 10);

--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -86,9 +86,26 @@ struct ActiveKickoff {
     resolution: Option<KickoffResolutionSnapshot>,
 }
 
+impl InFlightItem for ActiveKickoff {
+    fn recognition(&self) -> Recognition {
+        // A kickoff phase is always a real kickoff, so it is committed from the
+        // moment it is recognized.
+        Recognition::committed(self.start_time, self.start_frame)
+    }
+
+    fn on_boundary(&mut self, _boundary: Boundary) -> Disposition {
+        // A kickoff that is still in flight when the stream ends never reached a
+        // resolution; emitting a truncated event would be misleading, so it is
+        // discarded (preserving the previous "drop the unfinished kickoff"
+        // behavior, now handled structurally rather than by omission). Goal and
+        // live-play finalization happen earlier through `should_finish`.
+        Disposition::Discard
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct KickoffCalculator {
-    active: Option<ActiveKickoff>,
+    active: InFlightLedger<ActiveKickoff>,
     events: EventStream<KickoffEvent>,
 }
 
@@ -372,7 +389,7 @@ impl KickoffCalculator {
     }
 
     fn start_kickoff(&mut self, frame: &FrameInfo, players: &PlayerFrameState) {
-        self.active = Some(ActiveKickoff {
+        self.active.arm(ActiveKickoff {
             start_time: frame.time,
             start_frame: frame.frame_number,
             live_action_start_time: None,
@@ -391,6 +408,13 @@ impl KickoffCalculator {
             speed_flip_players: HashSet::new(),
             resolution: None,
         });
+    }
+
+    /// Finalize any in-flight kickoff at end of stream. Routed through the
+    /// ledger so the boundary is handled uniformly; an unresolved kickoff is
+    /// discarded rather than emitted (see `ActiveKickoff::on_boundary`).
+    pub fn finish(&mut self) {
+        let _ = self.active.finish();
     }
 
     fn observe_movement_start(
@@ -1238,11 +1262,11 @@ impl KickoffCalculator {
         ctx: KickoffUpdateContext<'_>,
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
-        if ctx.gameplay.kickoff_phase_active() && self.active.is_none() {
+        if ctx.gameplay.kickoff_phase_active() && self.active.is_empty() {
             self.start_kickoff(ctx.frame, ctx.players);
         }
 
-        let Some(active) = self.active.as_mut() else {
+        let Some(active) = self.active.in_flight_mut().first_mut() else {
             return Ok(());
         };
         Self::observe_movement_start(active, ctx.frame, ctx.gameplay);
@@ -1258,8 +1282,18 @@ impl KickoffCalculator {
             });
         }
 
-        if Self::should_finish(active, ctx.frame, ctx.gameplay, ctx.events) {
-            let active = self.active.take().expect("active kickoff should exist");
+        // Natural finalization: the kickoff resolves once `should_finish` is met
+        // (which already accounts for goals and goal-replay). The ledger keeps
+        // the in-flight kickoff queryable and guarantees it is resolved at the
+        // end of the stream.
+        let finished = self.active.advance(ctx.frame.time, |active| {
+            if Self::should_finish(active, ctx.frame, ctx.gameplay, ctx.events) {
+                Disposition::Finalize(FinalizeReason::Completed)
+            } else {
+                Disposition::Keep
+            }
+        });
+        for (active, _reason) in finished {
             let event = Self::finish_event(
                 active,
                 ctx.frame,

--- a/src/stats/calculators/mod.rs
+++ b/src/stats/calculators/mod.rs
@@ -15,6 +15,8 @@ mod frame_components;
 pub use frame_components::*;
 mod event_stream;
 pub use event_stream::*;
+mod in_flight;
+pub use in_flight::*;
 mod event_definition;
 pub use event_definition::*;
 mod continuous_ball_control;

--- a/src/stats/calculators/speed_flip.rs
+++ b/src/stats/calculators/speed_flip.rs
@@ -98,10 +98,22 @@ struct ActiveSpeedFlipCandidate {
     latest_frame: usize,
 }
 
+impl InFlightItem for ActiveSpeedFlipCandidate {
+    fn recognition(&self) -> Recognition {
+        // Speculative: a candidate can be pruned (stale), discarded at a
+        // boundary, or evaluate to no speed flip before emitting.
+        Recognition::speculative(self.start_time, self.start_frame)
+    }
+
+    fn on_boundary(&mut self, _boundary: Boundary) -> Disposition {
+        Disposition::Discard
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SpeedFlipCalculator {
     events: EventStream<SpeedFlipEvent>,
-    active_candidates: HashMap<PlayerId, ActiveSpeedFlipCandidate>,
+    active_candidates: KeyedInFlightLedger<PlayerId, ActiveSpeedFlipCandidate>,
     previous_dodge_active: HashMap<PlayerId, bool>,
     last_ground_contacts: HashMap<PlayerId, f32>,
     kickoff_approach_active_last_frame: bool,
@@ -325,7 +337,7 @@ impl SpeedFlipCalculator {
         let forward_z = (rotation * glam::Vec3::X).z;
         let initial_boost_alignment = Self::boost_alignment(player);
 
-        self.active_candidates.insert(
+        self.active_candidates.arm(
             player.player_id.clone(),
             ActiveSpeedFlipCandidate {
                 is_team_0: player.is_team_0,
@@ -580,7 +592,7 @@ impl SpeedFlipCalculator {
     fn finalize_candidates(&mut self, frame: &FrameInfo, force_all: bool) {
         let mut finished_candidates = Vec::new();
 
-        for (player_id, candidate) in &self.active_candidates {
+        for (player_id, candidate) in self.active_candidates.iter() {
             let duration = frame.time - candidate.start_time;
             if force_all || duration >= SPEED_FLIP_EVALUATION_SECONDS {
                 finished_candidates.push((
@@ -600,7 +612,10 @@ impl SpeedFlipCalculator {
         });
 
         for (_, _, _, player_id) in finished_candidates {
-            let Some(candidate) = self.active_candidates.remove(&player_id) else {
+            let Some(candidate) = self
+                .active_candidates
+                .finalize(&player_id, FinalizeReason::Completed)
+            else {
                 continue;
             };
             if let Some(event) = Self::candidate_event(&player_id, candidate) {
@@ -620,7 +635,7 @@ impl SpeedFlipCalculator {
         self.events.begin_update();
         let kickoff_approach_active = Self::kickoff_approach_active(gameplay);
         if !live_play_state.is_live_play && !kickoff_approach_active {
-            self.active_candidates.clear();
+            self.active_candidates.apply_boundary(Boundary::LivePlayEnded);
             self.current_kickoff_start_time = None;
             self.kickoff_approach_active_last_frame = false;
             self.last_ground_contacts.clear();
@@ -638,7 +653,7 @@ impl SpeedFlipCalculator {
             self.maybe_start_candidate(frame, gameplay, ball, player, live_play_state);
         }
 
-        for (player_id, candidate) in &mut self.active_candidates {
+        for (player_id, candidate) in self.active_candidates.iter_mut() {
             let Some(player) = Self::player_by_id(players, player_id) else {
                 continue;
             };

--- a/src/stats/calculators/speed_flip.rs
+++ b/src/stats/calculators/speed_flip.rs
@@ -635,7 +635,8 @@ impl SpeedFlipCalculator {
         self.events.begin_update();
         let kickoff_approach_active = Self::kickoff_approach_active(gameplay);
         if !live_play_state.is_live_play && !kickoff_approach_active {
-            self.active_candidates.apply_boundary(Boundary::LivePlayEnded);
+            self.active_candidates
+                .apply_boundary(Boundary::LivePlayEnded);
             self.current_kickoff_start_time = None;
             self.kickoff_approach_active_last_frame = false;
             self.last_ground_contacts.clear();

--- a/src/stats/calculators/touch.rs
+++ b/src/stats/calculators/touch.rs
@@ -133,10 +133,24 @@ struct PendingTouchBallMovementCredit {
     movement: TouchBallMovement,
 }
 
+impl InFlightItem for PendingTouchBallMovementCredit {
+    fn recognition(&self) -> Recognition {
+        // A touch credit always corresponds to a real touch, so it is committed
+        // from the moment it is armed.
+        Recognition::committed(self.movement.start_time, self.movement.start_frame)
+    }
+
+    fn on_boundary(&mut self, boundary: Boundary) -> Disposition {
+        // The credit window always closes at a boundary: the accumulated travel
+        // up to the goal / stoppage / end of replay is exactly what we keep.
+        Disposition::Finalize(FinalizeReason::Boundary(boundary))
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct TouchCalculator {
     events: EventStream<TouchClassificationEvent>,
-    pending_ball_movement_credit: Option<PendingTouchBallMovementCredit>,
+    ball_movement: InFlightLedger<PendingTouchBallMovementCredit>,
     active_touch_index_by_player: HashMap<PlayerId, usize>,
     previous_ball_velocity: Option<glam::Vec3>,
     previous_ball_position: Option<glam::Vec3>,
@@ -157,11 +171,31 @@ impl TouchCalculator {
     }
 
     pub fn flush_pending_ball_movement_credit(&mut self) {
-        let Some(pending) = self.pending_ball_movement_credit.take() else {
-            return;
-        };
-        if let Some(event) = self.events.get_mut(pending.touch_index) {
-            event.ball_movement = Some(pending.movement.finalized());
+        let finalized = self.ball_movement.finalize_all(FinalizeReason::Completed);
+        self.write_finalized_ball_movement(finalized);
+    }
+
+    /// Finalize any pending ball-movement credit at end of stream. Routed
+    /// through the ledger so the boundary is handled uniformly and can't be
+    /// forgotten.
+    pub fn finish(&mut self) {
+        let finalized = self.ball_movement.finish();
+        self.write_finalized_ball_movement(finalized);
+    }
+
+    fn finalize_ball_movement_at_boundary(&mut self, boundary: Boundary) {
+        let finalized = self.ball_movement.apply_boundary(boundary);
+        self.write_finalized_ball_movement(finalized);
+    }
+
+    fn write_finalized_ball_movement(
+        &mut self,
+        finalized: Vec<(PendingTouchBallMovementCredit, FinalizeReason)>,
+    ) {
+        for (pending, _reason) in finalized {
+            if let Some(event) = self.events.get_mut(pending.touch_index) {
+                event.ball_movement = Some(pending.movement.finalized());
+            }
         }
     }
 
@@ -365,35 +399,44 @@ impl TouchCalculator {
         let Some(&touch_index) = self.active_touch_index_by_player.get(player_id) else {
             return;
         };
-        let Some(pending) = self.pending_ball_movement_credit.as_mut() else {
-            if let Some(event) = self.events.get_mut(touch_index) {
-                event.player_position = player_position.or(event.player_position);
-                event.ball_movement = Some(movement.clone());
-            }
-            self.pending_ball_movement_credit = Some(PendingTouchBallMovementCredit {
-                touch_index,
-                movement,
-            });
-            return;
-        };
+        let pending_index = self
+            .ball_movement
+            .in_flight()
+            .first()
+            .map(|pending| pending.touch_index);
 
-        if pending.touch_index == touch_index {
-            pending.movement.absorb_delta(movement);
+        if pending_index == Some(touch_index) {
+            // Same touch still in flight: fold this frame's travel into it.
+            let merged = {
+                let pending = self
+                    .ball_movement
+                    .in_flight_mut()
+                    .first_mut()
+                    .expect("pending credit present");
+                pending.movement.absorb_delta(movement);
+                pending.movement.clone()
+            };
             if let Some(event) = self.events.get_mut(touch_index) {
                 event.player_position = player_position.or(event.player_position);
-                event.ball_movement = Some(pending.movement.clone());
+                event.ball_movement = Some(merged);
             }
-        } else {
-            self.flush_pending_ball_movement_credit();
-            if let Some(event) = self.events.get_mut(touch_index) {
-                event.player_position = player_position.or(event.player_position);
-                event.ball_movement = Some(movement.clone());
-            }
-            self.pending_ball_movement_credit = Some(PendingTouchBallMovementCredit {
-                touch_index,
-                movement,
-            });
+            return;
         }
+
+        // A different touch (or none) is in flight: supersede the old credit and
+        // arm a fresh one for this touch.
+        if pending_index.is_some() {
+            let finalized = self.ball_movement.finalize_all(FinalizeReason::Superseded);
+            self.write_finalized_ball_movement(finalized);
+        }
+        if let Some(event) = self.events.get_mut(touch_index) {
+            event.player_position = player_position.or(event.player_position);
+            event.ball_movement = Some(movement.clone());
+        }
+        self.ball_movement.arm(PendingTouchBallMovementCredit {
+            touch_index,
+            movement,
+        });
     }
 
     fn resolved_fifty_fifty_winner(event: &FiftyFiftyEvent) -> Option<(&PlayerId, bool)> {
@@ -483,7 +526,7 @@ impl TouchCalculator {
     ) {
         let current_ball_position = ball.position();
         if !live_play_state.is_live_play {
-            self.flush_pending_ball_movement_credit();
+            self.finalize_ball_movement_at_boundary(Boundary::LivePlayEnded);
             self.previous_ball_position = current_ball_position;
             self.pending_fifty_fifty_movement = None;
             return;
@@ -555,7 +598,7 @@ impl TouchCalculator {
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
         if !live_play_state.is_live_play {
-            self.flush_pending_ball_movement_credit();
+            self.finalize_ball_movement_at_boundary(Boundary::LivePlayEnded);
             self.previous_ball_velocity = ball.velocity();
             self.previous_ball_position = ball.position();
             self.pending_fifty_fifty_movement = None;

--- a/src/stats/calculators/whiff.rs
+++ b/src/stats/calculators/whiff.rs
@@ -331,7 +331,8 @@ impl WhiffCalculator {
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
         if !live_play_state.is_live_play {
-            self.active_candidates.apply_boundary(Boundary::LivePlayEnded);
+            self.active_candidates
+                .apply_boundary(Boundary::LivePlayEnded);
             return Ok(());
         }
         self.finish_touched_candidates(frame, touch_state);

--- a/src/stats/calculators/whiff.rs
+++ b/src/stats/calculators/whiff.rs
@@ -82,9 +82,23 @@ struct ActiveWhiffCandidate {
     aerial: bool,
 }
 
+impl InFlightItem for ActiveWhiffCandidate {
+    fn recognition(&self) -> Recognition {
+        // A whiff candidate is speculative: it only becomes an event if the
+        // player misses (exit/timeout) or is beaten to the ball. A touch by the
+        // candidate's own player, or a boundary, discards it.
+        Recognition::speculative(self.start_time, self.closest_frame)
+    }
+
+    fn on_boundary(&mut self, _boundary: Boundary) -> Disposition {
+        // An in-flight candidate at a boundary never resolved into a whiff.
+        Disposition::Discard
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct WhiffCalculator {
-    active_candidates: HashMap<PlayerId, ActiveWhiffCandidate>,
+    active_candidates: KeyedInFlightLedger<PlayerId, ActiveWhiffCandidate>,
     events: EventStream<WhiffEvent>,
 }
 
@@ -191,14 +205,25 @@ impl WhiffCalculator {
 
         let candidate_players = self.active_candidates.keys().cloned().collect::<Vec<_>>();
         for player_id in candidate_players {
-            let Some(candidate) = self.active_candidates.remove(&player_id) else {
+            let Some((candidate_player, candidate_team)) = self
+                .active_candidates
+                .get(&player_id)
+                .map(|candidate| (candidate.player.clone(), candidate.is_team_0))
+            else {
                 continue;
             };
-            if touched_players.contains(&candidate.player) {
-                continue;
-            }
-            if touched_teams.contains(&!candidate.is_team_0) {
-                self.emit_candidate(candidate, frame, WhiffEventKind::BeatenToBall);
+            if touched_players.contains(&candidate_player) {
+                // The candidate's own player touched the ball: not a whiff.
+                self.active_candidates.discard(&player_id);
+            } else if touched_teams.contains(&!candidate_team) {
+                if let Some(candidate) = self
+                    .active_candidates
+                    .finalize(&player_id, FinalizeReason::Completed)
+                {
+                    self.emit_candidate(candidate, frame, WhiffEventKind::BeatenToBall);
+                }
+            } else {
+                self.active_candidates.discard(&player_id);
             }
         }
     }
@@ -268,7 +293,10 @@ impl WhiffCalculator {
                 if distance > WHIFF_EXIT_DISTANCE
                     || frame.time - candidate.start_time > WHIFF_MAX_CANDIDATE_SECONDS
                 {
-                    if let Some(candidate) = self.active_candidates.remove(&player_id) {
+                    if let Some(candidate) = self
+                        .active_candidates
+                        .finalize(&player_id, FinalizeReason::Completed)
+                    {
                         self.emit_candidate(candidate, frame, WhiffEventKind::Whiff);
                     }
                 }
@@ -278,7 +306,7 @@ impl WhiffCalculator {
             if let Some(candidate) =
                 Self::whiff_candidate(frame, ball_position, ball_velocity, player)
             {
-                self.active_candidates.insert(player_id, candidate);
+                self.active_candidates.arm(player_id, candidate);
             }
         }
 
@@ -289,7 +317,7 @@ impl WhiffCalculator {
             .cloned()
             .collect::<Vec<_>>();
         for player_id in missing_players {
-            self.active_candidates.remove(&player_id);
+            self.active_candidates.discard(&player_id);
         }
     }
 
@@ -303,7 +331,7 @@ impl WhiffCalculator {
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
         if !live_play_state.is_live_play {
-            self.active_candidates.clear();
+            self.active_candidates.apply_boundary(Boundary::LivePlayEnded);
             return Ok(());
         }
         self.finish_touched_candidates(frame, touch_state);
@@ -318,6 +346,13 @@ impl WhiffCalculator {
             }
         }
         Ok(())
+    }
+
+    /// Resolve any in-flight candidates at end of stream. An unresolved
+    /// candidate never became a whiff, so it is discarded (handled uniformly via
+    /// the ledger rather than left to drop implicitly).
+    pub fn finish(&mut self) {
+        self.active_candidates.finish();
     }
 }
 


### PR DESCRIPTION
Introduces a principled, uniform abstraction for **in-flight events** — analysis results that are recognized on one frame but finalized later, after accumulating metadata over subsequent frames — and migrates 7 calculators onto it.

## Why
Calculators hand-rolled the same lifecycle (an `Active`/`Pending`/candidate struct accumulating state, emitted later once a condition is met) and each separately remembered to finalize pending state at boundaries (a goal, play leaving the live phase, end of replay). Miss a boundary and a pending item silently leaks or absorbs data across it. There was also no uniform way to ask "did event X happen recently?" *latently* — i.e. counting events recognized but not yet finalized.

## The abstraction (`src/stats/calculators/in_flight.rs`)
- `Boundary` (`LivePlayEnded` / `GoalScored` / `ReplayEnded` — no period/overtime; the data has no such concept), `FinalizeReason`, `Recognition { time, frame, committed }`, `Disposition`, and the `InFlightItem` trait.
- `InFlightLedger<C>` (unordered set) and `KeyedInFlightLedger<K, C>` (one item per subject, e.g. per player). Both provide:
  - **uniform boundary finalization** (`apply_boundary` / `finish`) so a pending item can't be forgotten, plus a guaranteed end-of-stream flush;
  - a **latent recognition log** — `happened_within(now, window, committed_only)` counts finalized *and* in-flight events, with `committed_only` so speculative candidates don't give false positives.
- 15 unit tests.

## Migrated calculators (all behavior-preserving)
| Calculator | Container | Notes |
|---|---|---|
| touch | `InFlightLedger` (emit-early/patch-in-place) | the motivating goal-mid-touch case; boundary flush now structural |
| kickoff | `InFlightLedger` (single) | end-of-stream now explicit (unresolved kickoff discarded) |
| controlled_play | `InFlightLedger` (single, validity-gated) | |
| whiff | `KeyedInFlightLedger` | speculative candidates |
| flip_impulse | `KeyedInFlightLedger` | sorted emission preserved |
| speed_flip | `KeyedInFlightLedger` | sorted emission preserved |
| double_tap | `KeyedInFlightLedger` | gains structural boundary safety |

## Not migrated (deliberately)
- **rush** — emits mid-flight and stays active; its finalize doesn't emit, so `on_boundary` can't express it. Already handles its boundaries.
- **wall_aerial** — multi-stage 3-map progression, not a simple in-flight→finalize. Already handles its boundaries.
- **fifty_fifty latent query** — fifty_fifty already exposes its in-flight `active_event` to touch; rewiring it through the ledger's latent-query API is a natural follow-up.

Full lib suite: **601 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)