### PR TITLE
fix(stats): attribute kickoff goals landing after kickoff's logical close

### DIFF
--- a/src/stats/analysis_graph/nodes/mod.rs
+++ b/src/stats/analysis_graph/nodes/mod.rs
@@ -8,14 +8,14 @@ use crate::stats::calculators::{
     DoubleTapGoalCalculator, EmptyNetGoalCalculator, FiftyFiftyCalculator, FiftyFiftyState,
     FlickCalculator, FlickGoalCalculator, FlipImpulseCalculator, FlipResetGoalCalculator,
     FrameEventsState, FrameInfo, GameplayState, HalfFlipCalculator, HalfVolleyCalculator,
-    HalfVolleyGoalCalculator, HighAerialGoalCalculator, KickoffCalculator, LivePlayState,
-    LongDistanceGoalCalculator, MatchStatsCalculator, MovementCalculator, MustyFlickCalculator,
-    OneTimerCalculator, OneTimerGoalCalculator, OwnHalfGoalCalculator, PassCalculator,
-    PassingGoalCalculator, PlayerFrameState, PlayerVerticalState, PositioningCalculator,
-    PossessionCalculator, PossessionState, PowerslideCalculator, RotationCalculator,
-    RushCalculator, SpeedFlipCalculator, TerritorialPressureCalculator, TouchCalculator,
-    TouchState, WallAerialCalculator, WallAerialShotCalculator, WavedashCalculator,
-    WhiffCalculator,
+    HalfVolleyGoalCalculator, HighAerialGoalCalculator, KickoffCalculator, KickoffGoalCalculator,
+    LivePlayState, LongDistanceGoalCalculator, MatchStatsCalculator, MovementCalculator,
+    MustyFlickCalculator, OneTimerCalculator, OneTimerGoalCalculator, OwnHalfGoalCalculator,
+    PassCalculator, PassingGoalCalculator, PlayerFrameState, PlayerVerticalState,
+    PositioningCalculator, PossessionCalculator, PossessionState, PowerslideCalculator,
+    RotationCalculator, RushCalculator, SpeedFlipCalculator, TerritorialPressureCalculator,
+    TouchCalculator, TouchState, WallAerialCalculator, WallAerialShotCalculator,
+    WavedashCalculator, WhiffCalculator,
 };
 
 pub(crate) mod backboard;
@@ -315,6 +315,10 @@ pub(crate) fn demo_goal_dependency() -> AnalysisDependency {
 
 pub(crate) fn half_volley_goal_dependency() -> AnalysisDependency {
     AnalysisDependency::with_default::<HalfVolleyGoalCalculator>(goal_tags::boxed_half_volley_goal)
+}
+
+pub(crate) fn kickoff_goal_dependency() -> AnalysisDependency {
+    AnalysisDependency::with_default::<KickoffGoalCalculator>(goal_tags::boxed_kickoff_goal)
 }
 
 pub(crate) fn backboard_dependency() -> AnalysisDependency {

--- a/src/stats/analysis_graph/nodes/stats_timeline_events.rs
+++ b/src/stats/analysis_graph/nodes/stats_timeline_events.rs
@@ -110,6 +110,7 @@ impl StatsTimelineEventsNode {
             bump_goal_dependency(),
             demo_goal_dependency(),
             half_volley_goal_dependency(),
+            kickoff_goal_dependency(),
         ]
     }
 
@@ -153,6 +154,7 @@ impl StatsTimelineEventsNode {
         let bump_goal = ctx.get::<BumpGoalCalculator>()?;
         let demo_goal = ctx.get::<DemoGoalCalculator>()?;
         let half_volley_goal = ctx.get::<HalfVolleyGoalCalculator>()?;
+        let kickoff_goal = ctx.get::<KickoffGoalCalculator>()?;
         let rush = ctx.get::<RushCalculator>()?;
         let flip_impulse = ctx.get::<FlipImpulseCalculator>()?;
         let speed_flip = ctx.get::<SpeedFlipCalculator>()?;
@@ -185,6 +187,7 @@ impl StatsTimelineEventsNode {
             bump_goal.events(),
             demo_goal.events(),
             half_volley_goal.events(),
+            kickoff_goal.events(),
         ]);
         let goal_context =
             goal_context_events_with_tags(match_stats.goal_context_events(), &goal_tag_assignments);

--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -84,6 +84,12 @@ struct ActiveKickoff {
     touches: Vec<KickoffTouchSnapshot>,
     speed_flip_players: HashSet<PlayerId>,
     resolution: Option<KickoffResolutionSnapshot>,
+    /// The fully built event, frozen at the kickoff's logical close
+    /// (`should_finish`). The item then stays in flight, awaiting goal
+    /// attribution: a goal scored within [`KICKOFF_GOAL_MAX_SECONDS`] of the
+    /// first touch still counts as a kickoff goal even though it lands after
+    /// the kickoff itself has closed.
+    concluded: Option<Box<KickoffEvent>>,
 }
 
 impl InFlightItem for ActiveKickoff {
@@ -93,13 +99,19 @@ impl InFlightItem for ActiveKickoff {
         Recognition::committed(self.start_time, self.start_frame)
     }
 
-    fn on_boundary(&mut self, _boundary: Boundary) -> Disposition {
-        // A kickoff that is still in flight when the stream ends never reached a
-        // resolution; emitting a truncated event would be misleading, so it is
-        // discarded (preserving the previous "drop the unfinished kickoff"
-        // behavior, now handled structurally rather than by omission). Goal and
-        // live-play finalization happen earlier through `should_finish`.
-        Disposition::Discard
+    fn on_boundary(&mut self, boundary: Boundary) -> Disposition {
+        // A concluded kickoff is a complete event that is merely waiting for
+        // late goal attribution; the stream ending just means no further goal
+        // can arrive, so it is emitted as-is. A kickoff that never reached its
+        // logical close has no resolution; emitting a truncated event would be
+        // misleading, so it is discarded (preserving the previous "drop the
+        // unfinished kickoff" behavior, now handled structurally rather than
+        // by omission).
+        if self.concluded.is_some() {
+            Disposition::Finalize(FinalizeReason::Boundary(boundary))
+        } else {
+            Disposition::Discard
+        }
     }
 }
 
@@ -407,14 +419,20 @@ impl KickoffCalculator {
             touches: Vec::new(),
             speed_flip_players: HashSet::new(),
             resolution: None,
+            concluded: None,
         });
     }
 
     /// Finalize any in-flight kickoff at end of stream. Routed through the
-    /// ledger so the boundary is handled uniformly; an unresolved kickoff is
-    /// discarded rather than emitted (see `ActiveKickoff::on_boundary`).
+    /// ledger so the boundary is handled uniformly; a concluded kickoff that
+    /// was only waiting for late goal attribution is emitted, while an
+    /// unresolved kickoff is discarded (see `ActiveKickoff::on_boundary`).
     pub fn finish(&mut self) {
-        let _ = self.active.finish();
+        for (active, _reason) in self.active.finish() {
+            if let Some(event) = active.concluded {
+                self.events.push(*event);
+            }
+        }
     }
 
     fn observe_movement_start(
@@ -1026,6 +1044,39 @@ impl KickoffCalculator {
             })
     }
 
+    fn earliest_goal(events: &FrameEventsState) -> Option<&GoalEvent> {
+        events.goal_events.iter().min_by(|left, right| {
+            left.time
+                .total_cmp(&right.time)
+                .then_with(|| left.frame.cmp(&right.frame))
+        })
+    }
+
+    /// Attribute a goal that landed after the kickoff's logical close but
+    /// within [`KICKOFF_GOAL_MAX_SECONDS`] of the first touch to the concluded
+    /// kickoff event. Mirrors the attribution `finish_event` performs when the
+    /// goal arrives while the kickoff is still open.
+    fn attribute_goal(event: &mut KickoffEvent, goal: &GoalEvent) {
+        let Some(first_touch_time) = event.first_touch_time else {
+            return;
+        };
+        let time_to_goal = goal.time - first_touch_time;
+        if !(0.0..KICKOFF_GOAL_MAX_SECONDS).contains(&time_to_goal) {
+            return;
+        }
+        event.time_to_goal = Some(time_to_goal);
+        event.kickoff_goal = true;
+        event.scoring_team_is_team_0 = Some(goal.scoring_team_is_team_0);
+        if event.first_follow_up_touch_time.is_none() {
+            event.kickoff_possession_outcome = if goal.scoring_team_is_team_0 {
+                KickoffPossessionOutcome::TeamZeroPossession
+            } else {
+                KickoffPossessionOutcome::TeamOnePossession
+            };
+            event.kickoff_possession_team_is_team_0 = Some(goal.scoring_team_is_team_0);
+        }
+    }
+
     fn finish_event(
         active: ActiveKickoff,
         frame: &FrameInfo,
@@ -1262,47 +1313,99 @@ impl KickoffCalculator {
         ctx: KickoffUpdateContext<'_>,
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
-        if ctx.gameplay.kickoff_phase_active() && self.active.is_empty() {
-            self.start_kickoff(ctx.frame, ctx.players);
+        if ctx.gameplay.kickoff_phase_active() {
+            // Once the next kickoff phase begins, no further goal can belong
+            // to a previous kickoff: flush any concluded kickoff still held
+            // for goal attribution before arming the new one.
+            let flushed = self.active.advance(ctx.frame.time, |active| {
+                if active.concluded.is_some() {
+                    Disposition::Finalize(FinalizeReason::Completed)
+                } else {
+                    Disposition::Keep
+                }
+            });
+            for (active, _reason) in flushed {
+                if let Some(event) = active.concluded {
+                    self.events.push(*event);
+                }
+            }
+            if self.active.is_empty() {
+                self.start_kickoff(ctx.frame, ctx.players);
+            }
         }
 
         let Some(active) = self.active.in_flight_mut().first_mut() else {
             return Ok(());
         };
-        Self::observe_movement_start(active, ctx.frame, ctx.gameplay);
-        if ctx.gameplay.kickoff_phase_active() && !ctx.gameplay.kickoff_countdown_active() {
-            Self::observe_live_action_start(active, ctx.frame);
-        }
-        Self::apply_player_samples(active, ctx.frame, ctx.players);
-        Self::apply_touches(active, ctx.touch_state);
-        Self::apply_speed_flip_events(active, ctx.frame, ctx.speed_flip_events);
-        if Self::should_capture_resolution(active, ctx.frame) {
-            active.resolution = Some(KickoffResolutionSnapshot {
-                ball: ctx.ball.clone(),
-            });
+        if active.concluded.is_none() {
+            Self::observe_movement_start(active, ctx.frame, ctx.gameplay);
+            if ctx.gameplay.kickoff_phase_active() && !ctx.gameplay.kickoff_countdown_active() {
+                Self::observe_live_action_start(active, ctx.frame);
+            }
+            Self::apply_player_samples(active, ctx.frame, ctx.players);
+            Self::apply_touches(active, ctx.touch_state);
+            Self::apply_speed_flip_events(active, ctx.frame, ctx.speed_flip_events);
+            if Self::should_capture_resolution(active, ctx.frame) {
+                active.resolution = Some(KickoffResolutionSnapshot {
+                    ball: ctx.ball.clone(),
+                });
+            }
         }
 
-        // Natural finalization: the kickoff resolves once `should_finish` is met
-        // (which already accounts for goals and goal-replay). The ledger keeps
-        // the in-flight kickoff queryable and guarantees it is resolved at the
-        // end of the stream.
+        // Natural finalization happens in two stages. The kickoff *concludes*
+        // once `should_finish` is met: its event content is frozen there
+        // (touches, possession, exit ball state). It then stays in flight,
+        // awaiting goal attribution, until a goal arrives, the attribution
+        // window closes, or the next kickoff begins. This lets a goal scored
+        // after the kickoff's logical close — but still within
+        // `KICKOFF_GOAL_MAX_SECONDS` of the first touch — count as a kickoff
+        // goal. The ledger keeps the in-flight kickoff queryable and
+        // guarantees it is resolved at the end of the stream.
         let finished = self.active.advance(ctx.frame.time, |active| {
-            if Self::should_finish(active, ctx.frame, ctx.gameplay, ctx.events) {
-                Disposition::Finalize(FinalizeReason::Completed)
-            } else {
-                Disposition::Keep
+            if let Some(event) = active.concluded.as_deref_mut() {
+                if let Some(goal) = Self::earliest_goal(ctx.events) {
+                    Self::attribute_goal(event, goal);
+                    return Disposition::Finalize(FinalizeReason::Completed);
+                }
+                let attribution_window_closed = active
+                    .first_touch_time
+                    .map(|first_touch_time| {
+                        ctx.frame.time - first_touch_time >= KICKOFF_GOAL_MAX_SECONDS
+                    })
+                    .unwrap_or(true);
+                if attribution_window_closed
+                    || ctx.gameplay.game_state == Some(GAME_STATE_GOAL_SCORED_REPLAY)
+                {
+                    return Disposition::Finalize(FinalizeReason::Completed);
+                }
+                return Disposition::Keep;
             }
+            if Self::should_finish(active, ctx.frame, ctx.gameplay, ctx.events) {
+                let event = Self::finish_event(
+                    active.clone(),
+                    ctx.frame,
+                    ctx.ball,
+                    ctx.players,
+                    ctx.events,
+                    ctx.speed_flip_events,
+                );
+                active.concluded = Some(Box::new(event));
+                // A goal (or goal replay) at the close frame is already
+                // attributed by `finish_event`; nothing further can change the
+                // event, so emit immediately.
+                if !ctx.events.goal_events.is_empty()
+                    || ctx.gameplay.game_state == Some(GAME_STATE_GOAL_SCORED_REPLAY)
+                {
+                    return Disposition::Finalize(FinalizeReason::Completed);
+                }
+                return Disposition::Keep;
+            }
+            Disposition::Keep
         });
         for (active, _reason) in finished {
-            let event = Self::finish_event(
-                active,
-                ctx.frame,
-                ctx.ball,
-                ctx.players,
-                ctx.events,
-                ctx.speed_flip_events,
-            );
-            self.events.push(event);
+            if let Some(event) = active.concluded {
+                self.events.push(*event);
+            }
         }
         Ok(())
     }

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -179,6 +179,7 @@ fn kickoff_goal_does_not_override_immediate_outcome() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(event.outcome, KickoffOutcome::TeamZeroWin);
     assert_eq!(event.winning_team_is_team_0, Some(true));
@@ -274,6 +275,7 @@ fn kickoff_records_movement_start_after_countdown() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(event.start_time, 0.0);
     assert_eq!(event.start_frame, 0);
@@ -362,6 +364,7 @@ fn kickoff_classifies_fake_and_missed_expected_takers() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(event.outcome, KickoffOutcome::TeamZeroWin);
     assert_eq!(event.win_strength, Some(2.0));
@@ -519,6 +522,7 @@ fn kickoff_classifies_support_players_as_cheating_or_going_for_boost() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     let blue_taker_event = event.team_zero_taker.as_ref().unwrap();
     assert_eq!(blue_taker_event.player, blue_taker);
@@ -663,6 +667,7 @@ fn kickoff_tracks_first_touch_taker_delay_exit_velocity_and_follow_up() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(event.first_touch_player, Some(blue_taker.clone()));
     assert_eq!(event.first_touch_team_is_team_0, Some(true));
@@ -823,6 +828,7 @@ fn kickoff_taker_tracks_time_to_ball_and_approach_boost_totals() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     let blue_taker_event = event.team_zero_taker.as_ref().unwrap();
     assert_eq!(blue_taker_event.player, blue_taker);
@@ -914,6 +920,7 @@ fn kickoff_taker_touch_delay_is_non_negative_when_team_one_touches_first() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(event.team_zero_taker_touch_time, Some(1.2));
     assert_eq!(event.team_one_taker_touch_time, Some(1.0));
@@ -1029,6 +1036,7 @@ fn kickoff_waits_past_resolution_to_capture_first_follow_up_touch() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(event.outcome, KickoffOutcome::TeamOneWin);
     assert_eq!(event.exit_velocity, Some([0.0, -500.0, 0.0]));
@@ -1109,6 +1117,7 @@ fn kickoff_without_follow_up_remains_contested_when_ball_resolution_is_neutral()
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(event.first_follow_up_touch_time, None);
     assert_eq!(
@@ -1259,6 +1268,7 @@ fn kickoff_follow_up_clean_possession_uses_unchallenged_touch_sequence() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(event.outcome, KickoffOutcome::TeamZeroWin);
     assert_eq!(event.first_follow_up_touch_time, Some(1.2));
@@ -1399,6 +1409,7 @@ fn kickoff_goal_preserves_actual_follow_up_contest() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert!(event.kickoff_goal);
     assert_eq!(event.scoring_team_is_team_0, Some(false));
@@ -1528,6 +1539,7 @@ fn kickoff_possession_outcome_tracks_team_advantage_before_late_challenge() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(event.first_follow_up_touch_time, Some(1.6));
     assert_eq!(event.first_follow_up_touch_frame, Some(18));
@@ -1610,6 +1622,7 @@ fn kickoff_uses_speed_flip_events_as_approach_source_of_truth() {
         })
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     let blue_taker_event = event.team_zero_taker.as_ref().unwrap();
     assert_eq!(blue_taker_event.player, blue_taker);
@@ -1841,6 +1854,7 @@ fn kickoff_tie_breaks_expected_taker_by_actual_touch_then_left_goes() {
         )
         .unwrap();
 
+    calculator.finish();
     let event = calculator.events().last().unwrap();
     assert_eq!(
         event.team_zero_taker.as_ref().map(|player| &player.player),
@@ -2096,4 +2110,218 @@ fn kickoff_direction_tracks_symmetric_taker_spawn_side() {
         ),
         KickoffDirection::Unknown
     );
+}
+
+/// Drives a kickoff through countdown, a first touch at t=1.0, an opposing
+/// contest touch, resolution capture, and a follow-up touch at t=2.6 that
+/// closes the kickoff. Returns the calculator with the kickoff concluded but
+/// not yet emitted (awaiting goal attribution).
+fn concluded_kickoff_awaiting_attribution(
+    blue_taker: &PlayerId,
+    blue_support: &PlayerId,
+    orange_taker: &PlayerId,
+) -> KickoffCalculator {
+    let mut calculator = KickoffCalculator::new();
+
+    calculator
+        .update(
+            &frame(0, 0.0),
+            &GameplayState {
+                ball_has_been_hit: Some(false),
+                ..GameplayState::default()
+            },
+            &ball(0.0),
+            &PlayerFrameState {
+                players: vec![
+                    player(
+                        blue_taker.clone(),
+                        true,
+                        glam::Vec3::new(-256.0, -3840.0, 17.0),
+                        33.0,
+                    ),
+                    player(
+                        blue_support.clone(),
+                        true,
+                        glam::Vec3::new(0.0, -4608.0, 17.0),
+                        33.0,
+                    ),
+                    player(
+                        orange_taker.clone(),
+                        false,
+                        glam::Vec3::new(256.0, 3840.0, 17.0),
+                        33.0,
+                    ),
+                ],
+            },
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    calculator
+        .update(
+            &frame(10, 1.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(0.0),
+            &PlayerFrameState::default(),
+            &TouchState {
+                touch_events: vec![touch(blue_taker.clone(), true, 10, 1.0)],
+                ..TouchState::default()
+            },
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    calculator
+        .update(
+            &frame(26, 2.3),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball_with_velocity(360.0, glam::Vec3::new(0.0, 900.0, 0.0)),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    calculator
+        .update(
+            &frame(31, 2.6),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball_with_velocity(360.0, glam::Vec3::new(0.0, 900.0, 0.0)),
+            &PlayerFrameState::default(),
+            &TouchState {
+                touch_events: vec![touch(blue_support.clone(), true, 31, 2.6)],
+                ..TouchState::default()
+            },
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    // The kickoff has reached its logical close, but emission is deferred
+    // while a goal could still be attributed to it.
+    assert!(calculator.events().is_empty());
+    calculator
+}
+
+#[test]
+fn kickoff_goal_after_logical_close_is_attributed_within_window() {
+    let blue_taker = PlayerId::Steam(60);
+    let blue_support = PlayerId::Steam(61);
+    let orange_taker = PlayerId::Steam(62);
+    let mut calculator =
+        concluded_kickoff_awaiting_attribution(&blue_taker, &blue_support, &orange_taker);
+
+    calculator
+        .update(
+            &frame(40, 3.4),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(5200.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState {
+                goal_events: vec![goal(true, 40, 3.4)],
+                ..FrameEventsState::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    let event = calculator.events().last().unwrap();
+    assert!(event.kickoff_goal);
+    let time_to_goal = event.time_to_goal.unwrap();
+    assert!((time_to_goal - 2.4).abs() < 1e-4);
+    assert_eq!(event.scoring_team_is_team_0, Some(true));
+    // Event content stays frozen at the logical close.
+    assert_eq!(event.end_time, 2.6);
+    assert_eq!(event.end_frame, 31);
+    assert_eq!(event.first_follow_up_touch_time, Some(2.6));
+}
+
+#[test]
+fn kickoff_goal_attribution_window_closes_after_max_seconds() {
+    let blue_taker = PlayerId::Steam(63);
+    let blue_support = PlayerId::Steam(64);
+    let orange_taker = PlayerId::Steam(65);
+    let mut calculator =
+        concluded_kickoff_awaiting_attribution(&blue_taker, &blue_support, &orange_taker);
+
+    calculator
+        .update(
+            &frame(140, 11.2),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(0.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    let event = calculator.events().last().unwrap();
+    assert!(!event.kickoff_goal);
+    assert_eq!(event.time_to_goal, None);
+    assert_eq!(event.end_time, 2.6);
+
+    // A goal landing after the window stays unattributed.
+    calculator
+        .update(
+            &frame(145, 11.6),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(5200.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState {
+                goal_events: vec![goal(true, 145, 11.6)],
+                ..FrameEventsState::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(calculator.events().len(), 1);
+    assert!(!calculator.events().last().unwrap().kickoff_goal);
+}
+
+#[test]
+fn next_kickoff_phase_flushes_kickoff_awaiting_attribution() {
+    let blue_taker = PlayerId::Steam(66);
+    let blue_support = PlayerId::Steam(67);
+    let orange_taker = PlayerId::Steam(68);
+    let mut calculator =
+        concluded_kickoff_awaiting_attribution(&blue_taker, &blue_support, &orange_taker);
+
+    calculator
+        .update(
+            &frame(60, 5.0),
+            &GameplayState {
+                ball_has_been_hit: Some(false),
+                ..GameplayState::default()
+            },
+            &ball(0.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    let event = calculator.events().last().unwrap();
+    assert!(!event.kickoff_goal);
+    assert_eq!(event.end_time, 2.6);
 }

--- a/src/stats/calculators/match_stats.rs
+++ b/src/stats/calculators/match_stats.rs
@@ -520,15 +520,22 @@ impl MatchStatsCalculator {
     }
 
     fn update_kickoff_reference(&mut self, gameplay: &GameplayState, events: &FrameEventsState) {
-        if let Some(first_touch_time) = events
-            .touch_events
-            .iter()
-            .map(|event| event.time)
-            .min_by(|a, b| a.total_cmp(b))
-        {
-            self.active_kickoff_touch_time = Some(first_touch_time);
-            self.kickoff_waiting_for_first_touch = false;
-            return;
+        // Only the first touch after a kickoff reset establishes the kickoff
+        // reference. Without this gate, every later touch in open play would
+        // overwrite the reference, turning `time_after_kickoff` into "time
+        // since the most recent touch" instead of "time since the kickoff's
+        // first touch".
+        if self.kickoff_waiting_for_first_touch {
+            if let Some(first_touch_time) = events
+                .touch_events
+                .iter()
+                .map(|event| event.time)
+                .min_by(|a, b| a.total_cmp(b))
+            {
+                self.active_kickoff_touch_time = Some(first_touch_time);
+                self.kickoff_waiting_for_first_touch = false;
+                return;
+            }
         }
 
         if Self::kickoff_phase_active(gameplay) {

--- a/src/stats/calculators/match_stats_tests.rs
+++ b/src/stats/calculators/match_stats_tests.rs
@@ -547,3 +547,104 @@ fn counter_attack_buildup_requires_a_defensive_pressure_signal() {
         GoalBuildupKind::Other
     );
 }
+
+#[test]
+fn time_after_kickoff_uses_kickoff_first_touch_not_latest_touch() {
+    let scorer = PlayerId::Steam(1);
+    let mut calculator = MatchStatsCalculator::new();
+
+    let touch_event = |time: f32, frame: usize| TouchEvent {
+        time,
+        frame,
+        team_is_team_0: true,
+        player: Some(scorer.clone()),
+        player_position: None,
+        closest_approach_distance: Some(0.0),
+        dodge_contact: false,
+    };
+
+    fn update_with(
+        calculator: &mut MatchStatsCalculator,
+        frame_info: FrameInfo,
+        kickoff_phase: bool,
+        player_goals: i32,
+        touch_events: Vec<TouchEvent>,
+        goal_events: Vec<GoalEvent>,
+    ) {
+        let scorer = PlayerId::Steam(1);
+        calculator
+            .update_parts(
+                &frame_info,
+                &GameplayState {
+                    ball_has_been_hit: Some(!kickoff_phase),
+                    team_zero_score: Some(player_goals),
+                    team_one_score: Some(0),
+                    ..GameplayState::default()
+                },
+                &ball(BALL_GROUND_CONTACT_MAX_Z),
+                &PlayerFrameState {
+                    players: vec![player(scorer, true, player_goals)],
+                },
+                &FrameEventsState {
+                    touch_events,
+                    goal_events,
+                    ..FrameEventsState::default()
+                },
+                &LivePlayState {
+                    gameplay_phase: GameplayPhase::ActivePlay,
+                    is_live_play: !kickoff_phase,
+                },
+                &TouchState::default(),
+            )
+            .unwrap();
+    }
+
+    // Kickoff countdown: waiting for the kickoff's first touch.
+    update_with(
+        &mut calculator,
+        frame(0, 0.0),
+        true,
+        0,
+        Vec::new(),
+        Vec::new(),
+    );
+    // Kickoff first touch at t=1.0 establishes the reference.
+    update_with(
+        &mut calculator,
+        frame(10, 1.0),
+        false,
+        0,
+        vec![touch_event(1.0, 10)],
+        Vec::new(),
+    );
+    // A mid-rally touch much later must not reset the kickoff reference.
+    update_with(
+        &mut calculator,
+        frame(200, 20.0),
+        false,
+        0,
+        vec![touch_event(20.0, 200)],
+        Vec::new(),
+    );
+    // Goal at t=21.0: time after kickoff is 20s, not 1s.
+    update_with(
+        &mut calculator,
+        frame(210, 21.0),
+        false,
+        1,
+        Vec::new(),
+        vec![goal_event(21.0, 210, scorer.clone())],
+    );
+
+    let core_event = calculator
+        .core_player_goal_context_events()
+        .last()
+        .expect("goal should emit a core goal context event");
+    let time_after_kickoff = core_event
+        .time_after_kickoff
+        .expect("time_after_kickoff should be set");
+    assert!(
+        (time_after_kickoff - 20.0).abs() < 1e-4,
+        "expected time_after_kickoff to measure from the kickoff first touch, got {time_after_kickoff}"
+    );
+}


### PR DESCRIPTION
## Problem

Goals scored shortly after a kickoff were not receiving the `kickoff_goal` tag in `goal_context` events. Observed concretely on replay `019eac0b` goal 6: the ball crossed the line **1.82s after the kickoff's first touch**, which is **0.54s after the kickoff event had already closed** (at its logical close of ~1.28s via `KICKOFF_FOLLOW_UP_AFTER_FIRST_TOUCH_SECONDS`).

Three concurrent bugs combined to cause this:

## Fixes

### 1. Deferred kickoff emission (`kickoff.rs`)

The `ActiveKickoff` in `InFlightLedger` previously emitted the event at the logical close (first follow-up touch or 2s after first touch). Any goal landing after that point couldn't be attributed.

Now a concluded kickoff stays in-flight. The `concluded` field holds a frozen `KickoffEvent` snapshot; `on_boundary` keeps it alive rather than discarding. Each frame the ledger advances: if a goal arrives within `KICKOFF_GOAL_MAX_SECONDS` (10s) of the first touch, `attribute_goal()` patches `kickoff_goal`, `time_to_goal`, `scoring_team`, and possession fields before the event is emitted. If the window closes or the next kickoff phase starts, the concluded event is emitted as-is (no goal attribution).

### 2. First-touch guard in match_stats (`match_stats.rs`)

`update_kickoff_reference()` wrote `kickoff_waiting_for_first_touch` but never read it, so **every touch event in open play overwrote `active_kickoff_touch_time`**. `time_after_kickoff` was measuring "time since the most recent touch" rather than "time since the kickoff's first touch", making `KickoffGoalCalculator`'s window check unreliable. Gated the capture branch on the flag so the reference stays anchored to the kickoff's actual first touch for the full rally.

### 3. Wire `KickoffGoalCalculator` into goal_context payloads (`stats_timeline_events.rs`)

`KickoffGoalCalculator` was registered as an analysis node and export module but was never included in `combined_goal_tag_assignments`, so its `kickoff_goal` tags were silently dropped from every `goal_context` event. Added the dependency and the slice entry.

## Tests

- 3 new kickoff tests: goal attributed after logical close, window expiry without goal, next kickoff phase flushes pending event
- 1 new `match_stats` regression test for the first-touch guard
- 12+ existing kickoff tests updated to call `calculator.finish()` before asserting on events (required because events no longer emit during the update loop)
- All 605 library tests pass; clippy clean

## Trade-off

Non-goal kickoff events now emit up to ~8s later than before (at the attribution-window close rather than the logical close). Downstream consumers are cursor-based and order-insensitive, so correctness is unaffected; playback-time stat accumulation for kickoff stats registers slightly later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)