### PR TITLE
chore(nix): single-source crate pins via hash-free git dep fetching

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,9 +122,10 @@
             let
               vendorDir = rustPlatform.importCargoLock {
                 lockFile = ./Cargo.lock;
-                outputHashes = {
-                  "boxcars-0.11.1" = "sha256-G6uUsXLqlZr2g3x8sIbrTx2Z3TX7shXxBqIPfQe/9Xo=";
-                };
+                # Fetch git dependencies (e.g. patched boxcars) via
+                # builtins.fetchGit so Cargo.lock stays the single source of
+                # truth — no outputHashes entry to keep in sync by hand.
+                allowBuiltinFetchGit = true;
                 extraRegistries = {
                   "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
                 };
@@ -198,7 +199,12 @@
           pname = "subtr-actor-bakkesmod-plugin";
           version = projectVersion;
           src = ./.;
-          cargoLock.lockFile = ./Cargo.lock;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            # Same as js-web-wasm: hash-free git-dependency fetching keeps
+            # Cargo.lock the single source of truth for crate revisions.
+            allowBuiltinFetchGit = true;
+          };
           nativeBuildInputs = [
             pkgs.cmake
             pkgs.llvmPackages_21.clang-unwrapped


### PR DESCRIPTION
## Why

The boxcars rev was effectively pinned in two places:

1. `Cargo.toml` `[patch.crates-io]` → `Cargo.lock` (the real pin)
2. a hand-maintained `outputHashes` entry in `flake.nix`'s `importCargoLock`

Forgetting to update (2) when (1) changed already broke the GitHub Pages build once (00662654 had to add the hash after the fact). And the bakkesmod plugin's `cargoLock` had no `outputHashes` at all, so it would fail on any git dependency.

## What

Set `allowBuiltinFetchGit = true` on both `importCargoLock` (js-web-wasm) and the bakkesmod plugin's `cargoLock`. Nix then fetches git dependencies via `builtins.fetchGit`, which needs no output hash because the lockfile's full rev is already an exact pin.

Result: `Cargo.toml`/`Cargo.lock` is the **single place** a crate revision lives. Bumping boxcars (e.g. when the World Cup fix lands upstream and the fork patch is dropped) is just editing the `[patch.crates-io]` rev and running `cargo update -p boxcars` — no flake change needed.

## Verification

- `nix build .#js-web-wasm` ✓
- `nix build .#js-stats-player-pages` ✓ (the bundle rocket-sense vendors for the in-browser player)

🤖 Generated with [Claude Code](https://claude.com/claude-code)