### PR TITLE
feat(stats): give confirmed touches a stable identity (touch_id)

### DIFF
--- a/bakkesmod/rust/src/lib_tests/live_processor_view.rs
+++ b/bakkesmod/rust/src/lib_tests/live_processor_view.rs
@@ -137,6 +137,7 @@ fn live_processor_view_satisfies_processor_surface_from_live_frame() {
     frame.has_scored_on_team = 1;
 
     let touch_events = vec![TouchEvent {
+        touch_id: None,
         time: frame.time,
         frame: frame.frame_number as usize,
         player: Some(RemoteId::SplitScreen(2)),
@@ -417,6 +418,7 @@ fn live_processor_view_exposes_cumulative_history_for_aggregate_inputs() {
                 },
             }],
             touch_events: vec![TouchEvent {
+                touch_id: None,
                 time,
                 frame,
                 team_is_team_0: true,

--- a/bakkesmod/rust/src/live_events.rs
+++ b/bakkesmod/rust/src/live_events.rs
@@ -264,6 +264,7 @@ pub(crate) fn explicit_touch_events(
             continue;
         }
         accepted.push(TouchEvent {
+            touch_id: None,
             time,
             frame: frame_number,
             team_is_team_0,
@@ -647,6 +648,7 @@ impl SaLiveEventGenerator {
             touch_events = dodge_refreshed_events
                 .iter()
                 .map(|event| TouchEvent {
+                    touch_id: None,
                     time: event.time,
                     frame: event.frame,
                     team_is_team_0: event.is_team_0,

--- a/docs/event-definitions.md
+++ b/docs/event-definitions.md
@@ -1454,7 +1454,7 @@ A goal where the scorer flipped (dodged) into the ball on the scoring touch.
 
 **Approach**
 
-- Match the scorer's last touch to its touch-classification event by player and frame.
+- Match the scorer's last touch to its touch-classification event by touch id (player and frame for data predating touch ids).
 - Require the scoring touch's dodge state to be active and the touch to fall within the touch-to-goal window.
 - Limitation: the dodge state covers any active dodge overlapping the touch, so incidental flips that happen to contact the ball can also qualify; dodge direction toward the ball is not yet verified.
 

--- a/js/player/src/generated/TouchEvent.ts
+++ b/js/player/src/generated/TouchEvent.ts
@@ -2,7 +2,15 @@
 import type { RemoteIdTs } from "./RemoteIdTs.ts";
 import type { Vector3fTs } from "./Vector3fTs.ts";
 
-export type TouchEvent = { time: number, frame: number, team_is_team_0: boolean, player: RemoteIdTs | null, player_position?: Vector3fTs | null,
+export type TouchEvent = {
+/**
+ * Stable identity for an attributed touch, assigned monotonically when the
+ * stats pipeline confirms the touch. `None` for raw replay team markers,
+ * which exist before attribution. Downstream events that reference a touch
+ * carry this id so consumers can join exactly instead of matching on
+ * player + frame.
+ */
+touch_id?: number, time: number, frame: number, team_is_team_0: boolean, player: RemoteIdTs | null, player_position?: Vector3fTs | null,
 /**
  * Ball-to-car hitbox contact gap in uu for attributed touches, when estimated.
  *

--- a/js/stat-evaluation-player/src/generated/GoalTouchContext.ts
+++ b/js/stat-evaluation-player/src/generated/GoalTouchContext.ts
@@ -3,4 +3,10 @@ import type { GoalContextPosition } from "./GoalContextPosition.ts";
 import type { GoalPlayerContext } from "./GoalPlayerContext.ts";
 import type { RemoteIdTs } from "./RemoteIdTs.ts";
 
-export type GoalTouchContext = { time: number, frame: number, player: RemoteIdTs, is_team_0: boolean, ball_position: GoalContextPosition | null, ball_speed_after_touch?: number | null, player_position: GoalContextPosition | null, players: Array<GoalPlayerContext>, };
+export type GoalTouchContext = {
+/**
+ * Identity of the source [`TouchEvent`](crate::TouchEvent) for this
+ * scoring touch. Join on this instead of player + frame. `None` only for
+ * data serialized before touch ids existed.
+ */
+touch_id?: number, time: number, frame: number, player: RemoteIdTs, is_team_0: boolean, ball_position: GoalContextPosition | null, ball_speed_after_touch?: number | null, player_position: GoalContextPosition | null, players: Array<GoalPlayerContext>, };

--- a/js/stat-evaluation-player/src/generated/KickoffEvent.ts
+++ b/js/stat-evaluation-player/src/generated/KickoffEvent.ts
@@ -10,6 +10,11 @@ import type { RemoteIdTs } from "./RemoteIdTs.ts";
 
 export type KickoffEvent = { start_time: number, start_frame: number, end_time: number, end_frame: number, live_action_start_time: number | null, live_action_start_frame: number | null, movement_start_time: number, movement_start_frame: number, kickoff_type: KickoffType, kickoff_direction: KickoffDirection, first_touch_time: number | null, first_touch_frame: number | null, first_touch_team_is_team_0: boolean | null, first_touch_player: RemoteIdTs | null,
 /**
+ * Identity of the first kickoff [`TouchEvent`](crate::TouchEvent). Join on
+ * this instead of player + frame.
+ */
+first_touch_id?: number,
+/**
  * Ball position (field coordinates) at the frame of the first kickoff touch.
  */
 first_touch_ball_position: [number, number, number] | null,

--- a/js/stat-evaluation-player/src/generated/TouchClassificationEvent.ts
+++ b/js/stat-evaluation-player/src/generated/TouchClassificationEvent.ts
@@ -4,4 +4,10 @@ import type { RemoteIdTs } from "./RemoteIdTs.ts";
 import type { RoleState } from "./RoleState.ts";
 import type { TouchBallMovement } from "./TouchBallMovement.ts";
 
-export type TouchClassificationEvent = { time: number, frame: number, sample_time: number, sample_frame: number, player: RemoteIdTs, player_position?: [number, number, number] | null, is_team_0: boolean, kind: string, height_band: string, surface: string, dodge_state: string, intention: string, first_touch: boolean, contested: boolean, role: RoleState, play_depth: PlayDepthState, ball_speed_change: number, ball_movement?: TouchBallMovement | null, };
+export type TouchClassificationEvent = {
+/**
+ * Identity of the source [`TouchEvent`](crate::TouchEvent) this
+ * classification was derived from. Join on this instead of player + frame.
+ * `None` only for data serialized before touch ids existed.
+ */
+touch_id?: number, time: number, frame: number, sample_time: number, sample_frame: number, player: RemoteIdTs, player_position?: [number, number, number] | null, is_team_0: boolean, kind: string, height_band: string, surface: string, dodge_state: string, intention: string, first_touch: boolean, contested: boolean, role: RoleState, play_depth: PlayDepthState, ball_speed_change: number, ball_movement?: TouchBallMovement | null, };

--- a/src/collector/stats/playback_event_parsers.rs
+++ b/src/collector/stats/playback_event_parsers.rs
@@ -434,6 +434,7 @@ pub(in crate::collector::stats::playback) fn parse_touch_stats_event(
     let time = json_required_f32(object, "time")?;
     let frame = json_required_usize(object, "frame")?;
     Ok(TouchClassificationEvent {
+        touch_id: json_optional_u64(object.get("touch_id"))?,
         time,
         frame,
         sample_time: json_optional_f32(object.get("sample_time"))?.unwrap_or(time),
@@ -629,6 +630,7 @@ pub(in crate::collector::stats::playback) fn parse_goal_touch_context(
 ) -> SubtrActorResult<GoalTouchContext> {
     let object = json_object(value, "goal touch context")?;
     Ok(GoalTouchContext {
+        touch_id: json_optional_u64(object.get("touch_id"))?,
         time: json_required_f32(object, "time")?,
         frame: json_required_usize(object, "frame")?,
         player: json_required_remote_id(object, "player")?,
@@ -1165,6 +1167,7 @@ pub(in crate::collector::stats::playback) fn parse_kickoff_event(
         first_touch_frame: json_optional_usize(object.get("first_touch_frame"))?,
         first_touch_team_is_team_0: json_optional_bool(object.get("first_touch_team_is_team_0")),
         first_touch_player: json_optional_remote_id(object.get("first_touch_player"))?,
+        first_touch_id: json_optional_u64(object.get("first_touch_id"))?,
         first_touch_ball_position: json_optional_vec3(object.get("first_touch_ball_position"))?,
         first_touch_ball_abs_x: json_optional_f32(object.get("first_touch_ball_abs_x"))?,
         first_touch_ball_height: json_optional_f32(object.get("first_touch_ball_height"))?,

--- a/src/collector/stats/playback_json.rs
+++ b/src/collector/stats/playback_json.rs
@@ -368,6 +368,19 @@ pub(in crate::collector::stats::playback) fn json_optional_usize(
     }
 }
 
+pub(in crate::collector::stats::playback) fn json_optional_u64(
+    value: Option<&Value>,
+) -> SubtrActorResult<Option<u64>> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value.as_u64().map(Some).ok_or_else(|| {
+            SubtrActorError::new(SubtrActorErrorVariant::StatsSerializationError(
+                "Expected optional JSON value to be an unsigned integer".to_owned(),
+            ))
+        }),
+    }
+}
+
 pub(in crate::collector::stats::playback) fn json_optional_u32(
     value: Option<&Value>,
 ) -> SubtrActorResult<Option<u32>> {

--- a/src/domain/replay_model.rs
+++ b/src/domain/replay_model.rs
@@ -274,6 +274,14 @@ pub struct PlayerStatEvent {
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
 pub struct TouchEvent {
+    /// Stable identity for an attributed touch, assigned monotonically when the
+    /// stats pipeline confirms the touch. `None` for raw replay team markers,
+    /// which exist before attribution. Downstream events that reference a touch
+    /// carry this id so consumers can join exactly instead of matching on
+    /// player + frame.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(type = "number")]
+    pub touch_id: Option<u64>,
     pub time: f32,
     pub frame: usize,
     pub team_is_team_0: bool,

--- a/src/domain/replay_model_tests.rs
+++ b/src/domain/replay_model_tests.rs
@@ -17,6 +17,7 @@ fn rigid_body(position: glam::Vec3, velocity: Option<glam::Vec3>) -> boxcars::Ri
 
 fn touch_event(frame: usize, time: f32) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame,
         team_is_team_0: true,

--- a/src/processor/updaters/tracking.rs
+++ b/src/processor/updaters/tracking.rs
@@ -8,6 +8,7 @@ impl<'a> ReplayProcessor<'a> {
         team_is_team_0: bool,
     ) -> TouchEvent {
         TouchEvent {
+            touch_id: None,
             time: frame.time,
             frame: frame_index,
             team_is_team_0,

--- a/src/stats/calculators/backboard_bounce_tests.rs
+++ b/src/stats/calculators/backboard_bounce_tests.rs
@@ -55,6 +55,7 @@ fn players(samples: Vec<PlayerSample>) -> PlayerFrameState {
 
 fn touch(player: PlayerId, is_team_0: bool, gap: f32) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: is_team_0,

--- a/src/stats/calculators/ball_control_test_support.rs
+++ b/src/stats/calculators/ball_control_test_support.rs
@@ -60,6 +60,7 @@ pub(crate) fn touch_state_with_touch(frame: usize, time: f32) -> TouchState {
     let player_id = boxcars::RemoteId::Steam(1);
     TouchState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time,
             frame,
             team_is_team_0: true,
@@ -69,6 +70,7 @@ pub(crate) fn touch_state_with_touch(frame: usize, time: f32) -> TouchState {
             dodge_contact: false,
         }],
         last_touch: Some(TouchEvent {
+            touch_id: None,
             time,
             frame,
             team_is_team_0: true,

--- a/src/stats/calculators/center_tests.rs
+++ b/src/stats/calculators/center_tests.rs
@@ -37,6 +37,7 @@ fn touch(
     is_team_0: bool,
 ) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame: frame_number,
         team_is_team_0: is_team_0,
@@ -55,6 +56,7 @@ fn touch_with_gap(
     contact_gap: f32,
 ) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         closest_approach_distance: Some(contact_gap),
         ..touch(frame_number, time, player_id, is_team_0)
     }

--- a/src/stats/calculators/controlled_play_tests.rs
+++ b/src/stats/calculators/controlled_play_tests.rs
@@ -75,6 +75,7 @@ fn players(player_one_y: f32, player_two_y: f32) -> PlayerFrameState {
 
 fn touch(frame_number: usize, time: f32, player: PlayerId, is_team_0: bool) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame: frame_number,
         team_is_team_0: is_team_0,

--- a/src/stats/calculators/dodge_reset_tests.rs
+++ b/src/stats/calculators/dodge_reset_tests.rs
@@ -87,6 +87,7 @@ fn reset_event_at(
 
 fn touch_event(player: PlayerId, time: f32, frame: usize) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame,
         team_is_team_0: true,
@@ -99,6 +100,7 @@ fn touch_event(player: PlayerId, time: f32, frame: usize) -> TouchEvent {
 
 fn raw_team_touch_event(time: f32, frame: usize) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame,
         team_is_team_0: true,

--- a/src/stats/calculators/double_tap_tests.rs
+++ b/src/stats/calculators/double_tap_tests.rs
@@ -55,6 +55,7 @@ fn frame(frame_number: usize, time: f32) -> FrameInfo {
 
 fn touch(frame_number: usize, time: f32, player_id: PlayerId, is_team_0: bool) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame: frame_number,
         team_is_team_0: is_team_0,

--- a/src/stats/calculators/fifty_fifty_state_tests.rs
+++ b/src/stats/calculators/fifty_fifty_state_tests.rs
@@ -11,6 +11,7 @@ fn frame(frame_number: usize, time: f32) -> FrameInfo {
 
 fn touch(frame: usize, time: f32, player: PlayerId, team_is_team_0: bool) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame,
         team_is_team_0,

--- a/src/stats/calculators/fifty_fifty_tests.rs
+++ b/src/stats/calculators/fifty_fifty_tests.rs
@@ -36,6 +36,7 @@ fn player(player_id: PlayerId, is_team_0: bool, position: glam::Vec3) -> PlayerS
 
 fn touch(player_id: PlayerId, is_team_0: bool, dodge_contact: bool) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time: 1.0,
         frame: 10,
         team_is_team_0: is_team_0,
@@ -48,6 +49,7 @@ fn touch(player_id: PlayerId, is_team_0: bool, dodge_contact: bool) -> TouchEven
 
 fn touch_at(player_id: PlayerId, is_team_0: bool, time: f32, frame: usize) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame,
         team_is_team_0: is_team_0,

--- a/src/stats/calculators/flick_tests.rs
+++ b/src/stats/calculators/flick_tests.rs
@@ -139,6 +139,7 @@ fn counts_controlled_dodge_touch_with_large_ball_impulse() {
             ),
             &players(true),
             &touch_state(vec![TouchEvent {
+                touch_id: None,
                 time: 0.4,
                 frame: 4,
                 team_is_team_0: true,
@@ -198,6 +199,7 @@ fn labels_reverse_flicks_with_backflip_pitch_forward_impulse_and_rotation_under_
                 glam::Vec3::new(0.0, -5.0, 0.0),
             ),
             &touch_state(vec![TouchEvent {
+                touch_id: None,
                 time: 0.4,
                 frame: 4,
                 team_is_team_0: true,
@@ -272,6 +274,7 @@ fn labels_left_reverse_flicks_from_negative_setup_rotation() {
                 glam::Vec3::new(0.0, -5.0, 0.0),
             ),
             &touch_state(vec![TouchEvent {
+                touch_id: None,
                 time: 0.4,
                 frame: 4,
                 team_is_team_0: true,
@@ -334,6 +337,7 @@ fn frontflip_pitch_forward_impulse_is_not_labeled_reverse() {
             ),
             &players_with_yaw_and_angular_velocity(true, final_yaw, glam::Vec3::new(0.0, 5.0, 0.0)),
             &touch_state(vec![TouchEvent {
+                touch_id: None,
                 time: 0.4,
                 frame: 4,
                 team_is_team_0: true,
@@ -383,6 +387,7 @@ fn rejects_dodge_touch_without_controlled_setup() {
             &players(true),
             &TouchState {
                 touch_events: vec![TouchEvent {
+                    touch_id: None,
                     time: 0.2,
                     frame: 2,
                     team_is_team_0: true,
@@ -414,6 +419,7 @@ fn setup_with_multiple_control_touches_can_count_after_minimum_duration() {
                 &ball(glam::Vec3::new(60.0, 0.0, 112.0), glam::Vec3::ZERO),
                 &players(frame_number == 3),
                 &touch_state(vec![TouchEvent {
+                    touch_id: None,
                     time,
                     frame: frame_number,
                     team_is_team_0: true,
@@ -436,6 +442,7 @@ fn setup_with_multiple_control_touches_can_count_after_minimum_duration() {
             ),
             &players(true),
             &touch_state(vec![TouchEvent {
+                touch_id: None,
                 time: 0.4,
                 frame: 4,
                 team_is_team_0: true,
@@ -471,6 +478,7 @@ fn rejects_tiny_multi_touch_setup() {
                 &ball(glam::Vec3::new(60.0, 0.0, 112.0), glam::Vec3::ZERO),
                 &players(frame_number == 2),
                 &touch_state(vec![TouchEvent {
+                    touch_id: None,
                     time,
                     frame: frame_number,
                     team_is_team_0: true,
@@ -498,6 +506,7 @@ fn rejects_tiny_multi_touch_setup() {
             ),
             &players(true),
             &touch_state(vec![TouchEvent {
+                touch_id: None,
                 time: 0.06,
                 frame: 3,
                 team_is_team_0: true,
@@ -550,6 +559,7 @@ fn rejects_dodge_after_ball_has_left_car() {
             ),
             &players(true),
             &touch_state(vec![TouchEvent {
+                touch_id: None,
                 time: 0.5,
                 frame: 5,
                 team_is_team_0: true,

--- a/src/stats/calculators/goal_tags.rs
+++ b/src/stats/calculators/goal_tags.rs
@@ -354,7 +354,7 @@ pub const ALL_GOAL_TAG_DEFINITIONS: &[GoalTagDefinition] = &[
         "Flip-Into-Ball Goal",
         "A goal where the scorer flipped (dodged) into the ball on the scoring touch.",
         &[
-            "Match the scorer's last touch to its touch-classification event by player and frame.",
+            "Match the scorer's last touch to its touch-classification event by touch id (player and frame for data predating touch ids).",
             "Require the scoring touch's dodge state to be active and the touch to fall within the touch-to-goal window.",
             "Limitation: the dodge state covers any active dodge overlapping the touch, so incidental flips that happen to contact the ball can also qualify; dodge direction toward the ball is not yet verified.",
         ],
@@ -1424,9 +1424,14 @@ impl FlipIntoBallGoalCalculator {
         touch: &GoalTouchContext,
         goal: &GoalContextEvent,
     ) -> bool {
-        candidate.is_team_0 == goal.scoring_team_is_team_0
-            && candidate.player == touch.player
-            && candidate.frame == touch.frame
+        // Joining by touch identity is exact; player + frame remains as a
+        // fallback for data serialized before touch ids existed.
+        let same_touch = match (candidate.touch_id, touch.touch_id) {
+            (Some(candidate_id), Some(touch_id)) => candidate_id == touch_id,
+            _ => candidate.player == touch.player && candidate.frame == touch.frame,
+        };
+        same_touch
+            && candidate.is_team_0 == goal.scoring_team_is_team_0
             && candidate.dodge_state == FLIP_INTO_BALL_DODGE_STATE_LABEL
     }
 }

--- a/src/stats/calculators/goal_tags_tests.rs
+++ b/src/stats/calculators/goal_tags_tests.rs
@@ -14,6 +14,7 @@ fn scorer_touch(
     players: Vec<GoalPlayerContext>,
 ) -> GoalTouchContext {
     GoalTouchContext {
+        touch_id: None,
         time: 9.5,
         frame: 95,
         player: player_id(1),
@@ -265,6 +266,7 @@ fn touch_classification_event(
     dodge_state: &str,
 ) -> TouchClassificationEvent {
     TouchClassificationEvent {
+        touch_id: None,
         time,
         frame,
         sample_time: time,
@@ -524,6 +526,7 @@ fn kickoff_event_for_goal(
         first_touch_frame: None,
         first_touch_team_is_team_0: None,
         first_touch_player: None,
+        first_touch_id: None,
         first_touch_ball_position: None,
         first_touch_ball_abs_x: None,
         first_touch_ball_height: None,
@@ -909,6 +912,27 @@ fn flip_into_ball_goal_rejects_stale_touches() {
     let events = calculator.tag_goals(&[goal], &touches);
 
     assert!(events.is_empty());
+}
+
+#[test]
+fn flip_into_ball_goal_joins_by_touch_id_when_present() {
+    let mut goal = goal_with_touch(true, position(0.0, 2200.0, 130.0), Vec::new());
+    goal.scorer_last_touch.as_mut().unwrap().touch_id = Some(7);
+
+    // Same player + frame as the scoring touch, but a different identity:
+    // an id-bearing candidate that is not the scoring touch must not match.
+    let mut other_touch = touch_classification_event(9.5, 95, player_id(1), "dodge");
+    other_touch.touch_id = Some(6);
+    assert!(FlipIntoBallGoalCalculator::new()
+        .tag_goals(std::slice::from_ref(&goal), &[other_touch.clone()])
+        .is_empty());
+
+    // The candidate carrying the matching id is the scoring touch.
+    let mut scoring_touch = other_touch;
+    scoring_touch.touch_id = Some(7);
+    let events =
+        FlipIntoBallGoalCalculator::new().tag_goals(std::slice::from_ref(&goal), &[scoring_touch]);
+    assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlipIntoBallGoal]);
 }
 
 #[test]

--- a/src/stats/calculators/half_volley_tests.rs
+++ b/src/stats/calculators/half_volley_tests.rs
@@ -57,6 +57,7 @@ fn players(player_id: PlayerId, z: f32, dodge_active: bool) -> PlayerFrameState 
 
 fn touch(frame_number: usize, player_id: PlayerId) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time: frame_number as f32 * 0.1,
         frame: frame_number,
         team_is_team_0: true,

--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -82,6 +82,7 @@ struct ActiveKickoff {
     first_touch_time: Option<f32>,
     first_touch_frame: Option<usize>,
     first_touch_team_is_team_0: Option<bool>,
+    first_touch_id: Option<u64>,
     first_touch_ball_position: Option<[f32; 3]>,
     first_touch_ball_velocity: Option<[f32; 3]>,
     touches: Vec<KickoffTouchSnapshot>,
@@ -426,6 +427,7 @@ impl KickoffCalculator {
             first_touch_time: None,
             first_touch_frame: None,
             first_touch_team_is_team_0: None,
+            first_touch_id: None,
             first_touch_ball_position: None,
             first_touch_ball_velocity: None,
             touches: Vec::new(),
@@ -558,6 +560,7 @@ impl KickoffCalculator {
                 active.first_touch_time = Some(touch.time);
                 active.first_touch_frame = Some(touch.frame);
                 active.first_touch_team_is_team_0 = Some(touch.team_is_team_0);
+                active.first_touch_id = touch.touch_id;
                 active.first_touch_ball_position =
                     ball.position().map(|position| position.to_array());
                 active.first_touch_ball_velocity =
@@ -1361,6 +1364,7 @@ impl KickoffCalculator {
             first_touch_frame: active.first_touch_frame,
             first_touch_team_is_team_0: active.first_touch_team_is_team_0,
             first_touch_player,
+            first_touch_id: active.first_touch_id,
             first_touch_ball_position,
             first_touch_ball_abs_x,
             first_touch_ball_height,

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -59,6 +59,7 @@ fn ball_at(position: glam::Vec3, velocity: glam::Vec3) -> BallFrameState {
 
 fn touch(player: PlayerId, team_is_team_0: bool, frame: usize, time: f32) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame,
         team_is_team_0,
@@ -1969,6 +1970,7 @@ fn kickoff_stats_accumulate_boost_strength_fake_and_miss_counts() {
         first_touch_frame: Some(5),
         first_touch_team_is_team_0: Some(true),
         first_touch_player: Some(player_id.clone()),
+        first_touch_id: None,
         first_touch_ball_position: Some([0.0, 0.0, 92.0]),
         first_touch_ball_abs_x: Some(0.0),
         first_touch_ball_height: Some(92.0),

--- a/src/stats/calculators/kickoff_types.rs
+++ b/src/stats/calculators/kickoff_types.rs
@@ -339,6 +339,11 @@ pub struct KickoffEvent {
     pub first_touch_team_is_team_0: Option<bool>,
     #[ts(as = "Option<crate::interop::ts_bindings::RemoteIdTs>")]
     pub first_touch_player: Option<PlayerId>,
+    /// Identity of the first kickoff [`TouchEvent`](crate::TouchEvent). Join on
+    /// this instead of player + frame.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(type = "number")]
+    pub first_touch_id: Option<u64>,
     /// Ball position (field coordinates) at the frame of the first kickoff touch.
     pub first_touch_ball_position: Option<[f32; 3]>,
     /// Lateral centrality of the first-touch contact: `abs(x)` of the ball

--- a/src/stats/calculators/match_stats.rs
+++ b/src/stats/calculators/match_stats.rs
@@ -139,6 +139,12 @@ pub struct GoalPlayerContext {
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
 pub struct GoalTouchContext {
+    /// Identity of the source [`TouchEvent`](crate::TouchEvent) for this
+    /// scoring touch. Join on this instead of player + frame. `None` only for
+    /// data serialized before touch ids existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(type = "number")]
+    pub touch_id: Option<u64>,
     pub time: f32,
     pub frame: usize,
     #[ts(as = "crate::interop::ts_bindings::RemoteIdTs")]
@@ -641,6 +647,7 @@ impl MatchStatsCalculator {
             self.last_touch_context_by_player.insert(
                 player_id.clone(),
                 GoalTouchContext {
+                    touch_id: touch.touch_id,
                     time: touch.time,
                     frame: touch.frame,
                     player: player_id.clone(),

--- a/src/stats/calculators/match_stats_tests.rs
+++ b/src/stats/calculators/match_stats_tests.rs
@@ -197,6 +197,7 @@ fn goal_context_links_scorer_touch_with_ball_location_and_speeds() {
             },
             &TouchState {
                 touch_events: vec![TouchEvent {
+                    touch_id: None,
                     time: 1.0,
                     frame: 10,
                     team_is_team_0: true,
@@ -554,6 +555,7 @@ fn time_after_kickoff_uses_kickoff_first_touch_not_latest_touch() {
     let mut calculator = MatchStatsCalculator::new();
 
     let touch_event = |time: f32, frame: usize| TouchEvent {
+        touch_id: None,
         time,
         frame,
         team_is_team_0: true,

--- a/src/stats/calculators/one_timer_tests.rs
+++ b/src/stats/calculators/one_timer_tests.rs
@@ -32,6 +32,7 @@ fn frame(frame_number: usize, time: f32) -> FrameInfo {
 
 fn touch(frame_number: usize, time: f32, player_id: PlayerId, is_team_0: bool) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame: frame_number,
         team_is_team_0: is_team_0,

--- a/src/stats/calculators/ordering_tests.rs
+++ b/src/stats/calculators/ordering_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 
 fn touch(player_id: u64, contact_gap: f32) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time: 2.0,
         frame: 20,
         team_is_team_0: true,

--- a/src/stats/calculators/pass_tests.rs
+++ b/src/stats/calculators/pass_tests.rs
@@ -37,6 +37,7 @@ fn touch(
     is_team_0: bool,
 ) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame: frame_number,
         team_is_team_0: is_team_0,
@@ -55,6 +56,7 @@ fn touch_with_gap(
     contact_gap: f32,
 ) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         closest_approach_distance: Some(contact_gap),
         ..touch(frame_number, time, player_id, is_team_0)
     }

--- a/src/stats/calculators/possession_tests.rs
+++ b/src/stats/calculators/possession_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 
 fn touch(frame: usize, time: f32, player: PlayerId, team_is_team_0: bool) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame,
         team_is_team_0,

--- a/src/stats/calculators/touch.rs
+++ b/src/stats/calculators/touch.rs
@@ -72,6 +72,12 @@ struct TouchClassification {
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
 pub struct TouchClassificationEvent {
+    /// Identity of the source [`TouchEvent`](crate::TouchEvent) this
+    /// classification was derived from. Join on this instead of player + frame.
+    /// `None` only for data serialized before touch ids existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(type = "number")]
+    pub touch_id: Option<u64>,
     pub time: f32,
     pub frame: usize,
     pub sample_time: f32,
@@ -386,6 +392,7 @@ impl TouchCalculator {
                 },
             );
             let event = TouchClassificationEvent {
+                touch_id: touch_event.touch_id,
                 time: touch_event.time,
                 frame: touch_event.frame,
                 sample_time: frame.time,

--- a/src/stats/calculators/touch_intention_tests.rs
+++ b/src/stats/calculators/touch_intention_tests.rs
@@ -15,6 +15,7 @@ fn frame_at(time: f32) -> FrameInfo {
 
 fn touch_at(player_id: &PlayerId, time: f32) -> TouchEvent {
     TouchEvent {
+        touch_id: None,
         time,
         frame: (time * 10.0).round() as usize,
         team_is_team_0: true,

--- a/src/stats/calculators/touch_state.rs
+++ b/src/stats/calculators/touch_state.rs
@@ -128,6 +128,7 @@ pub struct TouchStateCalculator {
     recent_touch_candidates: HashMap<PlayerId, TouchEvent>,
     last_touch_times: HashMap<TouchCooldownKey, f32>,
     recent_team_touches: Vec<RecentTeamTouch>,
+    next_touch_id: u64,
 }
 
 impl TouchStateCalculator {
@@ -184,6 +185,7 @@ impl TouchStateCalculator {
                 }
 
                 Some(TouchEvent {
+                    touch_id: None,
                     time: frame.time,
                     frame: frame.frame_number,
                     team_is_team_0: player.is_team_0,
@@ -292,6 +294,7 @@ impl TouchStateCalculator {
                 *closest_contact_gap <= MARKER_CONTACT_ATTRIBUTION_MAX_GAP
             })
             .map(|(closest_contact_gap, player, rigid_body)| TouchEvent {
+                touch_id: None,
                 time: event.time,
                 frame: event.frame,
                 team_is_team_0: event.team_is_team_0,
@@ -346,6 +349,7 @@ impl TouchStateCalculator {
         };
 
         Some(TouchEvent {
+            touch_id: None,
             time: event.time,
             frame: event.frame,
             team_is_team_0: event.team_is_team_0,
@@ -403,6 +407,7 @@ impl TouchStateCalculator {
         candidate: TouchEvent,
     ) -> TouchEvent {
         TouchEvent {
+            touch_id: None,
             time: dodge_refresh.time,
             frame: dodge_refresh.frame,
             team_is_team_0: dodge_refresh.is_team_0,
@@ -494,6 +499,7 @@ impl TouchStateCalculator {
                     return None;
                 }
                 Some(TouchEvent {
+                    touch_id: None,
                     time: frame.time,
                     frame: frame.frame_number,
                     team_is_team_0: player.is_team_0,
@@ -658,7 +664,11 @@ impl TouchStateCalculator {
             self.prune_recent_touch_candidates(frame.frame_number);
             self.update_recent_touch_candidates(frame, ball, players);
             let touch_events = self.confirmed_touch_events(frame, ball, players, events);
-            let touch_events = self.apply_touch_cooldown(touch_events);
+            let mut touch_events = self.apply_touch_cooldown(touch_events);
+            for event in &mut touch_events {
+                event.touch_id = Some(self.next_touch_id);
+                self.next_touch_id += 1;
+            }
             self.record_recent_team_touches(frame.frame_number, &touch_events);
             touch_events
         } else {

--- a/src/stats/calculators/touch_state_tests.rs
+++ b/src/stats/calculators/touch_state_tests.rs
@@ -176,6 +176,7 @@ fn team_only_explicit_touch_events_without_physics_candidate_are_ignored() {
     };
     let events = FrameEventsState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time: 0.1,
             frame: 1,
             team_is_team_0: true,
@@ -207,6 +208,7 @@ fn team_only_explicit_touch_events_keep_event_time_when_enriched_from_recent_cac
     calculator.recent_touch_candidates.insert(
         player_id.clone(),
         TouchEvent {
+            touch_id: None,
             time: 0.1,
             frame: 1,
             team_is_team_0: true,
@@ -222,6 +224,7 @@ fn team_only_explicit_touch_events_keep_event_time_when_enriched_from_recent_cac
     };
     let events = FrameEventsState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time: 0.3,
             frame: 3,
             team_is_team_0: true,
@@ -259,6 +262,7 @@ fn team_only_explicit_touch_events_ignore_expired_recent_cache_candidates() {
     calculator.recent_touch_candidates.insert(
         player_id.clone(),
         TouchEvent {
+            touch_id: None,
             time: 0.1,
             frame: 1,
             team_is_team_0: true,
@@ -274,6 +278,7 @@ fn team_only_explicit_touch_events_ignore_expired_recent_cache_candidates() {
     };
     let events = FrameEventsState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time: 0.6,
             frame: 6,
             team_is_team_0: true,
@@ -307,6 +312,7 @@ fn dodge_refresh_touch_events_keep_refresh_time_when_enriched_from_recent_cache(
     calculator.recent_touch_candidates.insert(
         player_id.clone(),
         TouchEvent {
+            touch_id: None,
             time: 0.1,
             frame: 1,
             team_is_team_0: true,
@@ -359,6 +365,7 @@ fn dodge_refresh_touch_events_ignore_expired_recent_cache_candidates() {
     calculator.recent_touch_candidates.insert(
         player_id.clone(),
         TouchEvent {
+            touch_id: None,
             time: 0.1,
             frame: 1,
             team_is_team_0: true,
@@ -407,6 +414,7 @@ fn player_explicit_touch_events_without_physics_candidate_are_accepted() {
     };
     let events = FrameEventsState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time: 0.1,
             frame: 1,
             team_is_team_0: false,
@@ -469,6 +477,7 @@ fn player_explicit_touch_events_without_physics_choose_best_current_gap() {
     let events = FrameEventsState {
         touch_events: vec![
             TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: false,
@@ -478,6 +487,7 @@ fn player_explicit_touch_events_without_physics_choose_best_current_gap() {
                 dodge_contact: false,
             },
             TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: true,
@@ -518,6 +528,7 @@ fn player_explicit_touch_events_prefer_current_frame_over_stale_cache() {
     calculator.recent_touch_candidates.insert(
         player_id.clone(),
         TouchEvent {
+            touch_id: None,
             time: 0.1,
             frame: 1,
             team_is_team_0: false,
@@ -533,6 +544,7 @@ fn player_explicit_touch_events_prefer_current_frame_over_stale_cache() {
     };
     let events = FrameEventsState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time: 0.2,
             frame: 2,
             team_is_team_0: false,
@@ -586,6 +598,7 @@ fn explicit_touch_events_respect_same_player_cooldown() {
         &players,
         &FrameEventsState {
             touch_events: vec![TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: true,
@@ -604,6 +617,7 @@ fn explicit_touch_events_respect_same_player_cooldown() {
         &players,
         &FrameEventsState {
             touch_events: vec![TouchEvent {
+                touch_id: None,
                 time: 0.2,
                 frame: 2,
                 team_is_team_0: true,
@@ -622,6 +636,7 @@ fn explicit_touch_events_respect_same_player_cooldown() {
         &players,
         &FrameEventsState {
             touch_events: vec![TouchEvent {
+                touch_id: None,
                 time: 0.4,
                 frame: 4,
                 team_is_team_0: true,
@@ -655,6 +670,7 @@ fn aggregate_explicit_touch_cooldown_processes_events_chronologically() {
     let events = FrameEventsState {
         touch_events: vec![
             TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: true,
@@ -664,6 +680,7 @@ fn aggregate_explicit_touch_cooldown_processes_events_chronologically() {
                 dodge_contact: false,
             },
             TouchEvent {
+                touch_id: None,
                 time: 0.4,
                 frame: 4,
                 team_is_team_0: true,
@@ -712,6 +729,7 @@ fn aggregate_last_touch_uses_latest_touch_not_best_older_touch() {
     let events = FrameEventsState {
         touch_events: vec![
             TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: true,
@@ -721,6 +739,7 @@ fn aggregate_last_touch_uses_latest_touch_not_best_older_touch() {
                 dodge_contact: false,
             },
             TouchEvent {
+                touch_id: None,
                 time: 0.4,
                 frame: 4,
                 team_is_team_0: true,
@@ -765,6 +784,7 @@ fn explicit_touch_events_are_enriched_with_proximity_distance() {
     };
     let events = FrameEventsState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time: 0.1,
             frame: 1,
             team_is_team_0: true,
@@ -935,6 +955,7 @@ fn current_frame_physics_candidate_wins_over_explicit_team_hint() {
         &players,
         &FrameEventsState {
             touch_events: vec![TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: true,
@@ -992,6 +1013,7 @@ fn player_explicit_touch_events_are_kept_alongside_physics_candidates() {
         &players,
         &FrameEventsState {
             touch_events: vec![TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: false,
@@ -1039,6 +1061,7 @@ fn duplicate_player_explicit_touch_event_does_not_duplicate_physics_candidate() 
         &players,
         &FrameEventsState {
             touch_events: vec![TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: true,
@@ -1325,6 +1348,7 @@ fn primary_touch_prefers_current_candidate_over_older_equal_contested_candidate(
     calculator.recent_touch_candidates.insert(
         cached_opponent_id.clone(),
         TouchEvent {
+            touch_id: None,
             time: 0.1,
             frame: 1,
             team_is_team_0: false,
@@ -1371,6 +1395,7 @@ fn primary_touch_prefers_current_candidate_over_older_equal_contested_candidate(
 fn primary_touch_event_only_uses_current_frame_touch_events() {
     let player_id = boxcars::RemoteId::Steam(1);
     let stale_touch = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: true,
@@ -1394,6 +1419,7 @@ fn primary_touch_event_scores_current_events_without_last_touch_hint() {
     let best_player_id = boxcars::RemoteId::Steam(1);
     let secondary_player_id = boxcars::RemoteId::Steam(2);
     let best_touch = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: true,
@@ -1403,6 +1429,7 @@ fn primary_touch_event_scores_current_events_without_last_touch_hint() {
         dodge_contact: false,
     };
     let secondary_touch = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: false,
@@ -1431,6 +1458,7 @@ fn primary_touch_event_tie_breaks_by_player_id() {
     let lower_player_id = boxcars::RemoteId::Steam(2);
     let higher_player_id = boxcars::RemoteId::Steam(10);
     let lower_player_touch = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: true,
@@ -1440,6 +1468,7 @@ fn primary_touch_event_tie_breaks_by_player_id() {
         dodge_contact: false,
     };
     let higher_player_touch = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: true,
@@ -1468,6 +1497,7 @@ fn best_candidate_for_team_tie_breaks_by_player_id() {
     let lower_player_id = boxcars::RemoteId::Steam(2);
     let higher_player_id = boxcars::RemoteId::Steam(10);
     let lower_player_touch = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: true,
@@ -1477,6 +1507,7 @@ fn best_candidate_for_team_tie_breaks_by_player_id() {
         dodge_contact: false,
     };
     let higher_player_touch = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: true,
@@ -1504,6 +1535,7 @@ fn best_candidate_for_team_tie_breaks_by_player_id() {
 #[test]
 fn contested_touch_candidates_include_all_close_opponents() {
     let primary = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: true,
@@ -1513,6 +1545,7 @@ fn contested_touch_candidates_include_all_close_opponents() {
         dodge_contact: false,
     };
     let close_opponent = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: false,
@@ -1522,6 +1555,7 @@ fn contested_touch_candidates_include_all_close_opponents() {
         dodge_contact: false,
     };
     let second_close_opponent = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: false,
@@ -1531,6 +1565,7 @@ fn contested_touch_candidates_include_all_close_opponents() {
         dodge_contact: false,
     };
     let loose_opponent = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: false,
@@ -1558,6 +1593,7 @@ fn contested_touch_candidates_include_all_close_opponents() {
 #[test]
 fn contested_touch_candidates_ignore_stale_opponents() {
     let primary = TouchEvent {
+        touch_id: None,
         time: 0.5,
         frame: 5,
         team_is_team_0: true,
@@ -1567,6 +1603,7 @@ fn contested_touch_candidates_ignore_stale_opponents() {
         dodge_contact: false,
     };
     let adjacent_opponent = TouchEvent {
+        touch_id: None,
         time: 0.4,
         frame: 4,
         team_is_team_0: false,
@@ -1576,6 +1613,7 @@ fn contested_touch_candidates_ignore_stale_opponents() {
         dodge_contact: false,
     };
     let stale_opponent = TouchEvent {
+        touch_id: None,
         time: 0.2,
         frame: 2,
         team_is_team_0: false,
@@ -1594,4 +1632,47 @@ fn contested_touch_candidates_ignore_stale_opponents() {
     let contested = calculator.contested_touch_candidates(&primary);
 
     assert_eq!(contested, vec![adjacent_opponent]);
+}
+
+#[test]
+fn confirmed_touches_receive_unique_monotonic_touch_ids() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let players = players(player_id.clone());
+    let mut calculator = TouchStateCalculator::new();
+    let live_play = LivePlayState {
+        gameplay_phase: GameplayPhase::ActivePlay,
+        is_live_play: true,
+    };
+
+    calculator.update(
+        &frame(0),
+        &ball(glam::Vec3::ZERO),
+        &players,
+        &FrameEventsState::default(),
+        &live_play,
+    );
+    let first_touch = calculator.update(
+        &frame(1),
+        &ball(glam::Vec3::new(300.0, 0.0, 0.0)),
+        &players,
+        &FrameEventsState::default(),
+        &live_play,
+    );
+    let second_touch = calculator.update(
+        &frame(4),
+        &ball(glam::Vec3::new(1000.0, 0.0, 0.0)),
+        &players,
+        &FrameEventsState::default(),
+        &live_play,
+    );
+
+    let first_id = first_touch.touch_events[0].touch_id;
+    let second_id = second_touch.touch_events[0].touch_id;
+    assert!(first_id.is_some());
+    assert!(second_id.is_some());
+    assert!(second_id > first_id);
+    assert_eq!(
+        second_touch.last_touch.as_ref().unwrap().touch_id,
+        second_id
+    );
 }

--- a/src/stats/calculators/touch_tests.rs
+++ b/src/stats/calculators/touch_tests.rs
@@ -50,6 +50,7 @@ fn possession(player_id: &PlayerId, is_team_0: bool) -> PossessionState {
 fn touch_state(frame_number: usize, player_id: &PlayerId) -> TouchState {
     TouchState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time: frame_number as f32 * 0.1,
             frame: frame_number,
             team_is_team_0: true,
@@ -67,6 +68,7 @@ fn touch_state(frame_number: usize, player_id: &PlayerId) -> TouchState {
 fn dodge_contact_touch_state(frame_number: usize, player_id: &PlayerId) -> TouchState {
     TouchState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time: frame_number as f32 * 0.1,
             frame: frame_number,
             team_is_team_0: true,
@@ -503,6 +505,7 @@ fn credits_fifty_fifty_direction_to_resolved_winner_not_last_touch() {
     let initial_touch_state = TouchState {
         touch_events: vec![
             TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: true,
@@ -512,6 +515,7 @@ fn credits_fifty_fifty_direction_to_resolved_winner_not_last_touch() {
                 dodge_contact: false,
             },
             TouchEvent {
+                touch_id: None,
                 time: 0.1,
                 frame: 1,
                 team_is_team_0: false,
@@ -744,6 +748,7 @@ fn touch_with_default_rotation_state_records_unknown_role_and_depth() {
 fn touch_classification_events_follow_chronological_touch_event_order() {
     let player = boxcars::RemoteId::Steam(1);
     let early_touch = TouchEvent {
+        touch_id: None,
         time: 0.1,
         frame: 1,
         team_is_team_0: true,
@@ -753,6 +758,7 @@ fn touch_classification_events_follow_chronological_touch_event_order() {
         dodge_contact: false,
     };
     let late_touch = TouchEvent {
+        touch_id: None,
         time: 0.4,
         frame: 4,
         team_is_team_0: true,

--- a/src/stats/calculators/wall_aerial_tests.rs
+++ b/src/stats/calculators/wall_aerial_tests.rs
@@ -67,6 +67,7 @@ fn touch_state_with_touch(frame: usize, time: f32) -> TouchState {
     let player = boxcars::RemoteId::Steam(1);
     TouchState {
         touch_events: vec![TouchEvent {
+            touch_id: None,
             time,
             frame,
             team_is_team_0: true,
@@ -76,6 +77,7 @@ fn touch_state_with_touch(frame: usize, time: f32) -> TouchState {
             dodge_contact: false,
         }],
         last_touch: Some(TouchEvent {
+            touch_id: None,
             time,
             frame,
             team_is_team_0: true,

--- a/src/stats/calculators/whiff_tests.rs
+++ b/src/stats/calculators/whiff_tests.rs
@@ -131,6 +131,7 @@ fn touch_cancels_active_whiff_candidate() {
             },
             &TouchState {
                 touch_events: vec![TouchEvent {
+                    touch_id: None,
                     time: 0.2,
                     frame: 2,
                     team_is_team_0: true,
@@ -176,6 +177,7 @@ fn opponent_touch_counts_as_beaten_to_ball_not_whiff() {
             },
             &TouchState {
                 touch_events: vec![TouchEvent {
+                    touch_id: None,
                     time: 0.2,
                     frame: 2,
                     team_is_team_0: false,
@@ -224,6 +226,7 @@ fn teammate_touch_cancels_active_whiff_candidate() {
             },
             &TouchState {
                 touch_events: vec![TouchEvent {
+                    touch_id: None,
                     time: 0.2,
                     frame: 2,
                     team_is_team_0: true,


### PR DESCRIPTION
## Summary

Follow-up to #124. Touches had no stable identity, so every downstream relationship — matching a goal's scoring touch to its classification event, kickoff first-touch attribution — re-derived "same touch" by player + frame equality. That heuristic family has produced real bugs before (contested-kickoff touch drops), and the flip-into-ball goal tag added another instance of it.

- `TouchStateCalculator` stamps a monotonically increasing `touch_id` on every confirmed touch at its single emission point (after cooldown filtering). Raw replay team markers in `ReplayData` keep `touch_id: None` — they exist before attribution.
- The id is threaded through every event that references a touch: `TouchClassificationEvent.touch_id`, `GoalTouchContext.touch_id`, `KickoffEvent.first_touch_id`.
- The flip-into-ball goal tag joins by touch id when both sides carry one, falling back to player + frame for data serialized before ids existed. Playback parsers read the id back.
- `u64` ids use the existing `#[ts(type = "number")]` convention so TS bindings stay JSON-safe (`touch_id?: number`, not `bigint`).

The shared fields (time/frame/player) intentionally remain on each event as denormalized convenience for consumers reading events in isolation; the id fixes identity, not duplication.

## Test plan

- [x] New test: confirmed touches receive unique monotonic ids; `last_touch` carries the id
- [x] New test: flip-into-ball join matches by id and rejects same-player+frame candidates with a different id
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --lib` — 657 passed
- [x] `cargo test --manifest-path bakkesmod/rust/Cargo.toml` — 78 passed
- [x] `cargo check --manifest-path python/Cargo.toml` — clean
- [x] `docs/event-definitions.md` regenerated (flip-into-ball approach text updated)
- [x] TS bindings regenerated for both `js/player` (raw types) and `js/stat-evaluation-player` (stats types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)