### PR TITLE
Use shared boostAmountToPercent for boost-meter rendering

### DIFF
--- a/js/player/src/ballchasing-overlay.ts
+++ b/js/player/src/ballchasing-overlay.ts
@@ -4,6 +4,7 @@ import type {
   ReplayPlayerPluginContext,
   ReplayPlayerRenderContext,
 } from "./types";
+import { boostAmountToPercent } from "./boost-units";
 
 export interface BallchasingOverlayPluginOptions {
   showFloatingNames?: boolean;
@@ -280,7 +281,7 @@ function setBoostBar(
     return;
   }
 
-  const percent = Math.max(0, Math.min(100, Math.round((amount / 255) * 100)));
+  const percent = Math.max(0, Math.min(100, Math.round(boostAmountToPercent(amount))));
   fill.style.width = `${percent}%`;
   text.textContent = `${percent} ${playerName}`;
 }

--- a/js/player/src/scene.ts
+++ b/js/player/src/scene.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import type { ReplayModel } from "./types";
+import { boostAmountToPercent } from "./boost-units";
 import { getReplayHitboxOverlayTransform, type ReplayHitboxSpec } from "./hitboxes";
 
 const HITBOX_OVERLAY_FILL_OPACITY = 0.08;
@@ -818,7 +819,7 @@ export function updateBoostMeter(
   meter.fillMesh.position.x = -(1 - fraction) * halfWidth;
   meter.fillMesh.position.y = -18;
 
-  const percent = Math.max(0, Math.min(100, Math.round((amount / 255) * 100)));
+  const percent = Math.max(0, Math.min(100, Math.round(boostAmountToPercent(amount))));
   if (meter.lastPercent !== percent) {
     const { labelContext, labelCanvas, labelTexture } = meter;
     labelContext.clearRect(0, 0, labelCanvas.width, labelCanvas.height);


### PR DESCRIPTION
Follow-up to #118 / #119. The shared `0..=255 → 0..=100` boost conversion now lives in `boost-units` (`boostAmountToPercent`), but two boost-meter renderers in the player still hand-rolled it as `(amount / 255) * 100`:

- `js/player/src/scene.ts` — the 3D boost meter label
- `js/player/src/ballchasing-overlay.ts` — the ballchasing overlay boost bars

Both now call the shared `boostAmountToPercent` from `./boost-units`, so the conversion lives in exactly one place across the package. The display-side `Math.round` + `[0, 100]` clamp are unchanged (behavior-preserving).

## Verification

- `tsc --noEmit` clean.
- `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)