### PR TITLE
Bump boxcars fork for PickupTimer + name-anonymization attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,8 +96,8 @@ checksum = "40ce3582fb888755eb1a77668e69f90c3b317fdcc85bbeacd0d9bdfa89427173"
 
 [[package]]
 name = "boxcars"
-version = "0.11.1"
-source = "git+https://github.com/colonelpanic8/boxcars.git?rev=70be5375a2e6fd52e82c267d8147522659580a31#70be5375a2e6fd52e82c267d8147522659580a31"
+version = "0.11.2"
+source = "git+https://github.com/colonelpanic8/boxcars.git?rev=342509319b5aa725abe0bbcfdb8a1f7a7a70a26d#342509319b5aa725abe0bbcfdb8a1f7a7a70a26d"
 dependencies = [
  "bitter",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,15 @@ status = "actively-developed"
 # patched fork. (Cargo ignores this section when subtr-actor is consumed as a
 # dependency and strips it on publish, so the crates.io version range above is
 # what downstream consumers still resolve.)
-# See https://github.com/colonelpanic8/boxcars/tree/fix/worldcup-ball
+# See https://github.com/colonelpanic8/boxcars/tree/frame-deserialize-and-pickup-timer-attrs
 [patch.crates-io]
-# Pinned past the World Cup fix to the frame `Deserialize` support
-# (nickbabcock/boxcars#284, stacked on #283) that `ReplayClip` fixtures need to
-# read decoded frames back in.
-boxcars = { git = "https://github.com/colonelpanic8/boxcars.git", rev = "70be5375a2e6fd52e82c267d8147522659580a31" }
+# Integration branch combining two not-yet-released boxcars changes:
+#   - frame `Deserialize` support (nickbabcock/boxcars#284, stacked on #283)
+#     that `ReplayClip` fixtures need to read decoded frames back in
+#   - the June 2026 PickupTimer_TA item-timer attributes (Rumble-family
+#     replays) and PRI_TA name-anonymization flags (general privacy feature)
+#     from nickbabcock/boxcars#286
+# boxcars fails the whole network-data decode on any unmapped attribute, so
+# both must be present. Once #284 and #286 land in an upstream release this
+# pin can move off the fork.
+boxcars = { git = "https://github.com/colonelpanic8/boxcars.git", rev = "342509319b5aa725abe0bbcfdb8a1f7a7a70a26d" }


### PR DESCRIPTION
Bumps the `[patch.crates-io]` boxcars pin to a rev that maps two attribute families a June 2026 Rocket League update added to replay network data:

- `TAGame.PickupTimer_TA:MaxTimeTillItem` / `TimeTillItem` — item-respawn timers (Rumble-family playlists)
- `TAGame.PRI_TA:bAnonymizeToOpponents` / `bAnonymizeToTeammates` — name-anonymization flags (general privacy feature)

`boxcars` fails the whole network-data decode on any unmapped attribute, so affected replays (e.g. Ranked Rumble) fail to parse entirely.

The mappings are proposed upstream in **nickbabcock/boxcars#286** (which also adds Ranked Rumble test replays + snapshots). The pin here points at `colonelpanic8/boxcars@3425093`, an **integration branch** (`frame-deserialize-and-pickup-timer-attrs`) that merges #286 onto the frame `Deserialize` support (#284) that `ReplayClip` needs — neither is in an upstream release yet, and both must be present. It also rides newer upstream boxcars (0.11.2). Once #284 and #286 land upstream, the pin can move off the fork.

The patch lives here (not just in the rocket-sense workspace) because the in-browser WASM player builds boxcars from subtr-actor's own lockfile.