### PR TITLE
refactor(processor): replace BALL_TYPES whitelist with prefix-only matching

### DIFF
--- a/src/processor/queries.rs
+++ b/src/processor/queries.rs
@@ -408,28 +408,21 @@ impl<'a> ReplayProcessor<'a> {
         })
     }
 
-    /// Scans the actor graph for the first actor that matches a known ball
-    /// type, falling back to any archetype under `Archetypes.Ball.` so balls
-    /// introduced by new game modes are still recognized.
+    /// Scans the actor graph for the first actor whose archetype lives under
+    /// `Archetypes.Ball.`. Matching the prefix rather than an explicit whitelist
+    /// means ball archetypes introduced by new or limited-time game modes are
+    /// recognized automatically.
     pub(crate) fn find_ball_actor(&self) -> Option<boxcars::ActorId> {
-        BALL_TYPES
+        self.actor_state
+            .actor_ids_by_type
             .iter()
-            .filter_map(|ball_type| self.iter_actors_by_type(ball_type))
-            .flatten()
-            .map(|(actor_id, _)| *actor_id)
-            .next()
-            .or_else(|| {
-                self.actor_state
-                    .actor_ids_by_type
-                    .iter()
-                    .filter(|(object_id, _)| {
-                        self.object_id_to_name
-                            .get(object_id)
-                            .is_some_and(|name| name.starts_with(BALL_TYPE_PREFIX))
-                    })
-                    .flat_map(|(_, actor_ids)| actor_ids.iter().copied())
-                    .next()
+            .filter(|(object_id, _)| {
+                self.object_id_to_name
+                    .get(object_id)
+                    .is_some_and(|name| name.starts_with(BALL_TYPE_PREFIX))
             })
+            .flat_map(|(_, actor_ids)| actor_ids.iter().copied())
+            .next()
     }
 
     /// Returns the tracked actor id for the replay ball.

--- a/src/processor/replay_keys.rs
+++ b/src/processor/replay_keys.rs
@@ -1,15 +1,8 @@
-pub(crate) static BALL_TYPES: [&str; 6] = [
-    "Archetypes.Ball.Ball_Default",
-    "Archetypes.Ball.Ball_Basketball",
-    "Archetypes.Ball.Ball_Puck",
-    "Archetypes.Ball.CubeBall",
-    "Archetypes.Ball.Ball_Breakout",
-    "Archetypes.Ball.Ball_WorldCup",
-];
-
-/// Limited-time modes ship new ball archetypes (e.g. `Ball_WorldCup`) that
-/// predate any explicit `BALL_TYPES` entry; anything under this prefix is a
-/// ball.
+/// Every ball archetype the game has shipped lives under this prefix
+/// (`Ball_Default`, `Ball_Basketball`, `Ball_Puck`, `CubeBall`, `Ball_Breakout`,
+/// `Ball_WorldCup`, ...). Matching the prefix rather than an explicit whitelist
+/// means limited-time modes that introduce new ball archetypes are recognized
+/// automatically instead of silently disabling touch detection match-wide.
 pub(crate) static BALL_TYPE_PREFIX: &str = "Archetypes.Ball.";
 
 pub(crate) static BOOST_TYPE: &str = "Archetypes.CarComponents.CarComponent_Boost";


### PR DESCRIPTION
## Summary

Follow-up to #134, which fixed the missing `Ball_WorldCup` archetype by both adding it to the `BALL_TYPES` whitelist *and* adding an `Archetypes.Ball.` prefix fallback. Once the prefix fallback exists, the whitelist is dead weight: every ball archetype the game has ever shipped lives under `Archetypes.Ball.`, and keeping the list means future archetypes route through a second-class fallback path instead of being first-class matches — preserving exactly the maintenance hazard #134 was fixing.

- Remove the `BALL_TYPES` whitelist entirely; keep only `BALL_TYPE_PREFIX`.
- Collapse `find_ball_actor` to a single prefix scan over `actor_ids_by_type`.

Net −14 lines, one ball-resolution code path instead of two.

## Test plan

- `cargo test --test worldcup_ball_kickoff_test -- --ignored` — the replay-backed regression from #134 passes via the prefix path alone (all five kickoffs resolve first touches).
- `cargo test --lib kickoff` (57 tests), `cargo clippy --lib`, `cargo fmt` all clean.
- Confirmed `find_ball_actor` is the sole ball-resolution point — no other whitelist exists for basketball/puck/breakout modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)