### PR TITLE
fix(kickoff): source taker boost_collected from deduplicated pickup events

### DIFF
--- a/src/stats/analysis_graph/nodes/kickoff.rs
+++ b/src/stats/analysis_graph/nodes/kickoff.rs
@@ -36,11 +36,13 @@ impl AnalysisNode for KickoffNode {
             touch_state_dependency(),
             frame_events_state_dependency(),
             speed_flip_dependency(),
+            boost_dependency(),
         ]
     }
 
     fn evaluate(&mut self, ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
         let speed_flip = ctx.get::<SpeedFlipCalculator>()?;
+        let boost = ctx.get::<BoostCalculator>()?;
         self.calculator
             .update_with_speed_flips(KickoffUpdateContext {
                 frame: ctx.get::<FrameInfo>()?,
@@ -50,6 +52,7 @@ impl AnalysisNode for KickoffNode {
                 touch_state: ctx.get::<TouchState>()?,
                 events: ctx.get::<FrameEventsState>()?,
                 speed_flip_events: speed_flip.events(),
+                boost_pickups: boost.new_pickup_events(),
             })
     }
 

--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -51,8 +51,15 @@ struct KickoffApproachTrace {
     max_speed: f32,
     min_boost: Option<f32>,
     previous_boost: Option<f32>,
-    sampled_boost_collected: f32,
     sampled_boost_used: f32,
+    /// Boost collected from pad pickups (including steals; overfill excluded)
+    /// during the approach window, summed from the `BoostCalculator`'s
+    /// deduplicated pickup events. This deliberately does NOT come from gross
+    /// frame-to-frame `boost_amount` deltas: a single pad pickup can show up as
+    /// a `+jump` one frame and a `-correction` the next as the inferred and
+    /// reported boost balances reconcile, so summing positive deltas
+    /// double-counts and can push `boost_used` past a full tank.
+    pickup_boost_collected: f32,
     last_position: Option<[f32; 3]>,
     previous_velocity: Option<glam::Vec3>,
     previous_dodge_active: bool,
@@ -141,6 +148,10 @@ pub(crate) struct KickoffUpdateContext<'a> {
     pub touch_state: &'a TouchState,
     pub events: &'a FrameEventsState,
     pub speed_flip_events: &'a [SpeedFlipEvent],
+    /// Boost pickup events newly emitted this frame by the `BoostCalculator`.
+    /// Used to attribute deduplicated boost collected to in-flight kickoff
+    /// players during their approach window.
+    pub boost_pickups: &'a [BoostPickupEvent],
 }
 
 pub(crate) const KICKOFF_SPAWN_LABELS: [StatLabel; 6] = [
@@ -499,9 +510,11 @@ impl KickoffCalculator {
         if let Some(boost_amount) = Self::boost_amount(player) {
             if let Some(previous_boost) = trace.previous_boost {
                 let delta = boost_amount - previous_boost;
-                if delta > 0.0 {
-                    trace.sampled_boost_collected += delta;
-                } else {
+                if delta < 0.0 {
+                    // Only the depletion side is sampled here, as a fallback for
+                    // `boost_used` when a player's first-touch boost is unknown.
+                    // Collected boost is sourced from deduplicated pickup events
+                    // (see `apply_boost_pickups`), not gross positive deltas.
                     trace.sampled_boost_used += -delta;
                 }
             }
@@ -594,6 +607,41 @@ impl KickoffCalculator {
                 player.first_touch_time = Some(touch.time);
                 player.first_touch_frame = Some(touch.frame);
             }
+        }
+    }
+
+    /// Attribute deduplicated boost pickups to in-flight kickoff players during
+    /// their approach window (from movement start through their first touch).
+    ///
+    /// `pickups` are the events newly emitted this frame by the
+    /// `BoostCalculator`, whose `collected_amount` already folds the former
+    /// Collected/Stolen ledger transactions into one accurate, capped figure
+    /// (overfill and respawn excluded). Summing these is what keeps
+    /// `boost_used = start_boost + collected - first_touch_boost` from
+    /// overcounting the way gross frame-to-frame `boost_amount` deltas did.
+    fn apply_boost_pickups(active: &mut ActiveKickoff, pickups: &[BoostPickupEvent]) {
+        if pickups.is_empty() {
+            return;
+        }
+        let lower_bound = active.movement_start_time.unwrap_or(active.start_time);
+        for pickup in pickups {
+            if pickup.time < lower_bound {
+                continue;
+            }
+            let Some(snapshot) = active
+                .players
+                .iter_mut()
+                .find(|player| player.player == pickup.player_id)
+            else {
+                continue;
+            };
+            if snapshot
+                .first_touch_time
+                .is_some_and(|touch_time| pickup.time > touch_time)
+            {
+                continue;
+            }
+            snapshot.approach_trace.pickup_boost_collected += pickup.collected_amount;
         }
     }
 
@@ -730,7 +778,7 @@ impl KickoffCalculator {
     }
 
     fn taker_boost_collected(player: &KickoffPlayerSnapshot) -> f32 {
-        player.approach_trace.sampled_boost_collected
+        player.approach_trace.pickup_boost_collected
     }
 
     fn taker_boost_used(player: &KickoffPlayerSnapshot) -> f32 {
@@ -1420,6 +1468,7 @@ impl KickoffCalculator {
             touch_state,
             events,
             speed_flip_events: &[],
+            boost_pickups: &[],
         })
     }
 
@@ -1459,6 +1508,7 @@ impl KickoffCalculator {
             }
             Self::apply_player_samples(active, ctx.frame, ctx.players);
             Self::apply_touches(active, ctx.touch_state, ctx.ball);
+            Self::apply_boost_pickups(active, ctx.boost_pickups);
             Self::apply_speed_flip_events(active, ctx.frame, ctx.speed_flip_events);
             if Self::should_capture_resolution(active, ctx.frame) {
                 active.resolution = Some(KickoffResolutionSnapshot {

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -34,6 +34,31 @@ fn player(player_id: PlayerId, is_team_0: bool, position: glam::Vec3, boost: f32
     }
 }
 
+fn boost_pickup(
+    player_id: PlayerId,
+    is_team_0: bool,
+    frame: usize,
+    time: f32,
+    collected_amount: f32,
+) -> BoostPickupEvent {
+    BoostPickupEvent {
+        frame,
+        time,
+        player_id,
+        player_position: None,
+        is_team_0,
+        pad_type: BoostPickupPadType::Big,
+        field_half: BoostPickupFieldHalf::Own,
+        activity: BoostPickupActivity::Active,
+        detection: BoostPickupDetection::Both,
+        is_steal: false,
+        collected_amount,
+        overfill_amount: 0.0,
+        boost_before: None,
+        boost_after: None,
+    }
+}
+
 fn frame(frame_number: usize, time: f32) -> FrameInfo {
     FrameInfo {
         frame_number,
@@ -996,26 +1021,32 @@ fn kickoff_taker_tracks_time_to_ball_and_approach_boost_totals() {
         )
         .unwrap();
 
+    // Blue ends the approach at 45 boost after dipping to 30: the gain back up
+    // is a real pad pickup, delivered as a deduplicated BoostPickupEvent rather
+    // than inferred from the gross boost-amount jump. boost_used is then the
+    // balance start(33) + collected(15) - first_touch(45) = 3.
     calculator
-        .update(
-            &frame(35, 3.5),
-            &GameplayState {
+        .update_with_speed_flips(KickoffUpdateContext {
+            frame: &frame(35, 3.5),
+            gameplay: &GameplayState {
                 ball_has_been_hit: Some(true),
                 ..GameplayState::default()
             },
-            &ball(0.0),
-            &PlayerFrameState {
+            ball: &ball(0.0),
+            players: &PlayerFrameState {
                 players: vec![
                     player(blue_taker.clone(), true, glam::Vec3::ZERO, 45.0),
                     player(orange_taker.clone(), false, glam::Vec3::ZERO, 28.0),
                 ],
             },
-            &TouchState {
+            touch_state: &TouchState {
                 touch_events: vec![touch(blue_taker.clone(), true, 35, 3.5)],
                 ..TouchState::default()
             },
-            &FrameEventsState::default(),
-        )
+            events: &FrameEventsState::default(),
+            speed_flip_events: &[],
+            boost_pickups: &[boost_pickup(blue_taker.clone(), true, 35, 3.5, 15.0)],
+        })
         .unwrap();
 
     calculator
@@ -1792,6 +1823,7 @@ fn kickoff_uses_speed_flip_events_as_approach_source_of_truth() {
             touch_state: &TouchState::default(),
             events: &FrameEventsState::default(),
             speed_flip_events: std::slice::from_ref(&speed_flip),
+            boost_pickups: &[],
         })
         .unwrap();
 
@@ -1810,6 +1842,7 @@ fn kickoff_uses_speed_flip_events_as_approach_source_of_truth() {
             },
             events: &FrameEventsState::default(),
             speed_flip_events: std::slice::from_ref(&speed_flip),
+            boost_pickups: &[],
         })
         .unwrap();
 
@@ -1825,6 +1858,7 @@ fn kickoff_uses_speed_flip_events_as_approach_source_of_truth() {
             touch_state: &TouchState::default(),
             events: &FrameEventsState::default(),
             speed_flip_events: std::slice::from_ref(&speed_flip),
+            boost_pickups: &[],
         })
         .unwrap();
 


### PR DESCRIPTION
## Problem

Kickoff takers can report `boost_used` exceeding a full tank (255 raw units), which surfaces in rocket-sense's kickoff view as impossible totals like **"Boost used: 124%"**.

Root cause: commit 84d2b2a6 ("Simplify kickoff taker boost accounting") made `taker_boost_collected` a gross sum of every positive frame-to-frame `boost_amount` delta. Inferred and reported boost balances reconcile with +jump/−correction oscillations across frames, so a single pad pickup can be counted multiple times, inflating:

```
boost_used = start_boost + boost_collected - first_touch_boost
```

## Fix

Restore deduplicated accounting, adapted to the current clean pickup model (the original `BoostLedgerEvent` / `projected_ledger_events()` API was replaced by `BoostPickupEvent` in ec5397a6):

- `KickoffNode` now declares a dependency on `BoostCalculator` and feeds its `new_pickup_events()` into the kickoff calculator via a new `boost_pickups` field on `KickoffUpdateContext`.
- The kickoff calculator attributes each pickup's `collected_amount` (overfill excluded) to the taker's approach window, bounded by movement start and first touch.
- Per-frame delta sampling now only accumulates the depletion side (`sampled_boost_used`), kept as a fallback for `boost_used` when a player's first-touch boost is unknown.

## Testing

- `cargo test --lib kickoff` — 58 passed (includes a rewritten balance test injecting a pickup event: start 33 + collected 15 − first-touch 45 = 3 used)
- `cargo test --lib analysis_graph` — 17 passed (no dependency cycle from the new `KickoffNode → BoostCalculator` edge)
- `cargo test --lib boost` — 35 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)