### PR TITLE
Expose @rlrml/player/boost-units as a dependency-free subpath export

### DIFF
--- a/js/player/package.json
+++ b/js/player/package.json
@@ -16,6 +16,10 @@
       "types": "./dist/lib.d.ts",
       "import": "./dist/index.js"
     },
+    "./boost-units": {
+      "types": "./dist/boost-units.d.ts",
+      "import": "./dist/boost-units.js"
+    },
     "./generated/*": {
       "types": "./dist/generated/*.d.ts"
     },

--- a/js/player/vite.config.ts
+++ b/js/player/vite.config.ts
@@ -28,9 +28,12 @@ export default defineConfig({
     outDir: distDir,
     emptyOutDir: true,
     lib: {
-      entry: path.resolve(srcDir, "lib.ts"),
-      name: "SubtrActorPlayer",
-      fileName: "index",
+      // `boost-units` is a dependency-free entry so consumers can rescale boost
+      // for display without pulling in the full player (three.js / wasm).
+      entry: {
+        index: path.resolve(srcDir, "lib.ts"),
+        "boost-units": path.resolve(srcDir, "boost-units.ts"),
+      },
       formats: ["es"],
     },
     rollupOptions: {


### PR DESCRIPTION
Follow-up to #118. That PR added the shared `boost-units` module and barrel export, but the subpath-export commit didn't make it into the merge — this re-lands it on its own.

## What

- Add a `./boost-units` subpath export to `@rlrml/player` and emit it as its own entry from the lib build, so consumers can import the raw `0..=255 → 0..=100` boost conversion **without pulling in the full player (three.js / wasm)**.
- The main barrel re-uses the same entry, so the conversion stays single-sourced even in the built output (`dist/index.js` imports `./boost-units.js`).

## Why

Downstream apps (e.g. rocket-sense's web frontend) need a clean, self-contained import target for boost display units. With this, `import { boostAmountToPercent } from "@rlrml/player/boost-units"` resolves natively against the package's own exports — no barrel, no heavy deps.

## Verification

- `vite build` emits `dist/boost-units.js` (~0.23 kB, dependency-free) + `dist/boost-units.d.ts`; `dist/index.js` imports the shared `./boost-units.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)