### PR TITLE
feat(flake): add js-wasm-pkg and js-player-pkg npm package outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -194,6 +194,60 @@
             runHook postInstall
           '';
         };
+        # The publishable npm package layout for @rlrml/subtr-actor, byte-for-byte
+        # equivalent to what `npm publish` ships (wasm-pack --no-pack output +
+        # prepare-wasm-package.mjs manifest). Downstream consumers can vendor this
+        # directly instead of the npm registry tarball, guaranteeing the wasm is
+        # built from this repo's Cargo.lock (including [patch.crates-io] forks).
+        packages.js-wasm-pkg =
+          pkgs.runCommand "rlrml-subtr-actor-npm-pkg"
+            { nativeBuildInputs = [ pkgs.nodejs ]; }
+            ''
+              mkdir -p build/js/pkg
+              cp ${./js/package.json} build/js/package.json
+              cp -r ${./js/scripts} build/js/scripts
+              cp -r ${self.packages.${system}.js-web-wasm}/. build/js/pkg/
+              chmod -R u+w build
+              # Mirror the publish flow (wasm-pack --no-pack): drop wasm-pack's own
+              # manifest so prepare-wasm-package.mjs regenerates the publishable one.
+              rm -f build/js/pkg/package.json
+              node build/js/scripts/prepare-wasm-package.mjs
+              mkdir -p $out
+              for f in package.json rl_replay_subtr_actor.js rl_replay_subtr_actor.d.ts rl_replay_subtr_actor_bg.wasm; do
+                install -m 644 "build/js/pkg/$f" "$out/$f"
+              done
+            '';
+        # The publishable npm package layout for @rlrml/player (dist/ + manifest via
+        # prepare-package.mjs), built against this repo's js-wasm-pkg bindings.
+        packages.js-player-pkg = pkgs.buildNpmPackage {
+          pname = "rlrml-player-npm-pkg";
+          version = projectVersion;
+          src = ./.;
+          npmRoot = "js/player";
+          npmDeps = pkgs.importNpmLock { npmRoot = ./js/player; };
+          npmConfigHook = pkgs.importNpmLock.npmConfigHook;
+          preBuild = ''
+            rm -rf js/pkg
+            mkdir -p js/pkg
+            cp -r ${self.packages.${system}.js-web-wasm}/. js/pkg/
+          '';
+          buildPhase = ''
+            runHook preBuild
+            pushd js/player
+            npm run build:dist
+            popd
+            runHook postBuild
+          '';
+          installPhase = ''
+            runHook preInstall
+            pushd js/player
+            staged="$(node ./scripts/prepare-package.mjs)"
+            popd
+            mkdir -p $out
+            cp -R "$staged"/. $out/
+            runHook postInstall
+          '';
+        };
         packages.xwin-msvc-sysroot = xwinMsvcSysroot;
         packages.bakkesmod-plugin = rustPlatform.buildRustPackage {
           pname = "subtr-actor-bakkesmod-plugin";

--- a/js/player/package.json
+++ b/js/player/package.json
@@ -36,6 +36,7 @@
     "check": "sh -lc 'test -f ../pkg/rl_replay_subtr_actor.js || ../scripts/with-clean-npm-env.sh node --run=build:bindings; ../scripts/with-clean-npm-env.sh node --run=verify:raw-types && tsc --noEmit'",
     "test": "tsx --tsconfig tsconfig.test.json --test test/*.test.ts",
     "build:types": "tsc --project tsconfig.build.json",
+    "build:dist": "vite build && tsc --project tsconfig.build.json",
     "build": "../scripts/with-clean-npm-env.sh node --run=build:bindings && ../scripts/with-clean-npm-env.sh node --run=check && vite build && ../scripts/with-clean-npm-env.sh node --run=build:types",
     "prepare:package": "node ./scripts/prepare-package.mjs",
     "smoke:install": "node ./scripts/smoke-install.mjs"


### PR DESCRIPTION
## Summary

Expose the publishable npm package layouts of `@rlrml/subtr-actor` and `@rlrml/player` as flake outputs, built from this repo's `Cargo.lock` (which pins patched crate forks via `[patch.crates-io]`).

This gives downstream consumers a canonical, foot-gun-free way to consume the wasm/player **locally from source** instead of from registry tarballs — so a prebuilt npm wasm can never drift behind the repo's parsing fixes. That's the exact failure mode that shipped a pre-`Ball_WorldCup` wasm to rocket-sense's web app while the server and standalone-player builds were already fixed.

- **`packages.js-wasm-pkg`**: `js-web-wasm` output + `prepare-wasm-package.mjs` manifest — byte-identical to the `npm publish` file set (`package.json`, `rl_replay_subtr_actor.js`, `.d.ts`, `_bg.wasm`).
- **`packages.js-player-pkg`**: `vite build` + declaration-only `tsc` + `prepare-package.mjs` staging, via a new cargo-free `build:dist` script (skips raw-types verification, which needs cargo; the wasm bindings are supplied by `js-web-wasm`).

## Verification

- `nix build .#js-wasm-pkg`: manifest byte-identical to the registry 0.12.0 package; wasm contains `Ball_WorldCup` strings.
- `nix build .#js-player-pkg`: manifest identical to registry 0.12.0 except the added `./boost-units` export; `dist/` includes the wasm worker chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)