### PR TITLE
fix: correctly tag kickoff flip-into-ball goals

### DIFF
--- a/src/stats/calculators/match_stats.rs
+++ b/src/stats/calculators/match_stats.rs
@@ -1001,11 +1001,24 @@ impl MatchStatsCalculator {
         goal_time: f32,
         scoring_team_is_team_0: bool,
     ) -> GoalBuildupKind {
+        // A goal's buildup must not reach back across the kickoff that
+        // immediately preceded it. Play before that kickoff belongs to a prior,
+        // already-concluded possession (a kickoff only follows a goal/reset), so
+        // counting its ball positions as "defensive pressure" for this goal is
+        // spurious — it is exactly what makes a clean kickoff goal masquerade as
+        // a counter-attack. Clamp the lookback window to the current kickoff's
+        // first touch when one is established.
+        let window_start = self
+            .active_kickoff_touch_time
+            .map(|kickoff_touch_time| {
+                kickoff_touch_time.max(goal_time - GOAL_BUILDUP_LOOKBACK_SECONDS)
+            })
+            .unwrap_or(goal_time - GOAL_BUILDUP_LOOKBACK_SECONDS);
         let relevant_samples: Vec<_> = self
             .goal_buildup_samples
             .iter()
             .filter(|entry| entry.time <= goal_time)
-            .filter(|entry| goal_time - entry.time <= GOAL_BUILDUP_LOOKBACK_SECONDS)
+            .filter(|entry| entry.time >= window_start)
             .collect();
         if relevant_samples.is_empty() {
             return GoalBuildupKind::Other;
@@ -1051,7 +1064,7 @@ impl MatchStatsCalculator {
 
         let opponent_shot_in_lookback = self.goal_buildup_pressure_events.iter().any(|entry| {
             entry.time <= goal_time
-                && goal_time - entry.time <= GOAL_BUILDUP_LOOKBACK_SECONDS
+                && entry.time >= window_start
                 && entry.is_team_0 != scoring_team_is_team_0
         });
         let has_defensive_pressure_signal = defensive_half_time

--- a/src/stats/calculators/match_stats_tests.rs
+++ b/src/stats/calculators/match_stats_tests.rs
@@ -517,6 +517,51 @@ fn counter_attack_buildup_accepts_defensive_half_pressure_without_defensive_thir
 }
 
 #[test]
+fn counter_attack_buildup_ignores_defensive_pressure_before_the_kickoff() {
+    // Regression: a clean kickoff goal must not be classified as a
+    // counter-attack just because the lookback window reaches back across the
+    // kickoff into the previous possession. The defensive-half presence here all
+    // predates the kickoff first touch, so it must not count toward this goal.
+    let mut calculator = MatchStatsCalculator::new();
+    calculator.goal_buildup_samples = vec![
+        buildup_sample(2.0, -500.0),
+        buildup_sample(3.0, -500.0),
+        buildup_sample(4.0, -500.0),
+        buildup_sample(5.0, -500.0),
+        buildup_sample(6.0, 600.0),
+        buildup_sample(7.0, 600.0),
+        buildup_sample(8.0, 600.0),
+        buildup_sample(9.0, 600.0),
+    ];
+    // Kickoff first touch lands after the (prior-possession) defensive pressure.
+    calculator.active_kickoff_touch_time = Some(5.5);
+
+    assert_eq!(
+        calculator.classify_goal_buildup(10.0, true),
+        GoalBuildupKind::Other
+    );
+}
+
+#[test]
+fn counter_attack_buildup_ignores_opponent_shot_before_the_kickoff() {
+    let mut calculator = MatchStatsCalculator::new();
+    calculator.goal_buildup_samples = vec![
+        buildup_sample(6.0, 600.0),
+        buildup_sample(7.0, 600.0),
+        buildup_sample(8.0, 600.0),
+        buildup_sample(9.0, 600.0),
+    ];
+    // Opponent shot belongs to the possession before this kickoff.
+    calculator.goal_buildup_pressure_events = vec![shot_pressure(5.0, false)];
+    calculator.active_kickoff_touch_time = Some(5.5);
+
+    assert_eq!(
+        calculator.classify_goal_buildup(10.0, true),
+        GoalBuildupKind::Other
+    );
+}
+
+#[test]
 fn counter_attack_buildup_accepts_opponent_shot_as_pressure_signal() {
     let mut calculator = MatchStatsCalculator::new();
     calculator.goal_buildup_samples = vec![

--- a/src/stats/calculators/touch.rs
+++ b/src/stats/calculators/touch.rs
@@ -4,6 +4,15 @@ const SOFT_TOUCH_BALL_SPEED_CHANGE_THRESHOLD: f32 = 320.0;
 const HARD_TOUCH_BALL_SPEED_CHANGE_THRESHOLD: f32 = 900.0;
 const AERIAL_TOUCH_MIN_PLAYER_Z: f32 = AIR_DRIBBLE_MIN_PLAYER_Z;
 
+/// How long after a touch we keep watching the toucher's dodge component before
+/// giving up on associating a flip with it. The `CarComponent_Dodge`
+/// `ReplicatedActive` byte routinely replicates a frame or two *after* the
+/// ball-hit it produced (the hit and the dodge-activation land on adjacent
+/// frames), so a flip-into-ball contact can be sampled on the one frame where
+/// the dodge flag has not yet flipped on. Re-checking for a brief window lets
+/// such touches be recognized as dodge contacts after the fact.
+const DODGE_LAG_TOLERANCE_SECONDS: f32 = 0.12;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TouchKind {
     Control,
@@ -135,6 +144,16 @@ impl TouchBallMovement {
     }
 }
 
+/// A `no_dodge` touch still within [`DODGE_LAG_TOLERANCE_SECONDS`] of being
+/// retroactively upgraded to a dodge contact, should the toucher's dodge
+/// component go active in the frames immediately following the hit.
+#[derive(Debug, Clone, PartialEq)]
+struct PendingDodgeUpgrade {
+    touch_index: usize,
+    player_id: PlayerId,
+    touch_time: f32,
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 struct PendingFiftyFiftyMovement {
     start_frame: usize,
@@ -170,6 +189,7 @@ pub struct TouchCalculator {
     previous_ball_velocity: Option<glam::Vec3>,
     previous_ball_position: Option<glam::Vec3>,
     pending_fifty_fifty_movement: Option<PendingFiftyFiftyMovement>,
+    pending_dodge_upgrades: Vec<PendingDodgeUpgrade>,
     intention_classifier: TouchIntentionClassifier,
     control_follow: ControlFollowTracker,
 }
@@ -422,6 +442,16 @@ impl TouchCalculator {
             self.events.push(event);
             self.active_touch_index_by_player
                 .insert(player_id.clone(), touch_index);
+            // The dodge byte often lags the hit by a frame or two; if this touch
+            // looked dodge-less, keep watching the toucher's dodge component so a
+            // flip-into-ball contact still gets recognized once it activates.
+            if matches!(classification.dodge_state, TouchDodgeState::NoDodge) {
+                self.pending_dodge_upgrades.push(PendingDodgeUpgrade {
+                    touch_index,
+                    player_id: player_id.clone(),
+                    touch_time: touch_event.time,
+                });
+            }
             if matches!(
                 resolution.intention,
                 TouchIntention::Pass | TouchIntention::Neutral
@@ -443,6 +473,34 @@ impl TouchCalculator {
         }
         if let Some(event) = self.events.get_mut(resolution.touch_index) {
             event.intention = TouchIntention::Control.as_label_value().to_owned();
+        }
+    }
+
+    /// Re-examine recent `no_dodge` touches against this frame's dodge state.
+    /// The dodge component's active byte frequently replicates a frame or two
+    /// after the ball-hit it caused, so a flip-into-ball contact can be sampled
+    /// on the one frame where the flag has not yet flipped on. Any pending touch
+    /// whose toucher is now dodging within [`DODGE_LAG_TOLERANCE_SECONDS`] is
+    /// upgraded to a dodge contact; entries that age out are dropped.
+    fn advance_dodge_upgrades(&mut self, frame: &FrameInfo, players: &PlayerFrameState) {
+        if self.pending_dodge_upgrades.is_empty() {
+            return;
+        }
+        let mut resolved = Vec::new();
+        self.pending_dodge_upgrades.retain(|pending| {
+            if frame.time - pending.touch_time > DODGE_LAG_TOLERANCE_SECONDS {
+                return false;
+            }
+            if Self::player_dodge_active(players, &pending.player_id) {
+                resolved.push(pending.touch_index);
+                return false;
+            }
+            true
+        });
+        for touch_index in resolved {
+            if let Some(event) = self.events.get_mut(touch_index) {
+                event.dodge_state = TouchDodgeState::Dodge.as_label_value().to_owned();
+            }
         }
     }
 
@@ -718,6 +776,7 @@ impl TouchCalculator {
             self.previous_ball_velocity = ball.velocity();
             self.previous_ball_position = ball.position();
             self.pending_fifty_fifty_movement = None;
+            self.pending_dodge_upgrades.clear();
             self.intention_classifier.reset();
             let resolution = self.control_follow.flush();
             self.apply_control_resolution(resolution);
@@ -734,6 +793,7 @@ impl TouchCalculator {
             &touch_state.touch_events,
             fifty_fifty_state,
         );
+        self.advance_dodge_upgrades(frame, players);
         self.advance_control_follow(frame, ball, players);
         self.credit_ball_movement(
             frame,

--- a/src/stats/calculators/touch_tests.rs
+++ b/src/stats/calculators/touch_tests.rs
@@ -303,6 +303,124 @@ fn touch_event_dodge_contact_flag_counts_as_dodge_hit() {
 }
 
 #[test]
+fn dodge_byte_lagging_one_frame_upgrades_touch_to_dodge() {
+    // Regression: the CarComponent_Dodge ReplicatedActive byte routinely
+    // replicates a frame after the ball-hit it produced, so a flip-into-ball
+    // contact is sampled on the one frame where the flag is not yet active. The
+    // touch must still be recognized as a dodge contact once the byte flips on
+    // within the lag-tolerance window.
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = TouchCalculator::new();
+
+    calculator
+        .update(
+            &frame(0),
+            &ball(0.0, 0.0),
+            &PlayerFrameState::default(),
+            &PlayerVerticalState::default(),
+            &RotationCalculator::default(),
+            &TouchState::default(),
+            &PossessionState::default(),
+            &FiftyFiftyState::default(),
+            &FrameEventsState::default(),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    // The hit lands while the dodge byte still reads inactive.
+    calculator
+        .update(
+            &frame(1),
+            &ball_with_velocity(0.0, 0.0, glam::Vec3::new(0.0, 1500.0, 0.0)),
+            &player_frame_state_with_dodge_active(&player_id, glam::Vec3::ZERO, false),
+            &vertical_state(&player_id, 0.0),
+            &RotationCalculator::default(),
+            &touch_state(1, &player_id),
+            &PossessionState::default(),
+            &FiftyFiftyState::default(),
+            &FrameEventsState::default(),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    assert_eq!(calculator.events()[0].dodge_state, "no_dodge");
+    // One frame later the dodge byte flips on (no new touch this frame).
+    calculator
+        .update(
+            &frame(2),
+            &ball_with_velocity(0.0, 0.0, glam::Vec3::new(0.0, 1500.0, 0.0)),
+            &player_frame_state_with_dodge_active(&player_id, glam::Vec3::ZERO, true),
+            &vertical_state(&player_id, 0.0),
+            &RotationCalculator::default(),
+            &TouchState::default(),
+            &PossessionState::default(),
+            &FiftyFiftyState::default(),
+            &FrameEventsState::default(),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events()[0].dodge_state, "dodge");
+    let stats = calculator.player_stats().get(&player_id).unwrap();
+    assert_eq!(stats.dodge_touch_count(), 1);
+}
+
+#[test]
+fn dodge_byte_outside_tolerance_window_does_not_upgrade_touch() {
+    // A dodge that activates well after the touch (beyond the lag tolerance) is
+    // a separate maneuver and must not retroactively mark the touch a dodge.
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = TouchCalculator::new();
+
+    calculator
+        .update(
+            &frame(0),
+            &ball(0.0, 0.0),
+            &PlayerFrameState::default(),
+            &PlayerVerticalState::default(),
+            &RotationCalculator::default(),
+            &TouchState::default(),
+            &PossessionState::default(),
+            &FiftyFiftyState::default(),
+            &FrameEventsState::default(),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(1),
+            &ball_with_velocity(0.0, 0.0, glam::Vec3::new(0.0, 1500.0, 0.0)),
+            &player_frame_state_with_dodge_active(&player_id, glam::Vec3::ZERO, false),
+            &vertical_state(&player_id, 0.0),
+            &RotationCalculator::default(),
+            &touch_state(1, &player_id),
+            &PossessionState::default(),
+            &FiftyFiftyState::default(),
+            &FrameEventsState::default(),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    // Dodge stays inactive through frame 2, then activates at frame 3 — by which
+    // point the touch (t=0.1) is 0.2s old, past the tolerance window.
+    for (frame_number, dodge_active) in [(2usize, false), (3usize, true)] {
+        calculator
+            .update(
+                &frame(frame_number),
+                &ball_with_velocity(0.0, 0.0, glam::Vec3::new(0.0, 1500.0, 0.0)),
+                &player_frame_state_with_dodge_active(&player_id, glam::Vec3::ZERO, dodge_active),
+                &vertical_state(&player_id, 0.0),
+                &RotationCalculator::default(),
+                &TouchState::default(),
+                &PossessionState::default(),
+                &FiftyFiftyState::default(),
+                &FrameEventsState::default(),
+                &LivePlayState::active_play(),
+            )
+            .unwrap();
+    }
+
+    assert_eq!(calculator.events()[0].dodge_state, "no_dodge");
+}
+
+#[test]
 fn controlled_ground_carry_touch_counts_as_control_despite_medium_impulse() {
     let player_id = boxcars::RemoteId::Steam(1);
     let mut calculator = TouchCalculator::new();


### PR DESCRIPTION
Two fixes that came out of investigating why a clean kickoff goal was mis-tagged. Both center on the opening goal of one replay: a flip-into-ball kickoff finish that was (a) wrongly tagged a counter-attack and (b) missing its flip-into-ball tag.

## 1. `fix(buildup)`: don't classify kickoff goals as counter-attacks

The goal-buildup classifier looked back a fixed 12s for defensive pressure, letting the window reach across the kickoff that immediately preceded the goal into the *previous* possession. Because a kickoff only follows a goal/reset, those pre-kickoff ball positions belong to an already-concluded sequence, so counting them as "defensive pressure" made clean kickoff goals get tagged `CounterAttackGoal`.

Fix: clamp the buildup lookback window to the current kickoff's first touch when one is established. Legitimate counter-attacks are unaffected — their defensive pressure happens during open play after the kickoff, well within the window.

## 2. `fix(touch)`: tolerate dodge-byte lag when classifying flip-into-ball touches

The `CarComponent_Dodge:ReplicatedActive` byte routinely replicates a frame or two **after** the ball-hit it produced — the hit and the dodge-activation land on adjacent frames. A flip-into-ball contact therefore gets sampled on the one frame where the dodge flag hasn't flipped on yet, so the touch is classified `no_dodge` and the `FlipIntoBallGoal` gate (which requires `dodge_state == "dodge"`) rejects it.

Evidence from the replay's opening goal — the scoring touch lands exactly on the frame the ball's velocity actually changes; the dodge byte goes active the *next* frame:

| frame | ball Δvel | dodge byte |
|---|---|---|
| 259 | 31.5 | off |
| **260** (touch) | **1105.1** ← the hit | off |
| **261** | 511.6 | **on** ← flip |

The `FlipImpulse` detector catches the flip because it watches the rising edge across frames; the touch classifier had zero tolerance and missed it.

Fix: hold a `no_dodge` touch briefly and upgrade it to a dodge contact if the toucher's dodge component goes active within `DODGE_LAG_TOLERANCE_SECONDS` (0.12s), mirroring the existing control-follow deferred resolution. This addresses the root cause for **every** dodge-gated touch stat (flip-into-ball, flick, 50/50, whiff), not just the one tag. A flip beyond the window is treated as a separate maneuver and does not upgrade the touch.

## Testing

- New unit tests: one-frame dodge lag → touch upgraded to `dodge`; dodge beyond the window → not upgraded.
- Verified end-to-end on the source replay: the opening goal now tags `["FlipIntoBallGoal", "KickoffGoal"]` (was `["KickoffGoal"]`, previously also mis-tagged `CounterAttackGoal`), with the unrelated earlier touch correctly staying `no_dodge`.
- Dodge-sensitive suites all green: touch, goal_tags, flick, fifty_fifty, whiff, speed_flip, half_flip, dodge_reset. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)