### PR TITLE
Patch boxcars to the World Cup fork for standalone builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,8 +97,7 @@ checksum = "40ce3582fb888755eb1a77668e69f90c3b317fdcc85bbeacd0d9bdfa89427173"
 [[package]]
 name = "boxcars"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1431e9bfa0c6d7d6d76e0b99d7035c7e13c7243f8ac11ffdcf5d92fbb57abdfa"
+source = "git+https://github.com/colonelpanic8/boxcars.git?rev=36598aa6db6ff9248502f9f762139ed3bdd94a34#36598aa6db6ff9248502f9f762139ed3bdd94a34"
 dependencies = [
  "bitter",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,14 @@ repository = "rlrml/subtr-actor"
 
 [badges.maintenance]
 status = "actively-developed"
+
+# A recent Rocket League update (World Cup event ball + player-name
+# anonymization) added network objects that boxcars 0.11.1 cannot decode,
+# which makes `must_parse_network_data()` fail on affected replays. Until the
+# fix lands in an upstream boxcars release, point standalone builds at the
+# patched fork. (Cargo ignores this section when subtr-actor is consumed as a
+# dependency and strips it on publish, so the crates.io version range above is
+# what downstream consumers still resolve.)
+# See https://github.com/colonelpanic8/boxcars/tree/fix/worldcup-ball
+[patch.crates-io]
+boxcars = { git = "https://github.com/colonelpanic8/boxcars.git", rev = "36598aa6db6ff9248502f9f762139ed3bdd94a34" }


### PR DESCRIPTION
## Why

A recent Rocket League update shipped the **World Cup event ball** and a **player-name anonymization** feature, adding three network objects that `boxcars` 0.11.1 cannot decode. `must_parse_network_data()` fails on any replay containing them:

- `Archetypes.Ball.Ball_WorldCup`
- `TAGame.PRI_TA:AnonymizedName`
- `TAGame.PRI_TA:bReceivedAnonymizationSettings`

The boxcars fix is in [colonelpanic8/boxcars@36598aa](https://github.com/colonelpanic8/boxcars/commit/36598aa6db6ff9248502f9f762139ed3bdd94a34) (upstream PR: nickbabcock/boxcars#283).

## What

Add `[patch.crates-io]` pointing boxcars at the patched fork so **standalone** subtr-actor builds (its own tests / CI / other consumers building it as a workspace root) parse these replays. This mirrors the patch rocket-sense applies at its own workspace root.

Cargo ignores `[patch]` sections from a manifest when the crate is consumed as a dependency, and strips them on publish — so the `>=0.11.1, <1.0.0` crates.io range is unchanged for downstream consumers; only local/standalone builds are affected.

## Verification

`cargo build -p subtr-actor` resolves boxcars to the git fork and compiles clean. Drop this patch once the fix lands in an upstream boxcars release.