### PR TITLE
fix(stats): detect boost-through and sloppier speed flips

### DIFF
--- a/crates/subtr-actor-tools/src/bin/kickoff_timing_dump.rs
+++ b/crates/subtr-actor-tools/src/bin/kickoff_timing_dump.rs
@@ -1,0 +1,116 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Context;
+use clap::Parser;
+use subtr_actor::{
+    EventPayload, KickoffEvent, KickoffTakerEvent, PlayerId, ReplayMeta, StatsTimelineCollector,
+};
+
+#[derive(Debug, Parser)]
+#[command(about = "Dump per-kickoff taker timing, spawn position, and approach.")]
+struct Args {
+    /// Replay paths to dump.
+    #[arg(value_name = "replay", num_args = 1..)]
+    paths: Vec<String>,
+}
+
+fn main() -> anyhow::Result<()> {
+    let Args { paths } = Args::parse();
+    // TSV header
+    println!("replay\ttaker\ttaker_id\tspawn\tapproach\ttime_to_ball\toutcome");
+    for path in paths {
+        if let Err(error) = dump_replay(&path) {
+            eprintln!("skip {path}: {error:?}");
+        }
+    }
+    Ok(())
+}
+
+fn dump_replay(path: &str) -> anyhow::Result<()> {
+    let replay = parse_replay(path)?;
+    let timeline = StatsTimelineCollector::new()
+        .get_legacy_replay_stats_timeline(&replay)
+        .map_err(|error| anyhow::anyhow!("failed to build stats timeline for {path}: {error:?}"))?;
+    let names = player_name_map(&timeline.replay_meta);
+    let short = Path::new(path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_owned());
+    for event in &timeline.events.events {
+        if let EventPayload::Kickoff(kickoff) = &event.payload {
+            emit_taker(&short, &names, kickoff, kickoff.team_zero_taker.as_ref());
+            emit_taker(&short, &names, kickoff, kickoff.team_one_taker.as_ref());
+        }
+    }
+    Ok(())
+}
+
+fn emit_taker(
+    replay: &str,
+    names: &HashMap<String, String>,
+    _kickoff: &KickoffEvent,
+    taker: Option<&KickoffTakerEvent>,
+) {
+    let Some(taker) = taker else {
+        return;
+    };
+    let name = player_name(names, &taker.player);
+    let id = player_id_string(&taker.player);
+    let spawn = taker.spawn_position.as_label_value();
+    let approach = taker.approach.as_label_value();
+    let time_to_ball = taker
+        .time_to_ball
+        .map(|value| format!("{value:.3}"))
+        .unwrap_or_else(|| "NA".to_owned());
+    let outcome = taker.outcome.as_label_value();
+    println!("{replay}\t{name}\t{id}\t{spawn}\t{approach}\t{time_to_ball}\t{outcome}");
+}
+
+fn parse_replay(path: &str) -> anyhow::Result<boxcars::Replay> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("failed to read {}", Path::new(path).display()))?;
+    boxcars::ParserBuilder::new(&bytes)
+        .always_check_crc()
+        .must_parse_network_data()
+        .parse()
+        .with_context(|| format!("failed to parse {}", Path::new(path).display()))
+}
+
+fn player_name_map(meta: &ReplayMeta) -> HashMap<String, String> {
+    meta.team_zero
+        .iter()
+        .chain(meta.team_one.iter())
+        .map(|player| (player_id_string(&player.remote_id), player.name.clone()))
+        .collect()
+}
+
+fn player_name(names: &HashMap<String, String>, player_id: &PlayerId) -> String {
+    let id = player_id_string(player_id);
+    names.get(&id).cloned().unwrap_or(id)
+}
+
+fn player_id_string(player_id: &PlayerId) -> String {
+    match serde_json::to_value(player_id) {
+        Ok(serde_json::Value::Object(map)) if map.len() == 1 => {
+            let (kind, value) = map.into_iter().next().expect("map has one value");
+            let id = value
+                .as_object()
+                .and_then(|object| object.get("online_id"))
+                .and_then(json_scalar_text)
+                .or_else(|| json_scalar_text(&value))
+                .unwrap_or_else(|| value.to_string());
+            format!("{kind}:{id}")
+        }
+        Ok(value) => value.to_string(),
+        Err(_) => format!("{player_id:?}"),
+    }
+}
+
+fn json_scalar_text(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}

--- a/src/stats/calculators/speed_flip.rs
+++ b/src/stats/calculators/speed_flip.rs
@@ -16,8 +16,10 @@ const SPEED_FLIP_MIN_ESTIMATED_DODGE_SIDE_COMPONENT: f32 = 0.88;
 const SPEED_FLIP_MAX_ESTIMATED_DODGE_SIDE_COMPONENT: f32 = 0.95;
 const SPEED_FLIP_MAX_ESTIMATED_DODGE_UP_COMPONENT: f32 = 0.82;
 const SPEED_FLIP_MIN_DIAGONAL_SCORE: f32 = 0.35;
-const SPEED_FLIP_MIN_STRONG_DIAGONAL_SCORE: f32 = 0.90;
+const SPEED_FLIP_MIN_STRONG_DIAGONAL_SCORE: f32 = 0.75;
 const SPEED_FLIP_MIN_UP_ROTATION_DEGREES: f32 = 90.0;
+const SPEED_FLIP_MAX_CANCELLED_FORWARD_ROTATION_DEGREES: f32 = 45.0;
+const SPEED_FLIP_MIN_BOOST_ALIGNMENT: f32 = 0.80;
 const SPEED_FLIP_MIN_CONFIDENCE: f32 = 0.45;
 const BOOST_ACCELERATION_UU_PER_SECOND_SQUARED: f32 = 991.6667;
 
@@ -536,7 +538,15 @@ impl SpeedFlipCalculator {
                 .contains(&estimated_dodge_side_component)
             && estimated_dodge_up_component <= SPEED_FLIP_MAX_ESTIMATED_DODGE_UP_COMPONENT
             && candidate.best_diagonal_score >= SPEED_FLIP_MIN_DIAGONAL_SCORE;
-        if !(has_strong_diagonal_rotation || has_diagonal_impulse) {
+        // Boost-through speed flips suppress the estimated dodge impulse (the
+        // boost compensation swallows it) and sloppier flips land below the
+        // strong-rotation score, but the flip cancel itself leaves a crisp
+        // signature: the car's up vector sweeps through the dodge rotation
+        // while the nose barely pitches because the cancel levels it out.
+        let has_cancelled_diagonal_dodge = candidate.max_forward_rotation_degrees
+            <= SPEED_FLIP_MAX_CANCELLED_FORWARD_ROTATION_DEGREES
+            && candidate.best_diagonal_score >= SPEED_FLIP_MIN_DIAGONAL_SCORE;
+        if !(has_strong_diagonal_rotation || has_diagonal_impulse || has_cancelled_diagonal_dodge) {
             return None;
         }
         let boost_alignment_score =
@@ -548,7 +558,10 @@ impl SpeedFlipCalculator {
             + 0.05 * boost_alignment_score
             + 0.05 * timeliness_score;
 
-        if boost_alignment_score < 0.25 {
+        // Mid-flip the car is yawed off its velocity axis, so raw alignment of
+        // a boost-through speed flip tops out around ~0.82 inside the short
+        // evaluation window; gate on the raw alignment rather than the score.
+        if candidate.best_boost_alignment < SPEED_FLIP_MIN_BOOST_ALIGNMENT {
             return None;
         }
         if cancel_score < 0.35 || confidence < SPEED_FLIP_MIN_CONFIDENCE {


### PR DESCRIPTION
## Problem

`SpeedFlipCalculator` rejected most genuine speed flips for players who hold boost through the flip, and `KickoffCalculator::classify_approach` labels every missed speed flip as `diagonal_flip` (its fallback for any dodge with a high side component). In production this labeled ~90% of one player's kickoff speed flips as `diagonal_flip` (580 diagonal_flip vs 22 speed_flip across 653 taker kickoffs).

Two failure modes, confirmed via debug instrumentation on the rejected candidates:

1. **Boost-through impulse suppression.** `dodge_boost_compensation` (`local_forward × 991.67 uu/s² × dt`) over-subtracts the velocity delta when boost is held through the dodge, crushing `best_estimated_dodge_impulse_magnitude` below the 90 uu/s floor — so the impulse-based qualification path is dead for exactly the input pattern a speed flip requires.
2. **Strong-rotation bar too high.** With the impulse path dead, qualification needed `best_diagonal_score >= 0.90`; genuine (slightly sloppy) speed flips score 0.59–0.90.

## Fix

- Lower `SPEED_FLIP_MIN_STRONG_DIAGONAL_SCORE` 0.90 → 0.75.
- Add a **cancelled-diagonal-dodge** qualification path: the flip cancel leaves a crisp signature — the up vector sweeps ≥90° while the nose pitches <45° because the cancel levels it out. Full diagonal flips have forward rotation ≈ up rotation ≈ 130–150°, so the 45° bar sits in a wide empirical gap (observed cancelled flips: 2–32°).
- Gate on raw `best_boost_alignment >= 0.80` instead of the normalized score (which required ≥0.8625 raw): mid-flip yaw caps raw alignment near ~0.82 inside the short evaluation window.

Also adds `kickoff_timing_dump`, a subtr-actor-tools binary emitting per-kickoff-taker TSV (spawn, approach, time-to-ball, outcome) used for the validation below.

## Validation

**Affected player, 50 replays (taker kickoffs):**

| approach | before | after |
|---|---|---|
| speed_flip | 7 | 113 |
| diagonal_flip | 138 | 43 |
| front_flip | 40 | 37 |

**83 pro replays (Zen, Squishy Muffinz et al., 1083 taker kickoffs):**

| approach | before | after |
|---|---|---|
| speed_flip | 661 | 886 |
| diagonal_flip | 174 | 75 |
| boost_into_ball | 194 | 92 |
| front_flip | 37 | 13 |

Per-pro: Zen 90→135 of 160, M0nkey M00n 21→33 of 34, TempoH 55→75 — consistent with pros speed-flipping nearly every kickoff.

**Timing consistency (pro diagonal spawns, time-to-ball):** newly detected speed flips median 1.933s vs already-detected 1.940s vs still-diagonal 1.956s — the new detections are timing-identical to known speed flips, not slower mislabels.

**Tests:** both human-reviewed replay regression tests pass (confirmed speed flip kept, reviewed false positives still rejected), plus the 13 speed_flip and 55 kickoff unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)