### PR TITLE
Centralize boost 0-255 → 0-100 conversion in @rlrml/player

### DIFF
--- a/js/player/src/boost-units.ts
+++ b/js/player/src/boost-units.ts
@@ -1,0 +1,31 @@
+// Canonical boost-unit conversion for JavaScript/TypeScript consumers of
+// subtr-actor.
+//
+// Rocket League replays store boost on a raw `0..=255` scale (a full tank is
+// 255 and a standard kickoff starts at 85). subtr-actor keeps boost in these
+// raw units all the way through processing and the bindings; the rescale to the
+// `0..=100` display scale must happen at display time. This module is the one
+// place the JS bindings perform that conversion, so every consumer renders
+// boost the same way.
+//
+// Mirrors `boost_amount_to_percent` / `boost_percent_to_amount` in
+// `src/domain/boost_units.rs`.
+
+/** The maximum raw boost value stored in replay data. */
+export const BOOST_RAW_MAX = 255;
+
+/** Converts a raw replay boost amount (`0..=255`) to a percentage (`0..=100`). */
+export function boostAmountToPercent(amount: number): number;
+export function boostAmountToPercent(amount: number | null | undefined): number | null;
+export function boostAmountToPercent(amount: number | null | undefined): number | null {
+  if (amount == null) return null;
+  return (amount * 100) / BOOST_RAW_MAX;
+}
+
+/** Converts a boost percentage (`0..=100`) to a raw replay boost amount (`0..=255`). */
+export function boostPercentToAmount(percent: number): number;
+export function boostPercentToAmount(percent: number | null | undefined): number | null;
+export function boostPercentToAmount(percent: number | null | undefined): number | null {
+  if (percent == null) return null;
+  return (percent * BOOST_RAW_MAX) / 100;
+}

--- a/js/player/src/lib.ts
+++ b/js/player/src/lib.ts
@@ -13,6 +13,7 @@ export {
 export type { BallchasingReplayDownloadOptions } from "./ballchasing";
 export { createBallchasingOverlayPlugin } from "./ballchasing-overlay";
 export type { BallchasingOverlayPluginOptions } from "./ballchasing-overlay";
+export { BOOST_RAW_MAX, boostAmountToPercent, boostPercentToAmount } from "./boost-units";
 export { createBoostPadOverlayPlugin } from "./boost-pad-overlay";
 export type { BoostPadOverlayPluginOptions } from "./boost-pad-overlay";
 export { createBoostPickupAnimationPlugin } from "./boost-pickup-animation";

--- a/js/player/test/boost-units.test.ts
+++ b/js/player/test/boost-units.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { BOOST_RAW_MAX, boostAmountToPercent, boostPercentToAmount } from "../src/boost-units";
+
+test("converts raw replay boost amounts to a 0-100 percentage", () => {
+  assert.equal(boostAmountToPercent(BOOST_RAW_MAX), 100);
+  assert.equal(boostAmountToPercent(0), 0);
+  assert.equal(boostAmountToPercent(BOOST_RAW_MAX / 3), 100 / 3);
+});
+
+test("passes nullish boost amounts through unchanged", () => {
+  assert.equal(boostAmountToPercent(null), null);
+  assert.equal(boostAmountToPercent(undefined), null);
+});
+
+test("round-trips percentages back to raw boost amounts", () => {
+  assert.equal(boostPercentToAmount(100), BOOST_RAW_MAX);
+  assert.equal(boostPercentToAmount(0), 0);
+  assert.equal(boostPercentToAmount(null), null);
+});

--- a/js/stat-evaluation-player/src/boostFormatting.ts
+++ b/js/stat-evaluation-player/src/boostFormatting.ts
@@ -1,12 +1,14 @@
-const BOOST_RAW_MAX = 255;
+import { boostAmountToPercent } from "@rlrml/player";
 
-export function toBoostDisplayUnits(amount: number): number {
-  return (amount * 100) / BOOST_RAW_MAX;
-}
+// The raw `0..=255` -> `0..=100` conversion lives in `@rlrml/player`
+// (`boostAmountToPercent`) so every subtr-actor JS consumer rescales boost the
+// same way. This module keeps the stat-player display conventions (the `"?"`
+// missing-value sentinel and the respawn-inclusive bound) on top of it.
+export { boostAmountToPercent as toBoostDisplayUnits } from "@rlrml/player";
 
 export function formatBoostDisplayAmount(amount: number | null | undefined): string {
   if (amount == null) return "?";
-  return toBoostDisplayUnits(amount).toFixed(0);
+  return boostAmountToPercent(amount).toFixed(0);
 }
 
 export function formatCollectedWithRespawnBound(


### PR DESCRIPTION
## Why

Rocket League replays store boost on a raw `0..=255` scale, and subtr-actor keeps it raw all the way through processing and the JS bindings — the rescale to the `0..=100` display scale has to happen at display time. That conversion was being re-implemented per consumer: `stat-evaluation-player`'s `boostFormatting.ts` had its own `BOOST_RAW_MAX = 255` + formula, hand-mirroring `boost_amount_to_percent` in `src/domain/boost_units.rs`, and downstream apps (e.g. rocket-sense's web frontend) were doing the same `* 100 / 255` independently. Anyone consuming subtr-actor for display needs this, so it belongs in the shared library.

## What

- Add a dependency-free `boost-units` module to **`@rlrml/player`** as the single JS home for the conversion:
  - `boostAmountToPercent(amount)` — raw `0..=255` → `0..=100` (overloaded to pass `null`/`undefined` through for display call sites)
  - `boostPercentToAmount(percent)` — the inverse, mirroring the Rust pair
  - `BOOST_RAW_MAX` constant
  - Mirrors `boost_amount_to_percent` / `boost_percent_to_amount` in `src/domain/boost_units.rs`.
- Export the helpers from the package barrel (`js/player/src/lib.ts`).
- **Expose `@rlrml/player/boost-units` as a first-class subpath export** and emit it as its own entry from the lib build, so consumers can import the conversion without pulling in the full player (three.js / wasm). The main barrel re-uses the same entry, so the conversion is single-sourced even in the built output (`dist/index.js` imports `./dist/boost-units.js`, which is ~0.2 kB and dependency-free).
- Route `stat-evaluation-player`'s `boostFormatting.ts` through the shared helper, dropping its duplicate constant/formula while keeping that package's display conventions (`"?"` missing-value sentinel, respawn-inclusive bound). `toBoostDisplayUnits` stays as a re-export alias, so its ~15 call sites are untouched.

## Verification

- `vite build` emits `dist/boost-units.js` (dependency-free) + `dist/index.js` (which imports the shared `./boost-units.js`); types build emits `dist/boost-units.d.ts`.
- `tsc --noEmit` clean in both `js/player` and `js/stat-evaluation-player`.
- New `js/player/test/boost-units.test.ts` passes (conversion, nullish pass-through, round-trip).
- Existing `js/stat-evaluation-player/src/boostFormatting.test.ts` still passes through the shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)