### PR TITLE
fix(kickoffs): capture movement start on the opening kickoff

### DIFF
--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -457,10 +457,21 @@ impl KickoffCalculator {
         frame: &FrameInfo,
         gameplay: &GameplayState,
     ) {
-        if active.movement_start_time.is_none()
-            && gameplay.kickoff_phase_active()
-            && !gameplay.kickoff_countdown_active()
-        {
+        // A kickoff is always armed while the countdown is still active, so the
+        // first armed frame on which the countdown is no longer active marks the
+        // "GO" — the moment players are released toward the ball.
+        //
+        // We deliberately do not also require `kickoff_phase_active()` here. On
+        // the opening kickoff of a match the engine reports
+        // `ball_has_been_hit == None` (rather than `Some(false)`) until the ball
+        // is first touched, so the kickoff phase never registers as active in the
+        // window between the countdown ending and the first touch. Requiring it
+        // left `movement_start` unset on the first kickoff, falling back to the
+        // countdown's *start* and inflating every taker's `time_to_ball` by the
+        // full countdown (~3s). Gating on the countdown alone keeps movement
+        // start aligned with "GO" on the opening kickoff and matches the
+        // behavior on every subsequent kickoff.
+        if active.movement_start_time.is_none() && !gameplay.kickoff_countdown_active() {
             active.movement_start_time = Some(frame.time);
             active.movement_start_frame = Some(frame.frame_number);
         }
@@ -1443,7 +1454,7 @@ impl KickoffCalculator {
         };
         if active.concluded.is_none() {
             Self::observe_movement_start(active, ctx.frame, ctx.gameplay);
-            if ctx.gameplay.kickoff_phase_active() && !ctx.gameplay.kickoff_countdown_active() {
+            if !ctx.gameplay.kickoff_countdown_active() {
                 Self::observe_live_action_start(active, ctx.frame);
             }
             Self::apply_player_samples(active, ctx.frame, ctx.players);

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -388,6 +388,109 @@ fn kickoff_records_movement_start_after_countdown() {
     assert_eq!(event.movement_start_frame, 30);
 }
 
+/// On the opening kickoff of a match the engine reports
+/// `ball_has_been_hit == None` (not `Some(false)`) until the first touch, so
+/// the post-countdown window never registers as an active kickoff phase.
+/// Movement start must still be captured at the "GO" moment rather than
+/// falling back to the countdown's start, which inflated `time_to_ball` by
+/// the full countdown.
+#[test]
+fn first_kickoff_records_movement_start_when_ball_has_been_hit_is_unset() {
+    let blue_taker = PlayerId::Steam(44);
+    let orange_taker = PlayerId::Steam(45);
+    let mut calculator = KickoffCalculator::new();
+
+    calculator
+        .update(
+            &frame(0, 0.0),
+            &GameplayState {
+                game_state: Some(GAME_STATE_KICKOFF_COUNTDOWN),
+                ball_has_been_hit: None,
+                kickoff_countdown_time: Some(3),
+                ..GameplayState::default()
+            },
+            &ball(0.0),
+            &PlayerFrameState {
+                players: vec![
+                    player(
+                        blue_taker.clone(),
+                        true,
+                        glam::Vec3::new(-2048.0, -2560.0, 17.0),
+                        33.0,
+                    ),
+                    player(
+                        orange_taker.clone(),
+                        false,
+                        glam::Vec3::new(-2048.0, 2560.0, 17.0),
+                        33.0,
+                    ),
+                ],
+            },
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    // Countdown over, but the opening kickoff still reports
+    // `ball_has_been_hit: None` until the first touch.
+    calculator
+        .update(
+            &frame(30, 3.0),
+            &GameplayState {
+                ball_has_been_hit: None,
+                kickoff_countdown_time: Some(0),
+                ..GameplayState::default()
+            },
+            &ball(0.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    calculator
+        .update(
+            &frame(50, 5.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(320.0),
+            &PlayerFrameState::default(),
+            &TouchState {
+                touch_events: vec![touch(blue_taker, true, 50, 5.0)],
+                ..TouchState::default()
+            },
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    calculator
+        .update(
+            &frame(80, 8.0),
+            &GameplayState {
+                ball_has_been_hit: Some(true),
+                ..GameplayState::default()
+            },
+            &ball(420.0),
+            &PlayerFrameState::default(),
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        )
+        .unwrap();
+
+    calculator.finish();
+    let event = calculator.events().last().unwrap();
+    assert_eq!(event.movement_start_time, 3.0);
+    assert_eq!(event.movement_start_frame, 30);
+    assert_eq!(event.live_action_start_time, Some(3.0));
+    assert_eq!(event.live_action_start_frame, Some(30));
+    let taker = event.team_zero_taker.as_ref().unwrap();
+    // time_to_ball is measured from "GO" (t=3.0) to the touch (t=5.0), not
+    // from the countdown's start (t=0.0).
+    assert_eq!(taker.time_to_ball, Some(2.0));
+}
+
 #[test]
 fn kickoff_classifies_fake_and_missed_expected_takers() {
     let blue_taker = PlayerId::Steam(1);


### PR DESCRIPTION
## Problem

`time_to_ball` for the **first kickoff of a match** was inflated by ~3 seconds (the full kickoff countdown). E.g. in the RLCS grand-final asset replay, the opening kickoff read **4.97s / 4.92s** while every subsequent kickoff read ~1.9–2.2s.

## Root cause

On the opening kickoff the engine reports `ball_has_been_hit == None` (rather than `Some(false)`) until the ball is first touched. `GameplayState::kickoff_phase_active()` is `countdown_active || ball_has_been_hit == Some(false)`, so in the window between the countdown ending and the first touch the kickoff phase never registers as active **on the first kickoff only**.

`KickoffCalculator::observe_movement_start` required `kickoff_phase_active() && !kickoff_countdown_active()`, so `movement_start_time` was never captured there; `finish_event` then fell back to `start_time` — the moment the countdown began at "3" — and `time_to_ball` (touch − movement start) absorbed the whole countdown.

## Fix

Gate movement start (and live-action start) only on the countdown no longer being active. A kickoff is only armed while the kickoff phase is active, so the first armed frame past the countdown is the "GO" moment on every kickoff, including the opener.

## Validation

`kickoff_timing_dump` on `assets/rlcs-2025-worlds-grand-final-flcn-nrg-g5.replay`:

| kickoff | before | after |
|---|---|---|
| 1st (Trk511) | 4.966 | **1.966** |
| 1st (BeastMode) | 4.916 | **1.916** |
| 2nd–6th | 1.90–2.20 | unchanged |

Added a regression test (`first_kickoff_records_movement_start_when_ball_has_been_hit_is_unset`) reproducing the `ball_has_been_hit: None` opening-kickoff state. All 45 kickoff calculator tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)