### PR TITLE
Color the touch overlay by intention or hit strength

### DIFF
--- a/js/stat-evaluation-player/package-lock.json
+++ b/js/stat-evaluation-player/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@rlrml/player": "^0.12.0",
-        "esbuild": "^0.27.2",
         "fflate": "^0.8.2"
       },
       "devDependencies": {
@@ -39,6 +38,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -55,6 +55,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71,6 +72,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -87,6 +89,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -103,6 +106,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -119,6 +123,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -135,6 +140,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -151,6 +157,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -167,6 +174,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -183,6 +191,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -199,6 +208,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -215,6 +225,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -231,6 +242,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -247,6 +259,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -263,6 +276,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -279,6 +293,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -295,6 +310,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -311,6 +327,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -327,6 +344,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -343,6 +361,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -359,6 +378,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -375,6 +395,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -391,6 +412,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -407,6 +429,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -423,6 +446,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -439,6 +463,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -881,6 +906,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/js/stat-evaluation-player/src/stat-modules/touchModule.ts
+++ b/js/stat-evaluation-player/src/stat-modules/touchModule.ts
@@ -1,7 +1,7 @@
 import { renderTouchStats } from "../touchFormatting.ts";
 import type { TouchBreakdownClass } from "../touchFormatting.ts";
 import { TouchEventOverlay } from "../touchOverlay.ts";
-import type { TouchOverlayMode } from "../touchOverlay.ts";
+import type { TouchOverlayColorMode, TouchOverlayMode } from "../touchOverlay.ts";
 import { buildTouchTimelineEvents } from "../timelineMarkers.ts";
 import { getStatsFrameForReplayFrame } from "../statsTimeline.ts";
 import {
@@ -16,9 +16,11 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
   let overlay: TouchEventOverlay | null = null;
   let decaySeconds = 5;
   let overlayMode: TouchOverlayMode = "advancement";
+  let overlayColorMode: TouchOverlayColorMode = "team";
   let settingsEl: HTMLDivElement | null = null;
   let decayReadoutEl: HTMLElement | null = null;
   let overlayModeReadoutEl: HTMLElement | null = null;
+  let overlayColorModeReadoutEl: HTMLElement | null = null;
   let breakdownReadoutEl: HTMLElement | null = null;
   const activeBreakdownClasses = new Set<TouchBreakdownClass>();
   const orderedBreakdownClasses: TouchBreakdownClass[] = [
@@ -40,6 +42,7 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
         ctx.statsTimeline,
         {
           mode: overlayMode,
+          colorMode: overlayColorMode,
         },
       );
       overlay.setDecaySeconds(decaySeconds);
@@ -63,6 +66,7 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
       return {
         decaySeconds,
         overlayMode,
+        overlayColorMode,
         breakdownClasses: getActiveBreakdownClasses(),
       };
     },
@@ -77,6 +81,14 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
         if (record.overlayMode === "markers" || record.overlayMode === "advancement") {
           overlayMode = record.overlayMode;
           overlay?.setMode(overlayMode);
+        }
+        if (
+          record.overlayColorMode === "team" ||
+          record.overlayColorMode === "intention" ||
+          record.overlayColorMode === "kind"
+        ) {
+          overlayColorMode = record.overlayColorMode;
+          overlay?.setColorMode(overlayColorMode);
         }
         activeBreakdownClasses.clear();
         if (Array.isArray(record.breakdownClasses)) {
@@ -209,6 +221,55 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
         }
         modeSection.append(modeHeader, modeOptions);
 
+        const colorSection = document.createElement("div");
+        colorSection.className = "module-settings-subgroup";
+
+        const colorHeader = document.createElement("div");
+        colorHeader.className = "module-settings-header";
+
+        const colorText = document.createElement("div");
+        const colorEyebrow = document.createElement("p");
+        colorEyebrow.className = "module-settings-eyebrow";
+        colorEyebrow.textContent = "Overlay";
+        const colorTitle = document.createElement("h3");
+        colorTitle.textContent = "Color by";
+        colorText.append(colorEyebrow, colorTitle);
+
+        overlayColorModeReadoutEl = document.createElement("strong");
+        overlayColorModeReadoutEl.className = "metric-readout";
+        colorHeader.append(colorText, overlayColorModeReadoutEl);
+
+        const colorOptions = document.createElement("div");
+        colorOptions.className = "module-settings-options";
+        for (const option of [
+          { colorMode: "team", label: "Team" },
+          { colorMode: "intention", label: "Intention" },
+          { colorMode: "kind", label: "Hit strength" },
+        ] satisfies Array<{ colorMode: TouchOverlayColorMode; label: string }>) {
+          const optionLabel = document.createElement("label");
+          optionLabel.className = "toggle";
+
+          const radio = document.createElement("input");
+          radio.type = "radio";
+          radio.name = "touch-overlay-color-mode";
+          radio.dataset.overlayColorMode = option.colorMode;
+          radio.addEventListener("change", () => {
+            if (!radio.checked) {
+              return;
+            }
+            overlayColorMode = option.colorMode;
+            overlay?.setColorMode(overlayColorMode);
+            syncTouchSettingsUi();
+            runtime.requestConfigSync?.();
+          });
+
+          const optionText = document.createElement("span");
+          optionText.textContent = option.label;
+          optionLabel.append(radio, optionText);
+          colorOptions.append(optionLabel);
+        }
+        colorSection.append(colorHeader, colorOptions);
+
         const breakdownSection = document.createElement("div");
         breakdownSection.className = "module-settings-subgroup";
 
@@ -260,7 +321,7 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
         }
 
         breakdownSection.append(breakdownHeader, breakdownOptions);
-        settingsEl.append(header, label, modeSection, breakdownSection);
+        settingsEl.append(header, label, modeSection, colorSection, breakdownSection);
       }
 
       syncTouchSettingsUi();
@@ -286,6 +347,18 @@ export function createTouchModule(runtime: StatModuleRuntime): StatModule {
     }
     if (overlayModeReadoutEl) {
       overlayModeReadoutEl.textContent = overlayMode === "advancement" ? "Advancement" : "Markers";
+    }
+    for (const radio of settingsEl.querySelectorAll<HTMLInputElement>(
+      "input[data-overlay-color-mode]",
+    )) {
+      radio.checked = radio.dataset.overlayColorMode === overlayColorMode;
+    }
+    if (overlayColorModeReadoutEl) {
+      overlayColorModeReadoutEl.textContent = {
+        team: "Team",
+        intention: "Intention",
+        kind: "Hit strength",
+      }[overlayColorMode];
     }
     for (const checkbox of settingsEl.querySelectorAll<HTMLInputElement>(
       "input[data-breakdown-class]",

--- a/js/stat-evaluation-player/src/touchOverlay.test.ts
+++ b/js/stat-evaluation-player/src/touchOverlay.test.ts
@@ -3,7 +3,13 @@ import assert from "node:assert/strict";
 
 import type { ReplayModel } from "@rlrml/player";
 import type { StatsFrame } from "./statsTimeline.ts";
-import { buildTouchMarkers, getLastTouchPlayer, getVisibleTouchMarkers } from "./touchOverlay.ts";
+import {
+  buildTouchMarkers,
+  getLastTouchPlayer,
+  getVisibleTouchMarkers,
+  touchMarkerColor,
+  type TouchMarker,
+} from "./touchOverlay.ts";
 import {
   createLegacyStatsTimeline,
   createPlayerStatsSnapshot,
@@ -121,6 +127,8 @@ test("buildTouchMarkers derives markers from touch stats and ball frames", () =>
       isTeamZero: true,
       playerId: "Steam:blue-id",
       playerName: "Blue",
+      kind: "control",
+      intention: null,
       position: { x: 100, y: -250, z: 320 },
       endPosition: { x: 100, y: -250, z: 320 },
       totalBallAdvanceDistance: 0,
@@ -309,6 +317,8 @@ test("getVisibleTouchMarkers returns markers inside the decay window", () => {
       isTeamZero: true,
       playerId: "Steam:blue-id",
       playerName: "Blue",
+      kind: null,
+      intention: null,
       position: { x: 0, y: 0, z: 0 },
       endPosition: { x: 0, y: 0, z: 0 },
       totalBallAdvanceDistance: 0,
@@ -322,6 +332,8 @@ test("getVisibleTouchMarkers returns markers inside the decay window", () => {
       isTeamZero: false,
       playerId: "Steam:orange-id",
       playerName: "Orange",
+      kind: null,
+      intention: null,
       position: { x: 0, y: 0, z: 0 },
       endPosition: { x: 0, y: 0, z: 0 },
       totalBallAdvanceDistance: 0,
@@ -334,4 +346,30 @@ test("getVisibleTouchMarkers returns markers inside the decay window", () => {
     getVisibleTouchMarkers(markers, 10, 5).map((marker) => marker.id),
     ["touch:2"],
   );
+});
+
+test("touchMarkerColor selects palettes by color mode with fallbacks", () => {
+  const marker: TouchMarker = {
+    id: "touch:1",
+    time: 0,
+    frame: 0,
+    isTeamZero: false,
+    playerId: "Steam:orange-id",
+    playerName: "Orange",
+    kind: "hard_hit",
+    intention: "shot",
+    position: { x: 0, y: 0, z: 0 },
+    endPosition: { x: 0, y: 0, z: 0 },
+    totalBallAdvanceDistance: 0,
+    totalBallRetreatDistance: 0,
+    totalBallTravelDistance: 0,
+  };
+
+  assert.equal(touchMarkerColor(marker, "team"), 0xffc15c);
+  assert.equal(touchMarkerColor({ ...marker, isTeamZero: true }, "team"), 0x59c3ff);
+  assert.equal(touchMarkerColor(marker, "intention"), 0xff5d6c);
+  assert.equal(touchMarkerColor(marker, "kind"), 0xff5d6c);
+  assert.equal(touchMarkerColor({ ...marker, kind: "control" }, "kind"), 0x4ade80);
+  assert.equal(touchMarkerColor({ ...marker, intention: null }, "intention"), 0x9aa5b1);
+  assert.equal(touchMarkerColor({ ...marker, kind: "mystery" }, "kind"), 0x9aa5b1);
 });

--- a/js/stat-evaluation-player/src/touchOverlay.ts
+++ b/js/stat-evaluation-player/src/touchOverlay.ts
@@ -16,6 +16,26 @@ const ADVANCEMENT_ARROW_MIN_LENGTH = 48;
 
 export type TouchOverlayMode = "markers" | "advancement";
 
+export type TouchOverlayColorMode = "team" | "intention" | "kind";
+
+const INTENTION_COLORS: Record<string, number> = {
+  shot: 0xff5d6c,
+  save: 0x4ade80,
+  clear: 0xfacc15,
+  pass: 0x22d3ee,
+  challenge: 0xc084fc,
+  control: 0xf1f5f9,
+  neutral: 0x9aa5b1,
+};
+
+const KIND_COLORS: Record<string, number> = {
+  control: 0x4ade80,
+  medium_hit: 0xfacc15,
+  hard_hit: 0xff5d6c,
+};
+
+const UNKNOWN_CLASSIFICATION_COLOR = 0x9aa5b1;
+
 export interface TouchMarker {
   id: string;
   time: number;
@@ -23,6 +43,8 @@ export interface TouchMarker {
   isTeamZero: boolean;
   playerId: string | null;
   playerName: string;
+  kind: string | null;
+  intention: string | null;
   position: {
     x: number;
     y: number;
@@ -60,20 +82,49 @@ function positiveDelta(current: number, previous: number): number {
   return Math.max(0, current - previous);
 }
 
-function touchCreditLabel(marker: TouchMarker, mode: TouchOverlayMode): string {
+function touchCreditLabel(
+  marker: TouchMarker,
+  mode: TouchOverlayMode,
+  colorMode: TouchOverlayColorMode,
+): string {
+  const classification = touchMarkerClassification(marker, colorMode);
+  const suffix = classification ? ` · ${classification.replaceAll("_", " ")}` : "";
   if (mode === "markers") {
-    return marker.playerName;
+    return `${marker.playerName}${suffix}`;
   }
 
   const advance = Math.round(marker.totalBallAdvanceDistance);
   const retreat = Math.round(marker.totalBallRetreatDistance);
   if (advance > 0 && retreat > 0) {
-    return `${marker.playerName} +${advance} / -${retreat} uu`;
+    return `${marker.playerName} +${advance} / -${retreat} uu${suffix}`;
   }
   if (retreat > 0) {
-    return `${marker.playerName} -${retreat} uu`;
+    return `${marker.playerName} -${retreat} uu${suffix}`;
   }
-  return `${marker.playerName} +${advance} uu`;
+  return `${marker.playerName} +${advance} uu${suffix}`;
+}
+
+function touchMarkerClassification(
+  marker: TouchMarker,
+  colorMode: TouchOverlayColorMode,
+): string | null {
+  if (colorMode === "intention") {
+    return marker.intention;
+  }
+  if (colorMode === "kind") {
+    return marker.kind;
+  }
+  return null;
+}
+
+export function touchMarkerColor(marker: TouchMarker, colorMode: TouchOverlayColorMode): number {
+  if (colorMode === "intention") {
+    return INTENTION_COLORS[marker.intention ?? ""] ?? UNKNOWN_CLASSIFICATION_COLOR;
+  }
+  if (colorMode === "kind") {
+    return KIND_COLORS[marker.kind ?? ""] ?? UNKNOWN_CLASSIFICATION_COLOR;
+  }
+  return marker.isTeamZero ? BLUE_TOUCH_COLOR : ORANGE_TOUCH_COLOR;
 }
 
 export function buildTouchMarkers(
@@ -108,6 +159,8 @@ export function buildTouchMarkers(
       isTeamZero: event.is_team_0,
       playerId,
       playerName: replay.players.find((player) => player.id === playerId)?.name ?? playerId,
+      kind: typeof event.kind === "string" ? event.kind : null,
+      intention: typeof event.intention === "string" ? event.intention : null,
       position: {
         x: ballPosition.x,
         y: ballPosition.y,
@@ -257,6 +310,7 @@ export class TouchEventOverlay {
   private originalContainerPosition = "";
   private decaySeconds = DEFAULT_DECAY_SECONDS;
   private mode: TouchOverlayMode = "markers";
+  private colorMode: TouchOverlayColorMode = "team";
 
   constructor(
     scene: ReplayScene,
@@ -266,6 +320,7 @@ export class TouchEventOverlay {
     options?: {
       decaySeconds?: number;
       mode?: TouchOverlayMode;
+      colorMode?: TouchOverlayColorMode;
     },
   ) {
     ensureStyles();
@@ -273,6 +328,7 @@ export class TouchEventOverlay {
     this.container = container;
     this.decaySeconds = Math.max(0.1, options?.decaySeconds ?? DEFAULT_DECAY_SECONDS);
     this.mode = options?.mode ?? "markers";
+    this.colorMode = options?.colorMode ?? "team";
     this.labelOffset.set(0, 0, TOUCH_LABEL_HEIGHT);
     this.markers = buildTouchMarkers(statsTimeline, replay);
 
@@ -306,6 +362,14 @@ export class TouchEventOverlay {
     this.mode = mode;
   }
 
+  getColorMode(): TouchOverlayColorMode {
+    return this.colorMode;
+  }
+
+  setColorMode(colorMode: TouchOverlayColorMode): void {
+    this.colorMode = colorMode;
+  }
+
   update(currentTime: number): void {
     const visibleMarkers = getVisibleTouchMarkers(this.markers, currentTime, this.decaySeconds);
     const visibleIds = new Set(visibleMarkers.map((marker) => marker.id));
@@ -329,18 +393,30 @@ export class TouchEventOverlay {
       const baseOpacity = 0.1 + 0.6 * life;
       const scale = 0.95 + (1 - life) * 0.28;
 
+      const color = touchMarkerColor(marker, this.colorMode);
       view.material.opacity = baseOpacity;
+      view.material.color.setHex(color);
+      view.arrow.setColor(color);
       view.ring.position.set(
         marker.position.x,
         marker.position.y,
         marker.position.z + TOUCH_RING_HEIGHT,
       );
       view.ring.scale.setScalar(scale);
-      view.label.textContent = touchCreditLabel(marker, this.mode);
+      view.label.textContent = touchCreditLabel(marker, this.mode, this.colorMode);
       view.label.classList.toggle(
         "sap-touch-overlay-label-advancement",
         this.mode === "advancement",
       );
+      const teamTinted = this.colorMode === "team";
+      view.label.classList.toggle("sap-touch-overlay-label-blue", teamTinted && marker.isTeamZero);
+      view.label.classList.toggle(
+        "sap-touch-overlay-label-orange",
+        teamTinted && !marker.isTeamZero,
+      );
+      view.label.style.borderColor = teamTinted
+        ? ""
+        : `#${color.toString(16).padStart(6, "0")}cc`;
 
       this.updateArrow(view, marker, baseOpacity);
 

--- a/js/stat-evaluation-player/src/touchOverlay.ts
+++ b/js/stat-evaluation-player/src/touchOverlay.ts
@@ -414,9 +414,7 @@ export class TouchEventOverlay {
         "sap-touch-overlay-label-orange",
         teamTinted && !marker.isTeamZero,
       );
-      view.label.style.borderColor = teamTinted
-        ? ""
-        : `#${color.toString(16).padStart(6, "0")}cc`;
+      view.label.style.borderColor = teamTinted ? "" : `#${color.toString(16).padStart(6, "0")}cc`;
 
       this.updateArrow(view, marker, baseOpacity);
 


### PR DESCRIPTION
## Summary

Adds a **Color by** setting to the stat-evaluation-player's touch module so the 3D touch visualization (rings, advancement arrows, and projected labels) can be colored by touch classification instead of team:

- **Team** (default) — existing blue/orange behavior, unchanged.
- **Intention** — shot (red), save (green), clear (yellow), pass (cyan), challenge (purple), control (white), neutral (gray).
- **Hit strength** — touch `kind`: control (green), medium hit (yellow), hard hit (red).

Details:

- `TouchMarker` now carries the touch event's `kind` and `intention`; a new exported `touchMarkerColor(marker, colorMode)` picks the palette, falling back to gray for unknown/missing classifications.
- Colors are applied in the per-frame `update()` so switching modes retints markers already on screen.
- In classification modes the floating label drops its team tint, takes a border in the classification color, and appends the classification name (e.g. `Blue +340 uu · shot`), so colors are self-explanatory without a legend.
- The choice round-trips through module config as `overlayColorMode` alongside the existing decay/overlay-mode settings.

Also includes a separate commit syncing the stale `js/stat-evaluation-player/package-lock.json` with `package.json` (esbuild is dev-only).

## Testing

- Updated `buildTouchMarkers` expectations for the new marker fields and added a palette/fallback unit test for `touchMarkerColor` (10/10 pass), plus the timeline-marker tests that share `buildTouchMarkers` (11/11 pass).
- `tsc --noEmit` clean with the repo's pinned TypeScript 5.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)