### PR TITLE
feat(stats): gate kickoff goals on possession chain and field position

### DIFF
--- a/src/stats/analysis_graph/nodes/goal_tags.rs
+++ b/src/stats/analysis_graph/nodes/goal_tags.rs
@@ -112,7 +112,13 @@ goal_tag_node!(
     SustainedPressureGoalCalculator,
     "sustained_pressure_goal"
 );
-goal_tag_node!(KickoffGoalNode, KickoffGoalCalculator, "kickoff_goal");
+mechanic_goal_tag_node!(
+    KickoffGoalNode,
+    KickoffGoalCalculator,
+    "kickoff_goal",
+    kickoff_dependency,
+    KickoffCalculator
+);
 mechanic_goal_tag_node!(
     FlickGoalNode,
     FlickGoalCalculator,

--- a/src/stats/calculators/goal_tags.rs
+++ b/src/stats/calculators/goal_tags.rs
@@ -24,7 +24,10 @@ const DEFAULT_BUMP_GOAL_MAX_EVENT_TO_GOAL_SECONDS: f32 = 3.0;
 const DEFAULT_DEMO_GOAL_MAX_EVENT_TO_GOAL_SECONDS: f32 = 3.0;
 const DEFAULT_HALF_VOLLEY_GOAL_MAX_TOUCH_TO_GOAL_SECONDS: f32 = 3.0;
 const DEFAULT_HALF_VOLLEY_GOAL_MIN_GOAL_ALIGNMENT: f32 = 0.55;
-const DEFAULT_KICKOFF_GOAL_MAX_TIME_AFTER_KICKOFF_SECONDS: f32 = 10.0;
+// Kickoff events record the attributed goal as first_touch_time +
+// time_to_goal; this epsilon absorbs the float round-trip when matching that
+// back to a goal context's timestamp.
+const KICKOFF_GOAL_TAG_MATCH_EPSILON_SECONDS: f32 = 0.05;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
@@ -375,10 +378,11 @@ pub const ALL_GOAL_TAG_DEFINITIONS: &[GoalTagDefinition] = &[
         GoalTagKind::KickoffGoal,
         "kickoff_goal",
         "Kickoff Goal",
-        "A goal scored shortly after the kickoff's first touch.",
+        "A goal flowing directly from the kickoff exchange.",
         &[
-            "Inspect the scorer's core goal context for time-after-kickoff data.",
-            "Require the goal to fall within the kickoff-goal timing window.",
+            "Use the kickoff calculator's goal attribution as the source of truth.",
+            "Require the goal to land within the kickoff-goal timing window of the first touch.",
+            "Reject goals where the conceding team settled possession or the play reset through the scoring team's own half.",
             "Attach goal-context evidence so the tag appears with the goal label.",
         ],
     ),
@@ -1503,46 +1507,56 @@ impl HalfVolleyGoalCalculator {
 }
 
 impl KickoffGoalCalculator {
-    pub fn update(&mut self, match_stats: &MatchStatsCalculator) -> SubtrActorResult<()> {
-        self.events.replace_all_assuming_append_only(self.tag_goals(
-            match_stats.goal_context_events(),
-            match_stats.core_player_goal_context_events(),
-        ));
+    pub fn update(
+        &mut self,
+        match_stats: &MatchStatsCalculator,
+        kickoff: &KickoffCalculator,
+    ) -> SubtrActorResult<()> {
+        self.events.replace_all_assuming_append_only(
+            self.tag_goals(match_stats.goal_context_events(), kickoff.events()),
+        );
         Ok(())
     }
 
+    /// The kickoff calculator is the source of truth for what counts as a
+    /// kickoff goal (timing window, unbroken possession chain, and
+    /// field-position gates); this tags exactly the goals some kickoff event
+    /// attributed to itself.
     fn tag_goals(
         &self,
         goals: &[GoalContextEvent],
-        core_goal_context_events: &[CorePlayerGoalContextEvent],
+        kickoff_events: &[KickoffEvent],
     ) -> Vec<GoalTagAssignment> {
-        let mut tags = Vec::new();
-        for core_event in core_goal_context_events {
-            let Some(time_after_kickoff) = core_event.time_after_kickoff else {
-                continue;
-            };
-            if !(0.0..DEFAULT_KICKOFF_GOAL_MAX_TIME_AFTER_KICKOFF_SECONDS)
-                .contains(&time_after_kickoff)
-            {
-                continue;
-            }
-            let Some((goal_index, goal)) = goals.iter().enumerate().find(|(_, goal)| {
-                goal.time == core_event.time
-                    && goal.frame == core_event.frame
-                    && goal.scoring_team_is_team_0 == core_event.scoring_team_is_team_0
-                    && goal.scorer.as_ref() == Some(&core_event.player)
-            }) else {
-                continue;
-            };
+        goals
+            .iter()
+            .enumerate()
+            .filter(|(_, goal)| {
+                kickoff_events
+                    .iter()
+                    .any(|event| kickoff_event_attributes_goal(event, goal))
+            })
+            .map(|(goal_index, goal)| {
+                goal_tag(
+                    GoalTaggingContext { goal_index },
+                    GoalTagKind::KickoffGoal,
+                    1.0,
+                    vec![goal_context_evidence(goal)],
+                )
+            })
+            .collect()
+    }
+}
 
-            tags.push(goal_tag(
-                GoalTaggingContext { goal_index },
-                GoalTagKind::KickoffGoal,
-                1.0,
-                vec![goal_context_evidence(goal)],
-            ));
+fn kickoff_event_attributes_goal(event: &KickoffEvent, goal: &GoalContextEvent) -> bool {
+    if !event.kickoff_goal || event.scoring_team_is_team_0 != Some(goal.scoring_team_is_team_0) {
+        return false;
+    }
+    match (event.first_touch_time, event.time_to_goal) {
+        (Some(first_touch_time), Some(time_to_goal)) => {
+            (first_touch_time + time_to_goal - goal.time).abs()
+                <= KICKOFF_GOAL_TAG_MATCH_EPSILON_SECONDS
         }
-        tags
+        _ => false,
     }
 }
 

--- a/src/stats/calculators/goal_tags_tests.rs
+++ b/src/stats/calculators/goal_tags_tests.rs
@@ -63,32 +63,6 @@ fn goal_with_touch(
     }
 }
 
-fn core_scoring_goal_context(
-    goal: &GoalContextEvent,
-    time_after_kickoff: Option<f32>,
-) -> CorePlayerGoalContextEvent {
-    CorePlayerGoalContextEvent {
-        time: goal.time,
-        frame: goal.frame,
-        player: goal.scorer.clone().expect("test goal should have scorer"),
-        player_position: None,
-        is_team_0: goal.scoring_team_is_team_0,
-        scoring_team_is_team_0: goal.scoring_team_is_team_0,
-        goals_conceded_while_last_defender: false,
-        goals_for_while_most_back: false,
-        goals_against_while_most_back: false,
-        caught_ahead_of_play_on_conceded_goal: false,
-        goal_against_boost_amount: None,
-        goal_against_average_boost_in_leadup: None,
-        goal_against_min_boost_in_leadup: None,
-        goal_against_position: None,
-        scoring_goal_last_touch_position: None,
-        time_after_kickoff,
-        goal_buildup: Some(goal.goal_buildup),
-        ball_air_time_before_goal: goal.ball_air_time_before_goal,
-    }
-}
-
 fn tag_kinds(events: &[GoalTagAssignment]) -> Vec<GoalTagKind> {
     let mut kinds: Vec<_> = events.iter().map(|event| event.tag.kind()).collect();
     kinds.sort_by_key(|kind| format!("{kind:?}"));
@@ -500,14 +474,64 @@ fn sustained_pressure_goal_rejects_other_buildup() {
     assert!(events.is_empty());
 }
 
+fn kickoff_event_for_goal(
+    scoring_team_is_team_0: Option<bool>,
+    first_touch_time: Option<f32>,
+    time_to_goal: Option<f32>,
+    kickoff_goal: bool,
+) -> KickoffEvent {
+    KickoffEvent {
+        start_time: first_touch_time.unwrap_or(0.0) - 1.0,
+        start_frame: 0,
+        end_time: first_touch_time.unwrap_or(0.0) + 2.0,
+        end_frame: 30,
+        live_action_start_time: None,
+        live_action_start_frame: None,
+        movement_start_time: 0.0,
+        movement_start_frame: 0,
+        kickoff_type: KickoffType::Center,
+        kickoff_direction: KickoffDirection::Center,
+        first_touch_time,
+        first_touch_frame: None,
+        first_touch_team_is_team_0: None,
+        first_touch_player: None,
+        team_zero_taker_touch_time: None,
+        team_zero_taker_touch_frame: None,
+        team_one_taker_touch_time: None,
+        team_one_taker_touch_frame: None,
+        taker_touch_delay_seconds: None,
+        exit_velocity: None,
+        exit_speed: None,
+        exit_y_velocity: None,
+        first_follow_up_touch_time: None,
+        first_follow_up_touch_frame: None,
+        first_follow_up_touch_team_is_team_0: None,
+        first_follow_up_touch_player: None,
+        outcome: KickoffOutcome::Unknown,
+        winning_team_is_team_0: None,
+        win_strength: None,
+        win_strength_band: KickoffWinStrengthBand::Unknown,
+        kickoff_possession_outcome: KickoffPossessionOutcome::Contested,
+        kickoff_possession_team_is_team_0: None,
+        kickoff_goal,
+        scoring_team_is_team_0,
+        time_to_goal,
+        team_zero_taker: None,
+        team_one_taker: None,
+        team_zero_non_takers: Vec::new(),
+        team_one_non_takers: Vec::new(),
+    }
+}
+
 #[test]
-fn kickoff_goal_tags_goals_scored_shortly_after_kickoff() {
-    let mut goal = goal_with_touch(true, position(0.0, 2200.0, 130.0), Vec::new());
-    goal.scorer_last_touch = None;
-    let core_context = core_scoring_goal_context(&goal, Some(2.7));
+fn kickoff_goal_tags_goals_attributed_by_a_kickoff_event() {
+    // goal_with_touch builds a goal at t=10.0; the kickoff attributed it as
+    // first touch at 7.3 + 2.7 to goal.
+    let goal = goal_with_touch(true, position(0.0, 2200.0, 130.0), Vec::new());
+    let kickoff_event = kickoff_event_for_goal(Some(true), Some(7.3), Some(2.7), true);
     let calculator = KickoffGoalCalculator::new();
 
-    let events = calculator.tag_goals(&[goal], &[core_context]);
+    let events = calculator.tag_goals(&[goal], &[kickoff_event]);
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::KickoffGoal]);
     assert!(events[0]
@@ -519,12 +543,17 @@ fn kickoff_goal_tags_goals_scored_shortly_after_kickoff() {
 }
 
 #[test]
-fn kickoff_goal_rejects_goals_at_or_after_ten_seconds_after_kickoff() {
+fn kickoff_goal_rejects_goals_without_a_matching_kickoff_attribution() {
     let goal = goal_with_touch(true, position(0.0, 2200.0, 130.0), Vec::new());
-    let core_context = core_scoring_goal_context(&goal, Some(10.0));
+    let unattributed = kickoff_event_for_goal(Some(true), Some(7.3), None, false);
+    let different_goal_time = kickoff_event_for_goal(Some(true), Some(1.0), Some(2.0), true);
+    let different_team = kickoff_event_for_goal(Some(false), Some(7.3), Some(2.7), true);
     let calculator = KickoffGoalCalculator::new();
 
-    let events = calculator.tag_goals(&[goal], &[core_context]);
+    let events = calculator.tag_goals(
+        &[goal],
+        &[unattributed, different_goal_time, different_team],
+    );
 
     assert!(events.is_empty());
 }

--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -9,6 +9,7 @@ const KICKOFF_DIAGONAL_MAX_ABS_Y: f32 = 3300.0;
 const KICKOFF_RESOLUTION_AFTER_FIRST_TOUCH_SECONDS: f32 = 1.25;
 const KICKOFF_FOLLOW_UP_AFTER_FIRST_TOUCH_SECONDS: f32 = 2.0;
 const KICKOFF_GOAL_MAX_SECONDS: f32 = 10.0;
+const KICKOFF_GOAL_MAX_DEFENSIVE_BALL_Y: f32 = 1280.0;
 const KICKOFF_WIN_MIN_BALL_Y: f32 = 180.0;
 const KICKOFF_WIN_MIN_BALL_SPEED_Y: f32 = 220.0;
 const KICKOFF_BALL_DIRECTION_MIN_ABS_X: f32 = 180.0;
@@ -84,6 +85,13 @@ struct ActiveKickoff {
     touches: Vec<KickoffTouchSnapshot>,
     speed_flip_players: HashSet<PlayerId>,
     resolution: Option<KickoffResolutionSnapshot>,
+    /// Running ball-y extremes observed since the kickoff's first touch,
+    /// including frames after the kickoff's logical close. Used by the
+    /// kickoff-goal field-position gate: if the ball retreated meaningfully
+    /// into the eventual scoring team's own half, the goal came from a reset
+    /// play rather than the kickoff exchange.
+    min_ball_y_after_first_touch: Option<f32>,
+    max_ball_y_after_first_touch: Option<f32>,
     /// The fully built event, frozen at the kickoff's logical close
     /// (`should_finish`). The item then stays in flight, awaiting goal
     /// attribution: a goal scored within [`KICKOFF_GOAL_MAX_SECONDS`] of the
@@ -419,6 +427,8 @@ impl KickoffCalculator {
             touches: Vec::new(),
             speed_flip_players: HashSet::new(),
             resolution: None,
+            min_ball_y_after_first_touch: None,
+            max_ball_y_after_first_touch: None,
             concluded: None,
         });
     }
@@ -1052,19 +1062,100 @@ impl KickoffCalculator {
         })
     }
 
-    /// Attribute a goal that landed after the kickoff's logical close but
-    /// within [`KICKOFF_GOAL_MAX_SECONDS`] of the first touch to the concluded
-    /// kickoff event. Mirrors the attribution `finish_event` performs when the
-    /// goal arrives while the kickoff is still open.
+    /// Track the ball's y extremes from the kickoff's first touch onward,
+    /// including frames after the kickoff's logical close while it awaits
+    /// goal attribution.
+    fn observe_ball_extent(active: &mut ActiveKickoff, ball: &BallFrameState) {
+        if active.first_touch_time.is_none() {
+            return;
+        }
+        let Some(sample) = ball.sample() else {
+            return;
+        };
+        let y = sample.position().y;
+        active.min_ball_y_after_first_touch = Some(
+            active
+                .min_ball_y_after_first_touch
+                .map_or(y, |current| current.min(y)),
+        );
+        active.max_ball_y_after_first_touch = Some(
+            active
+                .max_ball_y_after_first_touch
+                .map_or(y, |current| current.max(y)),
+        );
+    }
+
+    /// Whether a goal qualifies as a kickoff goal. The goal must land within
+    /// [`KICKOFF_GOAL_MAX_SECONDS`] of the first touch, but proximity in time
+    /// alone is not enough: the goal also has to flow from the kickoff
+    /// exchange itself, so the conceding team must never have settled the ball
+    /// in between, and the play must not have reset through the scoring
+    /// team's own half.
+    fn kickoff_goal_qualifies(active: &ActiveKickoff, goal: &GoalEvent) -> bool {
+        let Some(first_touch_time) = active.first_touch_time else {
+            return false;
+        };
+        let time_to_goal = goal.time - first_touch_time;
+        (0.0..KICKOFF_GOAL_MAX_SECONDS).contains(&time_to_goal)
+            && !Self::conceding_team_established_possession(&active.touches, goal)
+            && !Self::ball_reset_into_scoring_half(active, goal)
+    }
+
+    /// The conceding team "established possession" when it recorded two
+    /// touches separated by more than the immediate-contest window with no
+    /// scoring-team touch in between — they settled the ball rather than
+    /// merely deflecting it during the kickoff scramble. A single conceding
+    /// touch (a failed clear or deflection straight into punishment) does not
+    /// break the kickoff-goal chain.
+    fn conceding_team_established_possession(
+        touches: &[KickoffTouchSnapshot],
+        goal: &GoalEvent,
+    ) -> bool {
+        let conceding_is_team_0 = !goal.scoring_team_is_team_0;
+        let mut first_conceding_touch_time: Option<f32> = None;
+        for touch in touches.iter().filter(|touch| touch.time <= goal.time) {
+            if touch.team_is_team_0 == conceding_is_team_0 {
+                match first_conceding_touch_time {
+                    Some(anchor)
+                        if touch.time - anchor > KICKOFF_POSSESSION_IMMEDIATE_CONTEST_SECONDS =>
+                    {
+                        return true;
+                    }
+                    Some(_) => {}
+                    None => first_conceding_touch_time = Some(touch.time),
+                }
+            } else {
+                first_conceding_touch_time = None;
+            }
+        }
+        false
+    }
+
+    /// Whether the ball retreated past [`KICKOFF_GOAL_MAX_DEFENSIVE_BALL_Y`]
+    /// into the scoring team's own half between the kickoff's first touch and
+    /// the goal. Team zero attacks positive y, so its defensive half is
+    /// negative y.
+    fn ball_reset_into_scoring_half(active: &ActiveKickoff, goal: &GoalEvent) -> bool {
+        if goal.scoring_team_is_team_0 {
+            active
+                .min_ball_y_after_first_touch
+                .is_some_and(|y| y < -KICKOFF_GOAL_MAX_DEFENSIVE_BALL_Y)
+        } else {
+            active
+                .max_ball_y_after_first_touch
+                .is_some_and(|y| y > KICKOFF_GOAL_MAX_DEFENSIVE_BALL_Y)
+        }
+    }
+
+    /// Attribute a qualifying goal (see [`Self::kickoff_goal_qualifies`]) that
+    /// landed after the kickoff's logical close to the concluded kickoff
+    /// event. Mirrors the attribution `finish_event` performs when the goal
+    /// arrives while the kickoff is still open.
     fn attribute_goal(event: &mut KickoffEvent, goal: &GoalEvent) {
         let Some(first_touch_time) = event.first_touch_time else {
             return;
         };
-        let time_to_goal = goal.time - first_touch_time;
-        if !(0.0..KICKOFF_GOAL_MAX_SECONDS).contains(&time_to_goal) {
-            return;
-        }
-        event.time_to_goal = Some(time_to_goal);
+        event.time_to_goal = Some(goal.time - first_touch_time);
         event.kickoff_goal = true;
         event.scoring_team_is_team_0 = Some(goal.scoring_team_is_team_0);
         if event.first_follow_up_touch_time.is_none() {
@@ -1104,7 +1195,7 @@ impl KickoffCalculator {
                 .map(|first_touch| goal.time - first_touch)
         });
         let kickoff_goal =
-            time_to_goal.is_some_and(|time| (0.0..KICKOFF_GOAL_MAX_SECONDS).contains(&time));
+            scoring_goal.is_some_and(|goal| Self::kickoff_goal_qualifies(&active, goal));
         let win_strength_band = win_strength
             .map(Self::win_strength_band)
             .unwrap_or_default();
@@ -1350,7 +1441,13 @@ impl KickoffCalculator {
                     ball: ctx.ball.clone(),
                 });
             }
+        } else {
+            // The frozen event no longer changes, but the kickoff-goal gates
+            // still need the touch chain and ball-position history through the
+            // attribution window.
+            Self::apply_touches(active, ctx.touch_state);
         }
+        Self::observe_ball_extent(active, ctx.ball);
 
         // Natural finalization happens in two stages. The kickoff *concludes*
         // once `should_finish` is met: its event content is frozen there
@@ -1362,9 +1459,17 @@ impl KickoffCalculator {
         // goal. The ledger keeps the in-flight kickoff queryable and
         // guarantees it is resolved at the end of the stream.
         let finished = self.active.advance(ctx.frame.time, |active| {
-            if let Some(event) = active.concluded.as_deref_mut() {
+            if active.concluded.is_some() {
                 if let Some(goal) = Self::earliest_goal(ctx.events) {
-                    Self::attribute_goal(event, goal);
+                    if Self::kickoff_goal_qualifies(active, goal) {
+                        let event = active
+                            .concluded
+                            .as_deref_mut()
+                            .expect("concluded checked above");
+                        Self::attribute_goal(event, goal);
+                    }
+                    // Whether or not the goal qualified, play stops here; no
+                    // later goal can belong to this kickoff.
                     return Disposition::Finalize(FinalizeReason::Completed);
                 }
                 let attribution_window_closed = active

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -2299,6 +2299,267 @@ fn kickoff_goal_attribution_window_closes_after_max_seconds() {
 }
 
 #[test]
+fn kickoff_goal_rejected_when_conceding_team_settles_possession_before_close() {
+    let blue_taker = PlayerId::Steam(70);
+    let orange_taker = PlayerId::Steam(71);
+    let mut calculator = KickoffCalculator::new();
+
+    calculator
+        .update(
+            &frame(0, 0.0),
+            &GameplayState {
+                ball_has_been_hit: Some(false),
+                ..GameplayState::default()
+            },
+            &ball(0.0),
+            &PlayerFrameState {
+                players: vec![
+                    player(
+                        blue_taker.clone(),
+                        true,
+                        glam::Vec3::new(-2048.0, -2560.0, 17.0),
+                        33.0,
+                    ),
+                    player(
+                        orange_taker.clone(),
+                        false,
+                        glam::Vec3::new(2048.0, 2560.0, 17.0),
+                        33.0,
+                    ),
+                ],
+            },
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    calculator
+        .update(
+            &frame(10, 1.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(0.0),
+            &PlayerFrameState::default(),
+            &TouchState {
+                touch_events: vec![touch(blue_taker.clone(), true, 10, 1.0)],
+                ..TouchState::default()
+            },
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    // The conceding (orange) team settles the ball: two touches spaced past
+    // the immediate-contest window with no blue touch between them.
+    for (frame_number, time) in [(15usize, 1.5f32), (21, 2.1)] {
+        calculator
+            .update(
+                &frame(frame_number, time),
+                &GameplayState {
+                    ball_has_been_hit: Some(true),
+                    ..GameplayState::default()
+                },
+                &ball(0.0),
+                &PlayerFrameState::default(),
+                &TouchState {
+                    touch_events: vec![touch(orange_taker.clone(), false, frame_number, time)],
+                    ..TouchState::default()
+                },
+                &FrameEventsState::default(),
+            )
+            .unwrap();
+    }
+
+    // Kickoff reaches its logical close (2s past the first touch).
+    calculator
+        .update(
+            &frame(31, 3.1),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(0.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+    assert!(calculator.events().is_empty());
+
+    // Blue wins the ball back and scores within the timing window, but the
+    // chain was broken by orange's settled possession.
+    calculator
+        .update(
+            &frame(50, 5.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(5200.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState {
+                goal_events: vec![goal(true, 50, 5.0)],
+                ..FrameEventsState::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    let event = calculator.events().last().unwrap();
+    assert!(!event.kickoff_goal);
+    assert_eq!(event.time_to_goal, None);
+}
+
+#[test]
+fn kickoff_goal_rejected_when_conceding_team_settles_possession_after_close() {
+    let blue_taker = PlayerId::Steam(72);
+    let blue_support = PlayerId::Steam(73);
+    let orange_taker = PlayerId::Steam(74);
+    let mut calculator =
+        concluded_kickoff_awaiting_attribution(&blue_taker, &blue_support, &orange_taker);
+
+    // After the logical close, orange settles the ball (two spaced touches)
+    // before blue regains it and scores.
+    for (frame_number, time) in [(35usize, 3.0f32), (42, 3.6)] {
+        calculator
+            .update(
+                &frame(frame_number, time),
+                &GameplayState {
+                    ball_has_been_hit: Some(true),
+                    ..GameplayState::default()
+                },
+                &ball(0.0),
+                &PlayerFrameState::default(),
+                &TouchState {
+                    touch_events: vec![touch(orange_taker.clone(), false, frame_number, time)],
+                    ..TouchState::default()
+                },
+                &FrameEventsState::default(),
+            )
+            .unwrap();
+    }
+
+    calculator
+        .update(
+            &frame(55, 5.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(5200.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState {
+                goal_events: vec![goal(true, 55, 5.0)],
+                ..FrameEventsState::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    let event = calculator.events().last().unwrap();
+    assert!(!event.kickoff_goal);
+    assert_eq!(event.time_to_goal, None);
+}
+
+#[test]
+fn kickoff_goal_rejected_when_ball_resets_into_scoring_half() {
+    let blue_taker = PlayerId::Steam(75);
+    let blue_support = PlayerId::Steam(76);
+    let orange_taker = PlayerId::Steam(77);
+    let mut calculator =
+        concluded_kickoff_awaiting_attribution(&blue_taker, &blue_support, &orange_taker);
+
+    // The ball is cleared deep into blue's defensive half: the play reset, so
+    // a later blue goal is buildup rather than a kickoff goal.
+    calculator
+        .update(
+            &frame(45, 4.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(-2000.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    calculator
+        .update(
+            &frame(55, 5.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(5200.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState {
+                goal_events: vec![goal(true, 55, 5.0)],
+                ..FrameEventsState::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    let event = calculator.events().last().unwrap();
+    assert!(!event.kickoff_goal);
+    assert_eq!(event.time_to_goal, None);
+}
+
+#[test]
+fn kickoff_goal_allows_deep_ball_in_conceding_half() {
+    let blue_taker = PlayerId::Steam(78);
+    let blue_support = PlayerId::Steam(79);
+    let orange_taker = PlayerId::Steam(80);
+    let mut calculator =
+        concluded_kickoff_awaiting_attribution(&blue_taker, &blue_support, &orange_taker);
+
+    // The ball traveling deep into orange's half is the normal shape of a
+    // blue kickoff goal and must not trip the field-position gate.
+    calculator
+        .update(
+            &frame(45, 4.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(4000.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    calculator
+        .update(
+            &frame(55, 5.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(5200.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState {
+                goal_events: vec![goal(true, 55, 5.0)],
+                ..FrameEventsState::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    let event = calculator.events().last().unwrap();
+    assert!(event.kickoff_goal);
+    let time_to_goal = event.time_to_goal.unwrap();
+    assert!((time_to_goal - 4.0).abs() < 1e-4);
+}
+
+#[test]
 fn next_kickoff_phase_flushes_kickoff_awaiting_attribution() {
     let blue_taker = PlayerId::Steam(66);
     let blue_support = PlayerId::Steam(67);


### PR DESCRIPTION
Stacked on #122 (deferred kickoff emission for late goal attribution).

## Problem

The only kickoff-goal condition was `0 ≤ goal.time − first_touch_time < 10s`. Ten seconds is an eternity: the ball can be settled by the other team, lost, cleared into a corner, recovered in the defensive half, and shot again — and the result would still be tagged a kickoff goal.

## New definition

A goal qualifies as a kickoff goal only when all three gates hold:

1. **Timing** (unchanged): within `KICKOFF_GOAL_MAX_SECONDS` (10s) of the kickoff's first touch.
2. **Unbroken possession chain**: the conceding team never *settled* the ball between the first touch and the goal. Settling = two conceding-team touches spaced past the immediate-contest window (`KICKOFF_POSSESSION_IMMEDIATE_CONTEST_SECONDS`, 0.35s) with no scoring-team touch in between. A single deflection / failed clear does not break the chain, and alternating 50/50 scramble touches stay eligible. The rule is symmetric: a team that loses the kickoff and concedes directly still produces a kickoff goal.
3. **Field position**: the ball never retreated more than `KICKOFF_GOAL_MAX_DEFENSIVE_BALL_Y` (1280uu) into the *scoring team's* own half between first touch and goal. If the play reset that deep, the eventual goal is buildup, not a kickoff goal.

## Implementation

- `ActiveKickoff` keeps appending touches and tracks running ball-y extremes **after the logical close** while the event awaits attribution in the `InFlightLedger`. The frozen event content is untouched; only the gate inputs keep accumulating.
- `kickoff_goal_qualifies()` is shared between the in-window path (`finish_event`, goal lands while the kickoff is open) and the deferred path (goal lands after the logical close), so both use a single definition.
- `KickoffGoalCalculator` (the `goal_context` tag) now consumes `KickoffCalculator` events as the **source of truth** instead of re-deriving its own `time_after_kickoff` heuristic from match stats — the two definitions would otherwise disagree whenever the gates reject a goal. The node gains a dependency on the kickoff node; matching is by scoring team + reconstructed goal time within a small epsilon.

## Tuning note

The 1280uu defensive-half threshold (quarter of a field half) is a first guess. Strict midfield would be too twitchy (kickoff 50/50s routinely bounce slightly backward); if real replays show misclassification we can tune the constant in one place.

## Tests

- 4 new kickoff tests: conceding-team settled possession before/after the logical close → rejected; ball reset into scoring half → rejected; deep ball in the conceding half (normal kickoff-goal shape) → still tagged.
- Existing scramble/contest tests (`kickoff_goal_preserves_actual_follow_up_contest`, `kickoff_goal_does_not_override_immediate_outcome`) confirm contested exchanges still qualify.
- `goal_tags` kickoff tests rewritten against the new kickoff-event matching.
- Full lib suite: 609 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)