### PR TITLE
Dissolve boost pickup both/ghost/missed event-variant split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ README, or refactor-only commit.
 
 ## Unreleased
 
+- Dissolve the `boost_pickup_both` / `boost_pickup_ghost` / `boost_pickup_missed`
+  event-variant split: all boost pickups now surface under a single
+  `boost_pickup` review key. Corroboration provenance is still available as the
+  pickup payload's `detection` field (`both` | `inferred_only` | `reported_only`).
+
 ## v0.12.0 - 2026-05-28
 
 - Add stats-player event count derivation so timeline event totals can be

--- a/js/stat-evaluation-player/src/generated/eventDefinitionCatalog.generated.ts
+++ b/js/stat-evaluation-player/src/generated/eventDefinitionCatalog.generated.ts
@@ -44,18 +44,8 @@ export const EVENT_DEFINITION_CATALOG: EventDefinitionCatalogEntry[] = [
     "hidden_from_review": true,
     "variants": [
       {
-        "key": "boost_pickup_both",
-        "label": "Boost Pickup Both",
-        "category": "boost"
-      },
-      {
-        "key": "boost_pickup_ghost",
-        "label": "Boost Pickup Ghost",
-        "category": "boost"
-      },
-      {
-        "key": "boost_pickup_missed",
-        "label": "Boost Pickup Missed",
+        "key": "boost_pickup",
+        "label": "Boost Pickup",
         "category": "boost"
       }
     ]

--- a/src/stats/calculators/boost_tests.rs
+++ b/src/stats/calculators/boost_tests.rs
@@ -662,7 +662,7 @@ fn skips_inactive_pickup_without_observed_boost_gain() {
 }
 
 #[test]
-fn stale_unreported_boost_increase_is_counted_as_ghost_pickup() {
+fn stale_unreported_boost_increase_is_counted_as_inferred_only_pickup() {
     let mut calculator = BoostCalculator::new();
     let player_id = PlayerId::Steam(1);
     let (pad_position, _) = standard_soccar_boost_pad_layout()
@@ -729,7 +729,7 @@ fn stale_unreported_boost_increase_is_counted_as_ghost_pickup() {
 }
 
 #[test]
-fn non_live_boost_increase_is_not_counted_as_ghost_pickup() {
+fn non_live_boost_increase_is_not_counted_as_inferred_only_pickup() {
     let mut calculator = BoostCalculator::new();
     let player_id = PlayerId::Steam(1);
     let (pad_position, _) = standard_soccar_boost_pad_layout()

--- a/src/stats/calculators/event_definition.rs
+++ b/src/stats/calculators/event_definition.rs
@@ -461,23 +461,14 @@ macro_rules! register_event_producer {
 // Variant tables for expansion-parent definitions. Each parent is
 // `hidden_from_review` and surfaces these concrete keys instead. The keys must
 // match the ones serialized at runtime in the server's timeline expansion.
-const BOOST_PICKUP_VARIANTS: &[EventVariant] = &[
-    EventVariant::new(
-        "boost_pickup_both",
-        "Boost Pickup Both",
-        EventCategory::Boost,
-    ),
-    EventVariant::new(
-        "boost_pickup_ghost",
-        "Boost Pickup Ghost",
-        EventCategory::Boost,
-    ),
-    EventVariant::new(
-        "boost_pickup_missed",
-        "Boost Pickup Missed",
-        EventCategory::Boost,
-    ),
-];
+// All pickups surface under one key; the `detection` payload field
+// (`both` | `inferred_only` | `reported_only`) records corroboration provenance and is a
+// filter facet, not an event-type split.
+const BOOST_PICKUP_VARIANTS: &[EventVariant] = &[EventVariant::new(
+    "boost_pickup",
+    "Boost Pickup",
+    EventCategory::Boost,
+)];
 
 const ROTATION_PLAYER_VARIANTS: &[EventVariant] = &[EventVariant::new(
     "rotation_player_state_span",


### PR DESCRIPTION
## Summary

Boost pickups were surfaced as three separate review keys — `boost_pickup_both`, `boost_pickup_ghost`, `boost_pickup_missed` — derived from the pickup's `BoostPickupDetection`. Analysis across the 27 parseable replay assets (10,415 pickups) shows the trichotomy is **corroboration provenance** (which of the two detection channels — reported pad events vs inferred boost-amount jumps — saw the pickup), not a meaningful category of pickup:

- `both` = 83.6%, `reported_only` ("missed") = 13.5%, `inferred_only` ("ghost") = 2.9%
- ~83% of "missed" pickups still show a positive boost delta in their own before/after samples — they're real pickups that simply didn't pair with a separately-tracked inferred jump inside the 3-frame matching window
- "ghost" pickups concentrate in pre-2018 replay formats with sparse pad replication (one 2017 fixture is 100% inferred-only); modern replays run ~0–0.7%

The ghost/missed names misleadingly imply tracking errors when the union of the two channels is in fact catching essentially everything.

## Changes

- Replace the three-entry `BOOST_PICKUP_VARIANTS` table with a single `boost_pickup` review key
- Regenerate `eventDefinitionCatalog.generated.ts`
- Rename `*_ghost_pickup` test names to `*_inferred_only_pickup`
- CHANGELOG entry

`BoostPickupDetection` and the payload `detection` field are unchanged — provenance stays available as a filter facet (already how the stats player consumes it) and as a parser-health diagnostic.

## Test plan

- `cargo test boost --lib`, `cargo test event_definition --lib`, `cargo test event_stream --lib`
- JS: `eventCatalogParity.test.ts`, `boostPickupFilters.test.ts`, `timelineRanges.test.ts`

Downstream: rocket-sense's timeline expansion mints event types from these keys; a follow-up PR there will collapse its `boost_pickup_{both,ghost,missed}` event types onto `boost_pickup` and bump the vendored subtr-actor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)