### PR TITLE
fix(bootstrap): clean player names from remote ids without an in-game name

### DIFF
--- a/src/processor/bootstrap.rs
+++ b/src/processor/bootstrap.rs
@@ -187,9 +187,20 @@ impl<'a> ReplayProcessor<'a> {
     }
 }
 
+/// Derive a human-facing name from a player's remote id for use when no in-game
+/// name is available. Without this, callers fall back to the `Debug` formatting
+/// of the id (e.g. `Epic("3f67e5d2349f491c8b99825ec396a2…")`), which leaks the
+/// Rust enum representation into user-facing output.
 fn remote_id_display_name(player_id: &PlayerId) -> Option<String> {
-    match player_id {
-        boxcars::RemoteId::PlayStation(id) if !id.name.is_empty() => Some(id.name.clone()),
-        _ => None,
-    }
+    Some(match player_id {
+        boxcars::RemoteId::PlayStation(id) if !id.name.is_empty() => id.name.clone(),
+        boxcars::RemoteId::PlayStation(id) => id.online_id.to_string(),
+        boxcars::RemoteId::PsyNet(id) => id.online_id.to_string(),
+        boxcars::RemoteId::SplitScreen(id) => id.to_string(),
+        boxcars::RemoteId::Steam(id) => id.to_string(),
+        boxcars::RemoteId::Switch(id) => id.online_id.to_string(),
+        boxcars::RemoteId::Xbox(id) => id.to_string(),
+        boxcars::RemoteId::QQ(id) => id.to_string(),
+        boxcars::RemoteId::Epic(id) => id.clone(),
+    })
 }


### PR DESCRIPTION
## Problem

When a player has no resolvable in-game name, `ReplayProcessor`'s
`get_player_info` falls back to the Rust `Debug` formatting of the remote id:

```rust
.or_else(|| remote_id_display_name(player_id))
.unwrap_or_else(|| format!("{player_id:?}"));
```

For Epic Games players this surfaces strings like
`Epic("3f67e5d2349f491c8b99825ec396a2…")` directly in user-facing output
(replay viewers, exported player lists, etc.), since `remote_id_display_name`
only handled the `PlayStation` case and returned `None` for everything else.

## Fix

Extend `remote_id_display_name` to cover every `RemoteId` variant, returning
the bare platform id (online id) when no friendlier name is available. The
`Debug` fallback in `get_player_info` is now effectively unreachable for known
variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)