### PR TITLE
Enrich stats timeline event labels and add controlled_play spans

### DIFF
--- a/js/stat-evaluation-player/src/eventTimelineSources.test.ts
+++ b/js/stat-evaluation-player/src/eventTimelineSources.test.ts
@@ -180,11 +180,138 @@ test("event playlist sources include generic stats event streams such as positio
         sourceLabel: "Positioning Activity",
         time: 1.25,
         frame: 12,
-        label: "Blue positioning activity",
+        label: "Blue positioning active | 0.05s",
         shortLabel: "PA",
         playerId: "Steam:blue-id",
         playerName: "Blue",
         isTeamZero: true,
+      },
+    ],
+  );
+});
+
+test("controlled play timeline source renders spans as timeline ranges", () => {
+  const replay = {
+    frames: Array.from({ length: 13 }, (_, frame) => ({
+      time: frame === 5 ? 0.55 : frame === 12 ? 1.25 : frame,
+    })),
+    players: [{ id: "Steam:blue-id", name: "Blue" }],
+    timelineEvents: [],
+  } as ReplayModel;
+  const statsTimeline = createStatsTimeline({
+    events: {
+      controlled_play: [
+        {
+          player_id: { Steam: "blue-id" },
+          is_team_0: true,
+          start_frame: 5,
+          end_frame: 12,
+          start_time: 0.5,
+          end_time: 1.2,
+          duration: 0.7,
+          first_touch_frame: 5,
+          last_touch_frame: 12,
+          first_touch_time: 0.5,
+          last_touch_time: 1.2,
+          touch_count: 2,
+          close_duration: 0.6,
+          total_advance_distance: 400,
+        },
+      ],
+    },
+  });
+  const ctx = {
+    replay,
+    statsTimeline,
+  } as StatModuleContext;
+
+  const timelineSources = getTestTimelineSources(ctx);
+  const controlledPlaySource = timelineSources.find(
+    (source) => source.id === "stats-stream:controlled_play",
+  );
+
+  assert.ok(controlledPlaySource);
+  assert.equal(controlledPlaySource.count, 1);
+  assert.deepEqual(controlledPlaySource.buildTimelineEvents(), []);
+  assert.deepEqual(controlledPlaySource.buildTimelineRanges?.(), [
+    {
+      id: "stats-stream:controlled_play:5:12:0",
+      startTime: 0.55,
+      endTime: 1.25,
+      lane: "stats-stream:controlled_play",
+      laneLabel: "Controlled Play",
+      label: "Blue controlled play",
+      shortLabel: "CP",
+      isTeamZero: true,
+      color: "#3b82f6",
+    },
+  ]);
+});
+
+test("generic ball half playlist events include field half and duration", () => {
+  const replay = {
+    frames: Array.from({ length: 8 }, (_, frame) => ({ time: frame * 0.5 })),
+    players: [],
+    timelineEvents: [],
+  } as ReplayModel;
+  const statsTimeline = createStatsTimeline({
+    events: {
+      ball_half: [
+        {
+          time: 1,
+          frame: 2,
+          end_time: 2.5,
+          end_frame: 5,
+          active: true,
+          duration: 1.5,
+          field_half: "team_zero_side",
+        },
+        {
+          time: 2.5,
+          frame: 5,
+          end_time: 3,
+          end_frame: 6,
+          active: false,
+          duration: 0.5,
+          field_half: "neutral",
+        },
+      ],
+    },
+  });
+  const ctx = {
+    replay,
+    statsTimeline,
+  } as StatModuleContext;
+  const playlistSources = getEventPlaylistSources(ctx, getTestTimelineSources(ctx));
+
+  const items = buildEventPlaylistItems({
+    sources: playlistSources,
+    activeSourceIds: new Set(["stats-stream:ball_half"]),
+    replayPlayers: replay.players,
+  });
+
+  assert.deepEqual(
+    items.map((item) => ({
+      sourceId: item.sourceId,
+      time: item.event.time,
+      frame: item.event.frame,
+      label: item.event.label,
+      shortLabel: item.event.shortLabel,
+    })),
+    [
+      {
+        sourceId: "stats-stream:ball_half",
+        time: 2.5,
+        frame: 5,
+        label: "Ball on blue side | 1.5s",
+        shortLabel: "BH",
+      },
+      {
+        sourceId: "stats-stream:ball_half",
+        time: 3,
+        frame: 6,
+        label: "Ball half inactive | 0.5s",
+        shortLabel: "BH",
       },
     ],
   );

--- a/js/stat-evaluation-player/src/eventTimelineSources.ts
+++ b/js/stat-evaluation-player/src/eventTimelineSources.ts
@@ -47,6 +47,7 @@ const SPAN_BASED_STATS_EVENT_STREAM_IDS = new Set<string>([
   "possession",
   "ball_half",
   "territorial_pressure",
+  "controlled_play",
   "positioning_field_zone",
   "rotation_role_span",
   "rotation_depth_span",
@@ -170,6 +171,141 @@ function eventStreamShortLabel(streamId: string): string {
   );
 }
 
+function formatSeconds(value: unknown): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const digits = Math.abs(value) < 1 ? 2 : 1;
+  const seconds = value
+    .toFixed(digits)
+    .replace(/\.0+$/, "")
+    .replace(/(\.\d*[1-9])0+$/, "$1");
+  return `${seconds}s`;
+}
+
+function titleCaseValue(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  return value
+    .split(/[_-]+/)
+    .filter((part) => part.length > 0)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function formatFieldHalf(value: unknown): string | null {
+  if (value === "team_zero_side") return "Blue side";
+  if (value === "team_one_side") return "Orange side";
+  if (value === "neutral") return "Neutral zone";
+  return titleCaseValue(value);
+}
+
+function formatFieldThird(value: unknown): string | null {
+  const label = titleCaseValue(value);
+  return label ? `${label.toLowerCase()} third` : null;
+}
+
+function payloadRecord(event: Event): Record<string, unknown> {
+  return isRecord(event.payload.payload) ? event.payload.payload : {};
+}
+
+function joinEventDetails(parts: Array<string | null>): string {
+  return parts.filter((part): part is string => Boolean(part)).join(" | ");
+}
+
+function formatGenericStatsEventLabel({
+  event,
+  playerName,
+  streamLabel,
+  teamLabel,
+}: {
+  event: Event;
+  playerName: string | null;
+  streamLabel: string;
+  teamLabel: string | null;
+}): string {
+  const payload = payloadRecord(event);
+  const duration = formatSeconds(payload.duration);
+
+  if (event.payload.kind === "ball_half") {
+    const half = formatFieldHalf(payload.field_half);
+    const state =
+      payload.active === false
+        ? "Ball half inactive"
+        : half
+          ? `Ball on ${half.toLowerCase()}`
+          : null;
+    return joinEventDetails([state ?? streamLabel, duration]);
+  }
+
+  if (event.payload.kind === "territorial_pressure") {
+    const reason = titleCaseValue(payload.end_reason);
+    const main = `${teamLabel ?? ""} territorial pressure`.trim();
+    return joinEventDetails([reason ? `${main} ended: ${reason.toLowerCase()}` : main, duration]);
+  }
+
+  if (event.payload.kind === "possession") {
+    const state = titleCaseValue(payload.possession_state);
+    const third = formatFieldThird(payload.field_third);
+    const main = state ? `${state} possession` : streamLabel;
+    return joinEventDetails([main, third, duration]);
+  }
+
+  if (event.payload.kind === "controlled_play") {
+    const prefix = playerName ? `${playerName} controlled play` : streamLabel;
+    return joinEventDetails([prefix, duration]);
+  }
+
+  if (event.payload.kind === "positioning_activity") {
+    const state =
+      payload.demolished === true
+        ? "demolished"
+        : payload.active === false
+          ? "inactive"
+          : payload.tracked === false
+            ? "untracked"
+            : "active";
+    const prefix = playerName ? `${playerName} positioning` : streamLabel;
+    return joinEventDetails([`${prefix} ${state}`, duration]);
+  }
+
+  if (event.payload.kind === "positioning_field_zone") {
+    const defensive = Number(payload.defensive_zone_fraction ?? 0);
+    const neutral = Number(payload.neutral_zone_fraction ?? 0);
+    const offensive = Number(payload.offensive_zone_fraction ?? 0);
+    const zone =
+      defensive >= neutral && defensive >= offensive
+        ? "defensive zone"
+        : offensive >= neutral
+          ? "offensive zone"
+          : "neutral zone";
+    const prefix = playerName ? `${playerName} positioning` : streamLabel;
+    return joinEventDetails([`${prefix} in ${zone}`, duration]);
+  }
+
+  if (event.payload.kind === "rotation_role_span") {
+    const role = titleCaseValue(payload.current_role_state);
+    const prefix = playerName ? `${playerName} rotation` : streamLabel;
+    return joinEventDetails([role ? `${prefix}: ${role.toLowerCase()}` : prefix, duration]);
+  }
+
+  if (event.payload.kind === "rotation_depth_span") {
+    const depth = titleCaseValue(payload.current_depth_state);
+    const prefix = playerName ? `${playerName} rotation depth` : streamLabel;
+    return joinEventDetails([depth ? `${prefix}: ${depth.toLowerCase()}` : prefix, duration]);
+  }
+
+  if (event.payload.kind === "rotation_first_man_stint") {
+    const prefix = playerName ? `${playerName} first-man stint` : streamLabel;
+    return joinEventDetails([prefix, duration]);
+  }
+
+  return playerName ? `${playerName} ${streamLabel.toLowerCase()}` : streamLabel;
+}
+
 function buildGenericStatsEventTimelineEvents(
   ctx: StatModuleContext,
   streamId: string,
@@ -186,6 +322,7 @@ function buildGenericStatsEventTimelineEvents(
     const playerId = remoteIdToString(event.meta.primary_player);
     const playerName = playerId ? (playerNames.get(playerId) ?? playerId) : null;
     const isTeamZero = event.meta.team_is_team_0 ?? null;
+    const teamLabel = isTeamZero == null ? null : isTeamZero ? "Blue" : "Orange";
     const eventId = event.meta.id || `${streamId}:${timing.frame ?? timing.time}:${index}`;
 
     return [
@@ -194,7 +331,12 @@ function buildGenericStatsEventTimelineEvents(
         time: ctx.replay.frames[timing.frame ?? -1]?.time ?? timing.time,
         frame: timing.frame,
         kind: streamId,
-        label: playerName ? `${playerName} ${streamLabel.toLowerCase()}` : streamLabel,
+        label: formatGenericStatsEventLabel({
+          event,
+          playerName,
+          streamLabel,
+          teamLabel,
+        }),
         shortLabel: eventStreamShortLabel(streamId),
         playerId,
         playerName,
@@ -216,6 +358,7 @@ function buildGenericStatsEventTimelineRanges(
   events: readonly Event[],
 ): ReplayTimelineRange[] {
   const streamLabel = formatMechanicKind(streamId);
+  const playerNames = new Map(ctx.replay.players.map((player) => [player.id, player.name]));
 
   return events
     .flatMap((event, index) => {
@@ -231,9 +374,16 @@ function buildGenericStatsEventTimelineRanges(
 
       const isTeamZero = event.meta.team_is_team_0 ?? null;
       const teamLabel = isTeamZero == null ? null : isTeamZero ? "Blue" : "Orange";
+      const playerId = remoteIdToString(event.meta.primary_player);
+      const playerName = playerId ? (playerNames.get(playerId) ?? playerId) : null;
       const eventId =
         event.meta.id ||
         `${streamId}:${timing.startFrame ?? timing.startTime}:${timing.endFrame ?? timing.endTime}:${index}`;
+      const label = playerName
+        ? `${playerName} ${streamLabel.toLowerCase()}`
+        : teamLabel
+          ? `${teamLabel} ${streamLabel.toLowerCase()}`
+          : streamLabel;
 
       return [
         {
@@ -245,7 +395,7 @@ function buildGenericStatsEventTimelineRanges(
           ),
           lane: `stats-stream:${streamId}`,
           laneLabel: streamLabel,
-          label: teamLabel ? `${teamLabel} ${streamLabel.toLowerCase()}` : streamLabel,
+          label,
           shortLabel: eventStreamShortLabel(streamId),
           isTeamZero,
           color:

--- a/js/stat-evaluation-player/src/timelineRanges.test.ts
+++ b/js/stat-evaluation-player/src/timelineRanges.test.ts
@@ -371,7 +371,7 @@ test("buildBallHalfTimelineRanges derives half-control spans from labeled deltas
       lane: "half-control",
       laneLabel: "Half Control",
       label: "Blue half control",
-      color: "rgba(89, 195, 255, 0.76)",
+      color: "#3b82f6",
       isTeamZero: true,
     },
     {
@@ -392,12 +392,14 @@ test("buildBallHalfTimelineRanges derives spans from compact event timelines", (
     events: {
       ball_half: [
         { frame: 1, time: 0.5, active: true, field_half: "team_zero_side" },
-        { frame: 2, time: 1, active: true, field_half: "neutral" },
+        { frame: 2, time: 1, active: true, field_half: "team_one_side" },
+        { frame: 3, time: 1.5, active: true, field_half: "neutral" },
       ],
     },
     frames: [
       { frame_number: 1, time: 0.5, dt: 0.5, team_zero: {}, team_one: {}, players: [] },
       { frame_number: 2, time: 1, dt: 0.5, team_zero: {}, team_one: {}, players: [] },
+      { frame_number: 3, time: 1.5, dt: 0.5, team_zero: {}, team_one: {}, players: [] },
     ],
   });
 
@@ -409,13 +411,23 @@ test("buildBallHalfTimelineRanges derives spans from compact event timelines", (
       lane: "half-control",
       laneLabel: "Half Control",
       label: "Blue half control",
-      color: "rgba(89, 195, 255, 0.76)",
+      color: "#3b82f6",
       isTeamZero: true,
     },
     {
-      id: "half-control:neutral:0.500",
+      id: "half-control:team_one_side:0.500",
       startTime: 0.5,
       endTime: 1,
+      lane: "half-control",
+      laneLabel: "Half Control",
+      label: "Orange half control",
+      color: "#f59e0b",
+      isTeamZero: false,
+    },
+    {
+      id: "half-control:neutral:1.000",
+      startTime: 1,
+      endTime: 1.5,
       lane: "half-control",
       laneLabel: "Half Control",
       label: "Neutral half control",
@@ -827,7 +839,7 @@ test("buildBallHalfTimelineRanges uses replay centerline fallback for legacy hal
       lane: "half-control",
       laneLabel: "Half Control",
       label: "Blue half control",
-      color: "rgba(89, 195, 255, 0.76)",
+      color: "#3b82f6",
       isTeamZero: true,
     },
     {

--- a/js/stat-evaluation-player/src/timelineRanges.ts
+++ b/js/stat-evaluation-player/src/timelineRanges.ts
@@ -168,7 +168,7 @@ function createBallHalfRange(
     lane: "half-control",
     laneLabel: "Half Control",
     label: isTeamZero ? "Blue half control" : "Orange half control",
-    color: isTeamZero ? "rgba(89, 195, 255, 0.76)" : "rgba(255, 193, 92, 0.76)",
+    color: teamTimelineColor(isTeamZero) ?? undefined,
     isTeamZero,
   };
 }


### PR DESCRIPTION
## Summary

Improves the stats-evaluation timeline UI by making generic stats event streams render with descriptive, context-rich labels instead of generic `"<team> <stream>"` text.

- Adds descriptive playlist/timeline labels for the generic stats event streams — ball half, possession, territorial pressure, controlled play, positioning activity/zone, rotation role/depth, and first-man stint — including field half/zone/role context and span durations (e.g. `"Ball on blue side | 1.5s"`, `"Demolished | 0.05s"`, `"Defensive possession | defensive third | 2s"`).
- Registers `controlled_play` as a span-based stream so it renders as a timeline range rather than point markers, and surfaces player names on generic stats ranges.
- Consolidates ball-half range colors onto the shared `teamTimelineColor` helper instead of hardcoded rgba literals.

## Testing

- `tsx --test src/eventTimelineSources.test.ts src/timelineRanges.test.ts` — 17 passing (includes new coverage for controlled-play spans and ball-half label/duration formatting)
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)