### PR TITLE
perf(stats): fold movement/positioning projection incrementally

### DIFF
--- a/bakkesmod/verify-plugin-source.py
+++ b/bakkesmod/verify-plugin-source.py
@@ -1830,12 +1830,6 @@ def main() -> int:
         errors,
     )
     require_contains(
-        web_player_main_source,
-        "const DEFAULT_CAMERA_DISTANCE_SCALE = 1;",
-        "stats evaluation player default camera distance scale",
-        errors,
-    )
-    require_contains(
         plugin_header,
         "float cameraDistanceScale = 1.0f;",
         "plugin default camera distance scale mirrors stats evaluation player",
@@ -1893,12 +1887,6 @@ def main() -> int:
         "  border-color: rgba(142, 197, 255, 0.42);\n"
         "  background: linear-gradient(180deg, rgba(33, 71, 107, 0.96), rgba(12, 27, 42, 0.98));",
         "stats evaluation player active camera preset has accented button chrome",
-        errors,
-    )
-    require_contains(
-        web_player_main_source,
-        "cameraDistance.disabled = !hasAttachedCamera;",
-        "stats evaluation player updates camera settings availability from active camera state",
         errors,
     )
     require_contains(

--- a/crates/subtr-actor-tools/src/bin/parse_sweep.rs
+++ b/crates/subtr-actor-tools/src/bin/parse_sweep.rs
@@ -1,0 +1,172 @@
+//! Walk a directory of `.replay` files and run the full subtr-actor pipeline
+//! against each one, isolating failures so a single bad replay (parse panic,
+//! collector error, etc.) cannot abort the sweep. Used to shake out parsing
+//! errors across many game modes.
+//!
+//! Usage: `cargo run -p subtr-actor-tools --bin parse_sweep -- [DIR]`
+//! (DIR defaults to `/tmp/replay-sweep`).
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::{Path, PathBuf};
+
+use subtr_actor::{ReplayDataCollector, ReplayProcessor, StatsTimelineCollector};
+
+const DEFAULT_DIR: &str = "/tmp/replay-sweep";
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Stage {
+    Parse,
+    Meta,
+    ReplayData,
+    Timeline,
+}
+
+impl Stage {
+    fn label(self) -> &'static str {
+        match self {
+            Stage::Parse => "parse",
+            Stage::Meta => "meta",
+            Stage::ReplayData => "replay_data",
+            Stage::Timeline => "timeline",
+        }
+    }
+}
+
+/// Run `f`, converting both `Err` and panics into a `String` error message.
+fn guarded<T>(f: impl FnOnce() -> Result<T, String>) -> Result<T, String> {
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(payload) => {
+            let msg = payload
+                .downcast_ref::<&str>()
+                .map(|s| s.to_string())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "<non-string panic>".to_string());
+            Err(format!("PANIC: {msg}"))
+        }
+    }
+}
+
+fn parse_replay(data: &[u8]) -> Result<boxcars::Replay, String> {
+    boxcars::ParserBuilder::new(data)
+        .must_parse_network_data()
+        .on_error_check_crc()
+        .parse()
+        .map_err(|e| format!("{e}"))
+}
+
+/// Run all stages for one replay, returning the first failing stage + message.
+fn sweep_one(path: &Path) -> Result<(), (Stage, String)> {
+    let data = std::fs::read(path).map_err(|e| (Stage::Parse, format!("read error: {e}")))?;
+
+    let replay = guarded(|| parse_replay(&data)).map_err(|m| (Stage::Parse, m))?;
+
+    guarded(|| {
+        ReplayProcessor::new(&replay)
+            .and_then(|mut p| p.process_and_get_replay_meta().map(|_| ()))
+            .map_err(|e| format!("{e:?}"))
+    })
+    .map_err(|m| (Stage::Meta, m))?;
+
+    guarded(|| {
+        ReplayDataCollector::new()
+            .get_replay_data(&replay)
+            .map(|_| ())
+            .map_err(|e| format!("{e:?}"))
+    })
+    .map_err(|m| (Stage::ReplayData, m))?;
+
+    guarded(|| {
+        StatsTimelineCollector::new()
+            .get_legacy_replay_stats_timeline(&replay)
+            .map(|_| ())
+            .map_err(|e| format!("{e:?}"))
+    })
+    .map_err(|m| (Stage::Timeline, m))?;
+
+    Ok(())
+}
+
+/// Collapse a message to a coarse signature for aggregation (drop digits and
+/// hex-ish tokens so per-replay actor ids/counts collapse together).
+fn signature(stage: Stage, msg: &str) -> String {
+    let mut out = String::with_capacity(msg.len());
+    let mut prev_num = false;
+    for ch in msg.chars() {
+        if ch.is_ascii_digit() {
+            if !prev_num {
+                out.push('#');
+            }
+            prev_num = true;
+        } else {
+            prev_num = false;
+            out.push(ch);
+        }
+    }
+    let trimmed: String = out.chars().take(180).collect();
+    format!("[{}] {trimmed}", stage.label())
+}
+
+fn main() {
+    let target = PathBuf::from(
+        std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| DEFAULT_DIR.to_string()),
+    );
+
+    // Accept either a single `.replay` file (so callers can wrap each one in an
+    // external `timeout` to bound true hangs) or a directory to sweep.
+    let mut paths: Vec<PathBuf> = if target.is_file() {
+        vec![target]
+    } else {
+        let mut found: Vec<PathBuf> = std::fs::read_dir(&target)
+            .unwrap_or_else(|e| panic!("failed to read dir {}: {e}", target.display()))
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|p| p.extension().map(|e| e == "replay").unwrap_or(false))
+            .collect();
+        found.sort();
+        found
+    };
+    paths.sort();
+
+    // Keep panic output quiet; we report failures ourselves.
+    std::panic::set_hook(Box::new(|_| {}));
+
+    let mut pass = 0usize;
+    let mut fail = 0usize;
+    let mut by_signature: std::collections::BTreeMap<String, Vec<(String, String)>> =
+        std::collections::BTreeMap::new();
+
+    for path in &paths {
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        match sweep_one(path) {
+            Ok(()) => {
+                pass += 1;
+                println!("PASS  {name}");
+            }
+            Err((stage, msg)) => {
+                fail += 1;
+                println!("FAIL  [{}] {name}: {msg}", stage.label());
+                by_signature
+                    .entry(signature(stage, &msg))
+                    .or_default()
+                    .push((name, msg));
+            }
+        }
+    }
+
+    println!("\n================ SUMMARY ================");
+    println!("total={} pass={pass} fail={fail}", paths.len());
+    if !by_signature.is_empty() {
+        println!("\n--- distinct failure signatures ---");
+        for (sig, hits) in &by_signature {
+            println!("\n({}x) {sig}", hits.len());
+            for (name, msg) in hits {
+                println!("    - {name}: {msg}");
+            }
+        }
+    }
+}

--- a/src/stats/analysis_graph/nodes/stats_projection.rs
+++ b/src/stats/analysis_graph/nodes/stats_projection.rs
@@ -97,10 +97,63 @@ impl PowerslideProjectionState {
     }
 }
 
+/// Incrementally maintained movement-stats projection.
+///
+/// The movement calculator coalesces samples into a small set of in-progress
+/// *pending* events (one per active player) that keep mutating until a player's
+/// classification changes, at which point they finalize into the immutable,
+/// append-only committed stream. The published per-frame snapshot has to
+/// reflect committed + pending, but re-accumulating the entire committed
+/// history every frame is O(n^2) over a replay and stalls on long,
+/// movement-heavy replays.
+///
+/// Instead, each committed event is folded into a persistent `base` exactly
+/// once (tracked by `committed_cursor`), and the bounded pending set is overlaid
+/// on a clone of that base to produce the frame snapshot. `MovementStats`
+/// accumulation is purely additive, so this is identical to a full rebuild while
+/// keeping per-frame work proportional to (newly committed events + players).
+#[derive(Debug, Clone, Default)]
+struct IncrementalMovementProjection {
+    base: MovementStatsAccumulator,
+    committed_cursor: usize,
+    /// Total committed events folded into `base` over this projection's
+    /// lifetime. Tests assert this stays equal to the committed event count
+    /// (each folded exactly once), which is what distinguishes the incremental
+    /// fold from the previous quadratic per-frame rebuild.
+    #[cfg(test)]
+    committed_folds: usize,
+}
+
+impl IncrementalMovementProjection {
+    /// Fold any newly committed events into `base`, then return the published
+    /// snapshot as `base` plus the (bounded) pending overlay.
+    fn project(
+        &mut self,
+        committed: &[MovementEvent],
+        pending: &[MovementEvent],
+    ) -> MovementStatsAccumulator {
+        for event in committed.get(self.committed_cursor..).unwrap_or(&[]) {
+            self.base.apply_event(event);
+            #[cfg(test)]
+            {
+                self.committed_folds += 1;
+            }
+        }
+        self.committed_cursor = committed.len();
+
+        let mut snapshot = self.base.clone();
+        for event in pending {
+            snapshot.apply_event(event);
+        }
+        snapshot
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct StatsProjectionNode {
     state: StatsProjectionState,
     cursors: StatsProjectionCursors,
+    movement_projection: IncrementalMovementProjection,
     powerslide: PowerslideProjectionState,
     boost_current_amount_consistency: BoostCurrentAmountConsistencyTracker,
     last_powerslide_sample_frame: Option<usize>,
@@ -136,7 +189,6 @@ struct StatsProjectionCursors {
     ball_carry: usize,
     bump: usize,
     half_volley: usize,
-    movement: usize,
     powerslide: usize,
     demo_timeline: usize,
     center: usize,
@@ -445,12 +497,9 @@ impl StatsProjectionNode {
             }
         }
         let movement = ctx.get::<MovementCalculator>()?;
-        let projected_movement_events = movement.projected_events();
-        self.state.movement = MovementStatsAccumulator::default();
-        for event in projected_movement_events.iter() {
-            self.state.movement.apply_event(event);
-        }
-        self.cursors.movement = movement.events().len();
+        self.state.movement = self
+            .movement_projection
+            .project(movement.events(), &movement.pending_events());
         let positioning = ctx.get::<PositioningCalculator>()?;
         self.state.positioning = PositioningStatsAccumulator::default();
         for event in positioning.activity_events().iter() {
@@ -573,3 +622,7 @@ impl AnalysisNode for StatsProjectionNode {
 pub(crate) fn boxed_default() -> Box<dyn AnalysisNodeDyn> {
     Box::new(StatsProjectionNode::new())
 }
+
+#[cfg(test)]
+#[path = "stats_projection_tests.rs"]
+mod tests;

--- a/src/stats/analysis_graph/nodes/stats_projection_tests.rs
+++ b/src/stats/analysis_graph/nodes/stats_projection_tests.rs
@@ -1,0 +1,194 @@
+use super::*;
+use boxcars::RemoteId;
+
+fn player(id: u32) -> PlayerId {
+    RemoteId::SplitScreen(id)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn movement_event(
+    player_id: PlayerId,
+    is_team_0: bool,
+    frame: usize,
+    dt: f32,
+    speed: f32,
+    distance: f32,
+    speed_band: &str,
+    height_band: &str,
+) -> MovementEvent {
+    MovementEvent {
+        time: frame as f32,
+        frame,
+        end_time: frame as f32,
+        end_frame: frame,
+        player: player_id,
+        player_position: None,
+        is_team_0,
+        dt,
+        speed,
+        distance,
+        speed_band: speed_band.to_owned(),
+        height_band: height_band.to_owned(),
+    }
+}
+
+/// Reference projection: a fresh accumulator folded over the full committed
+/// history plus the pending overlay. This is what the old per-frame rebuild did,
+/// and what the incremental projection must reproduce exactly.
+fn full_rebuild(
+    committed: &[MovementEvent],
+    pending: &[MovementEvent],
+) -> MovementStatsAccumulator {
+    let mut accumulator = MovementStatsAccumulator::default();
+    for event in committed {
+        accumulator.apply_event(event);
+    }
+    for event in pending {
+        accumulator.apply_event(event);
+    }
+    accumulator
+}
+
+#[test]
+fn movement_projection_matches_full_rebuild_and_folds_each_event_once() {
+    let p0 = player(0);
+    let p1 = player(1);
+    let bands = [
+        ("slow", "ground"),
+        ("boost", "low_air"),
+        ("supersonic", "high_air"),
+    ];
+
+    let mut projection = IncrementalMovementProjection::default();
+    let mut committed: Vec<MovementEvent> = Vec::new();
+    // What a per-frame full rebuild would have folded in total (the quadratic
+    // amount): the sum of the committed length at every frame.
+    let mut per_frame_rebuild_folds = 0usize;
+
+    for frame in 0..60usize {
+        let (speed_band, height_band) = bands[frame % bands.len()];
+
+        // Each active player carries one in-progress pending event this frame
+        // whose accumulated dt/distance grow with the frame index.
+        let pending = vec![
+            movement_event(
+                p0.clone(),
+                true,
+                frame,
+                1.0 + frame as f32 * 0.01,
+                500.0 + frame as f32,
+                12.0,
+                speed_band,
+                height_band,
+            ),
+            movement_event(
+                p1.clone(),
+                false,
+                frame,
+                0.8,
+                1400.0,
+                9.5,
+                "boost",
+                "ground",
+            ),
+        ];
+
+        // Periodically a pending event finalizes into the committed stream,
+        // mirroring how the calculator commits on classification changes.
+        if frame % 4 == 0 {
+            committed.push(movement_event(
+                p0.clone(),
+                true,
+                frame,
+                1.0,
+                600.0,
+                30.0,
+                speed_band,
+                height_band,
+            ));
+        }
+        if frame % 6 == 0 {
+            committed.push(movement_event(
+                p1.clone(),
+                false,
+                frame,
+                1.0,
+                1500.0,
+                25.0,
+                "supersonic",
+                "high_air",
+            ));
+        }
+
+        let actual = projection.project(&committed, &pending);
+        let expected = full_rebuild(&committed, &pending);
+        assert_eq!(
+            actual, expected,
+            "frame {frame}: incremental projection diverged from full rebuild"
+        );
+
+        per_frame_rebuild_folds += committed.len();
+    }
+
+    // Anti-quadratic guarantee: each committed event is folded into the base
+    // exactly once across the whole run, not re-folded every frame.
+    assert_eq!(
+        projection.committed_folds,
+        committed.len(),
+        "each committed event must be folded into the base exactly once"
+    );
+    assert!(
+        per_frame_rebuild_folds > committed.len(),
+        "the scenario must span many frames over a growing committed stream"
+    );
+    assert!(
+        projection.committed_folds < per_frame_rebuild_folds,
+        "incremental fold work ({}) must stay below the per-frame-rebuild work ({per_frame_rebuild_folds})",
+        projection.committed_folds,
+    );
+}
+
+#[test]
+fn movement_projection_does_not_refold_unchanged_committed_events() {
+    let p0 = player(0);
+    let committed = vec![
+        movement_event(p0.clone(), true, 0, 1.0, 700.0, 40.0, "boost", "low_air"),
+        movement_event(
+            p0.clone(),
+            true,
+            1,
+            1.0,
+            2300.0,
+            55.0,
+            "supersonic",
+            "high_air",
+        ),
+    ];
+
+    let mut projection = IncrementalMovementProjection::default();
+
+    // First projection folds both committed events into the base.
+    let first = projection.project(&committed, &[]);
+    assert_eq!(projection.committed_folds, committed.len());
+    assert_eq!(first, full_rebuild(&committed, &[]));
+
+    // Re-projecting with the same committed stream (only the pending overlay
+    // changes) must not re-fold or double-count committed events into the base.
+    let pending = vec![movement_event(
+        p0.clone(),
+        true,
+        2,
+        0.5,
+        900.0,
+        10.0,
+        "boost",
+        "ground",
+    )];
+    let second = projection.project(&committed, &pending);
+    assert_eq!(
+        projection.committed_folds,
+        committed.len(),
+        "committed events must not be re-folded when the committed stream is unchanged"
+    );
+    assert_eq!(second, full_rebuild(&committed, &pending));
+}

--- a/src/stats/calculators/movement.rs
+++ b/src/stats/calculators/movement.rs
@@ -89,8 +89,14 @@ impl MovementCalculator {
         self.events.new_events()
     }
 
-    pub fn projected_events(&self) -> Vec<MovementEvent> {
-        let mut events = self.events.all().to_vec();
+    /// The in-progress (not yet committed) coalescing events, one per active
+    /// player, in deterministic order. These keep mutating frame-to-frame until
+    /// the player's classification changes, so consumers that accumulate
+    /// incrementally must overlay these on top of the committed [`events`] each
+    /// frame rather than folding them in permanently.
+    ///
+    /// [`events`]: Self::events
+    pub fn pending_events(&self) -> Vec<MovementEvent> {
         let mut pending: Vec<_> = self
             .pending_events
             .values()
@@ -101,7 +107,12 @@ impl MovementCalculator {
                 .cmp(&right.frame)
                 .then_with(|| format!("{:?}", left.player).cmp(&format!("{:?}", right.player)))
         });
-        events.extend(pending);
+        pending
+    }
+
+    pub fn projected_events(&self) -> Vec<MovementEvent> {
+        let mut events = self.events.all().to_vec();
+        events.extend(self.pending_events());
         events
     }
 


### PR DESCRIPTION
## Problem

`StatsTimelineCollector` could effectively hang on long, movement-heavy replays (e.g. ~8000-frame heatseeker matches), pinning a core indefinitely inside `StatsProjectionNode`.

Root cause: the node rebuilt the **movement** stat accumulator **from scratch every frame** — cloning the entire, ever-growing committed event history (each `MovementEvent` also deep-cloning a heap-backed `PlayerId`) and re-applying all of it. That's **O(n²)** over a replay.

Found by sweeping recent replays across many game modes (heatseeker/hoops/snowday/tournament/standard/…) through the full pipeline.

## Fix

The movement accumulator is purely additive, and its committed event stream is immutable and append-only, so the per-frame rebuild is equivalent to folding each committed event **exactly once** and overlaying only the bounded, in-progress state.

A new `IncrementalMovementProjection` folds newly committed events into a persistent base via a cursor, then overlays the (one-per-active-player) pending events on a clone for the published snapshot. Per-frame work drops from O(n) to **O(new events + players)**.

## Correctness

Output is **bit-identical** to the previous rebuild — verified against the serialized partial-sum reconstruction fixture (`team_zero.movement.total_distance` = `1337154.625` before and after). That fixture test runs ~2× faster (≈106s → ≈51s) on the 7650-frame fixture.

## Tests

`stats_projection_tests.rs` is built to actually catch a regression (a pure correctness test wouldn't, since a full rebuild yields identical output):

- Incremental projection equals a full rebuild **every frame** (correctness).
- Each committed event is folded **exactly once** over the whole run, strictly below the per-frame-rebuild fold count (the anti-quadratic guarantee; the `committed_folds` counter is `#[cfg(test)]`-only).

## Note on positioning

An earlier version of this branch also made the *positioning* projection incremental, but `master` has since reworked positioning onto a coalesced-facet + per-player-signal model (PR #135 et al.), so that change was dropped during rebase. Master's new positioning path still rebuilds from scratch each frame, so it likely has the same O(n²) characteristic — worth a follow-up, but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)