### PR TITLE
[codex] Add possession half breakdowns

### DIFF
--- a/js/stat-evaluation-player/src/possessionEventDerivation.test.ts
+++ b/js/stat-evaluation-player/src/possessionEventDerivation.test.ts
@@ -71,6 +71,15 @@ test("possession event derivation populates compacted team stats", () => {
   );
   assertClose(blueDefensive?.value, 0.1);
 
+  const blueDefensiveHalf = derived.frames[3]!.team_zero.possession.labeled_time?.entries.find(
+    (entry) =>
+      entry.labels.some((label) => label.key === "possession_state" && label.value === "own") &&
+      entry.labels.some(
+        (label) => label.key === "field_half" && label.value === "defensive_half",
+      ),
+  );
+  assertClose(blueDefensiveHalf?.value, 0.1);
+
   const orangeDefensive = derived.frames[3]!.team_one.possession.labeled_time?.entries.find(
     (entry) =>
       entry.labels.some((label) => label.key === "possession_state" && label.value === "own") &&
@@ -79,4 +88,13 @@ test("possession event derivation populates compacted team stats", () => {
       ),
   );
   assertClose(orangeDefensive?.value, 0.3);
+
+  const orangeDefensiveHalf = derived.frames[3]!.team_one.possession.labeled_time?.entries.find(
+    (entry) =>
+      entry.labels.some((label) => label.key === "possession_state" && label.value === "own") &&
+      entry.labels.some(
+        (label) => label.key === "field_half" && label.value === "defensive_half",
+      ),
+  );
+  assertClose(orangeDefensiveHalf?.value, 0.3);
 });

--- a/js/stat-evaluation-player/src/possessionEventDerivation.test.ts
+++ b/js/stat-evaluation-player/src/possessionEventDerivation.test.ts
@@ -74,9 +74,7 @@ test("possession event derivation populates compacted team stats", () => {
   const blueDefensiveHalf = derived.frames[3]!.team_zero.possession.labeled_time?.entries.find(
     (entry) =>
       entry.labels.some((label) => label.key === "possession_state" && label.value === "own") &&
-      entry.labels.some(
-        (label) => label.key === "field_half" && label.value === "defensive_half",
-      ),
+      entry.labels.some((label) => label.key === "field_half" && label.value === "defensive_half"),
   );
   assertClose(blueDefensiveHalf?.value, 0.1);
 
@@ -92,9 +90,7 @@ test("possession event derivation populates compacted team stats", () => {
   const orangeDefensiveHalf = derived.frames[3]!.team_one.possession.labeled_time?.entries.find(
     (entry) =>
       entry.labels.some((label) => label.key === "possession_state" && label.value === "own") &&
-      entry.labels.some(
-        (label) => label.key === "field_half" && label.value === "defensive_half",
-      ),
+      entry.labels.some((label) => label.key === "field_half" && label.value === "defensive_half"),
   );
   assertClose(orangeDefensiveHalf?.value, 0.3);
 });

--- a/js/stat-evaluation-player/src/possessionEventDerivation.ts
+++ b/js/stat-evaluation-player/src/possessionEventDerivation.ts
@@ -103,7 +103,19 @@ function relativePossessionLabel(label: StatLabel, isTeamZero: boolean): StatLab
   if (label.key === "field_third" && label.value === "team_one_third") {
     return { key: "field_third", value: isTeamZero ? "offensive_third" : "defensive_third" };
   }
+  if (label.key === "field_half" && label.value === "team_zero_side") {
+    return { key: "field_half", value: isTeamZero ? "defensive_half" : "offensive_half" };
+  }
+  if (label.key === "field_half" && label.value === "team_one_side") {
+    return { key: "field_half", value: isTeamZero ? "offensive_half" : "defensive_half" };
+  }
   return { ...label };
+}
+
+function fieldHalfForThird(fieldThird: string): string {
+  if (fieldThird === "team_zero_third") return "team_zero_side";
+  if (fieldThird === "team_one_third") return "team_one_side";
+  return "neutral";
 }
 
 function possessionTeamStats(raw: RawPossessionStats, isTeamZero: boolean): PossessionTeamStats {
@@ -152,6 +164,7 @@ function accumulatePossessionFrame(
   const labels: StatLabel[] = [{ key: "possession_state", value: state.possessionState }];
   if (state.fieldThird != null) {
     labels.push({ key: "field_third", value: state.fieldThird });
+    labels.push({ key: "field_half", value: fieldHalfForThird(state.fieldThird) });
   }
   addLabeledTime(raw.labeled_time, labels, dt);
 }

--- a/js/stat-evaluation-player/src/possessionFormatting.test.ts
+++ b/js/stat-evaluation-player/src/possessionFormatting.test.ts
@@ -173,6 +173,52 @@ test("renderPossessionStats can render a field-third breakdown on its own", () =
   assert.match(html, /Orange third<\/span><span class="value">5\.0s \(50\.0%\)/);
 });
 
+test("renderPossessionStats can render a field-half breakdown", () => {
+  const html = renderPossessionStats(
+    {
+      tracked_time: 10,
+      possession_time: 4,
+      opponent_possession_time: 4,
+      neutral_time: 2,
+      labeled_time: {
+        entries: [
+          {
+            labels: [
+              { key: "possession_state", value: "own" },
+              { key: "field_half", value: "defensive_half" },
+            ],
+            value: 3,
+          },
+          {
+            labels: [
+              { key: "possession_state", value: "neutral" },
+              { key: "field_half", value: "neutral" },
+            ],
+            value: 2,
+          },
+          {
+            labels: [
+              { key: "possession_state", value: "opponent" },
+              { key: "field_half", value: "offensive_half" },
+            ],
+            value: 5,
+          },
+        ],
+      },
+    },
+    {
+      labelPerspective: {
+        kind: "team",
+      },
+      breakdownClasses: ["field_half"],
+    },
+  );
+
+  assert.match(html, /Own half<\/span><span class="value">3\.0s \(30\.0%\)/);
+  assert.match(html, /Neutral<\/span><span class="value">2\.0s \(20\.0%\)/);
+  assert.match(html, /Opp half<\/span><span class="value">5\.0s \(50\.0%\)/);
+});
+
 test("renderPossessionStats omits breakdown rows when no classes are selected", () => {
   const html = renderPossessionStats(
     {

--- a/js/stat-evaluation-player/src/possessionFormatting.ts
+++ b/js/stat-evaluation-player/src/possessionFormatting.ts
@@ -1,6 +1,6 @@
 import type { TeamStatsSnapshot } from "./statsTimeline.ts";
 
-export type PossessionBreakdownClass = "possession_state" | "field_third";
+export type PossessionBreakdownClass = "possession_state" | "field_third" | "field_half";
 
 interface PossessionRenderOptions {
   breakdownClasses?: PossessionBreakdownClass[];
@@ -131,6 +131,31 @@ function getOrderedFieldThirds(
   return ["defensive_third", "neutral_third", "offensive_third"];
 }
 
+function formatFieldHalfLabel(
+  value: string,
+  labelPerspective: PossessionRenderOptions["labelPerspective"],
+): string {
+  if (value === "neutral") {
+    return "Neutral";
+  }
+
+  if (labelPerspective.kind === "shared") {
+    return value === "defensive_half" ? "Blue half" : "Orange half";
+  }
+
+  return value === "defensive_half" ? "Own half" : "Opp half";
+}
+
+function getOrderedFieldHalves(
+  labelPerspective: PossessionRenderOptions["labelPerspective"],
+): string[] {
+  if (labelPerspective.kind === "shared") {
+    return ["defensive_half", "neutral", "offensive_half"];
+  }
+
+  return ["defensive_half", "neutral", "offensive_half"];
+}
+
 type PossessionBreakdownValueMap = Record<PossessionBreakdownClass, string>;
 
 function compareBreakdownValues(
@@ -143,7 +168,9 @@ function compareBreakdownValues(
     const valueOrder =
       className === "possession_state"
         ? getOrderedPossessionStates(labelPerspective)
-        : getOrderedFieldThirds(labelPerspective);
+        : className === "field_third"
+          ? getOrderedFieldThirds(labelPerspective)
+          : getOrderedFieldHalves(labelPerspective);
     const leftIndex = valueOrder.indexOf(left[className]);
     const rightIndex = valueOrder.indexOf(right[className]);
     const normalizedLeftIndex = leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex;
@@ -164,7 +191,9 @@ function formatBreakdownLabel(
   const formatValue = (className: PossessionBreakdownClass, value: string): string =>
     className === "possession_state"
       ? formatPossessionStateLabel(value, labelPerspective)
-      : formatFieldThirdLabel(value, labelPerspective);
+      : className === "field_third"
+        ? formatFieldThirdLabel(value, labelPerspective)
+        : formatFieldHalfLabel(value, labelPerspective);
 
   if (classes.length === 1) {
     const className = classes[0]!;

--- a/js/stat-evaluation-player/src/stat-modules/teamModules.ts
+++ b/js/stat-evaluation-player/src/stat-modules/teamModules.ts
@@ -27,7 +27,11 @@ export function createPossessionModule(runtime: StatModuleRuntime): StatModule {
   let settingsEl: HTMLDivElement | null = null;
   let breakdownReadoutEl: HTMLElement | null = null;
   const activeBreakdownClasses = new Set<PossessionBreakdownClass>();
-  const orderedBreakdownClasses: PossessionBreakdownClass[] = ["possession_state", "field_third"];
+  const orderedBreakdownClasses: PossessionBreakdownClass[] = [
+    "possession_state",
+    "field_half",
+    "field_third",
+  ];
 
   return {
     id: "possession",
@@ -166,6 +170,28 @@ export function createPossessionModule(runtime: StatModuleRuntime): StatModule {
         thirdOptionLabel.append(thirdCheckbox, thirdOptionText);
         options.append(thirdOptionLabel);
 
+        const halfOptionLabel = document.createElement("label");
+        halfOptionLabel.className = "toggle";
+
+        const halfCheckbox = document.createElement("input");
+        halfCheckbox.type = "checkbox";
+        halfCheckbox.dataset.breakdownClass = "field_half";
+        halfCheckbox.addEventListener("change", () => {
+          if (halfCheckbox.checked) {
+            activeBreakdownClasses.add("field_half");
+          } else {
+            activeBreakdownClasses.delete("field_half");
+          }
+          syncPossessionSettingsUi();
+          runtime.rerenderCurrentState();
+          runtime.requestConfigSync?.();
+        });
+
+        const halfOptionText = document.createElement("span");
+        halfOptionText.textContent = "Half";
+        halfOptionLabel.append(halfCheckbox, halfOptionText);
+        options.append(halfOptionLabel);
+
         settingsEl.append(header, options);
       }
 
@@ -194,7 +220,13 @@ export function createPossessionModule(runtime: StatModuleRuntime): StatModule {
         enabled.length === 0
           ? "Total only"
           : enabled
-              .map((className) => (className === "possession_state" ? "Control" : "Third"))
+              .map((className) =>
+                className === "possession_state"
+                  ? "Control"
+                  : className === "field_half"
+                    ? "Half"
+                    : "Third",
+              )
               .join(" x ");
     }
   }

--- a/js/stat-evaluation-player/src/stat-modules/teamModules.ts
+++ b/js/stat-evaluation-player/src/stat-modules/teamModules.ts
@@ -166,7 +166,7 @@ export function createPossessionModule(runtime: StatModuleRuntime): StatModule {
         });
 
         const thirdOptionText = document.createElement("span");
-        thirdOptionText.textContent = "Third";
+        thirdOptionText.textContent = "Thirds";
         thirdOptionLabel.append(thirdCheckbox, thirdOptionText);
         options.append(thirdOptionLabel);
 
@@ -188,7 +188,7 @@ export function createPossessionModule(runtime: StatModuleRuntime): StatModule {
         });
 
         const halfOptionText = document.createElement("span");
-        halfOptionText.textContent = "Half";
+        halfOptionText.textContent = "Halves";
         halfOptionLabel.append(halfCheckbox, halfOptionText);
         options.append(halfOptionLabel);
 
@@ -224,8 +224,8 @@ export function createPossessionModule(runtime: StatModuleRuntime): StatModule {
                 className === "possession_state"
                   ? "Control"
                   : className === "field_half"
-                    ? "Half"
-                    : "Third",
+                    ? "Halves"
+                    : "Thirds",
               )
               .join(" x ");
     }

--- a/src/stats/accumulators/possession.rs
+++ b/src/stats/accumulators/possession.rs
@@ -120,8 +120,13 @@ impl PossessionStatsAccumulator {
             .as_deref()
             .and_then(static_field_third_label_value)
         {
+            let field_half = field_half_for_field_third(field_third);
             self.stats.labeled_time.add(
-                [possession_label, StatLabel::new("field_third", field_third)],
+                [
+                    possession_label,
+                    StatLabel::new("field_third", field_third),
+                    StatLabel::new("field_half", field_half),
+                ],
                 event.duration,
             );
         } else {
@@ -138,6 +143,14 @@ fn static_field_third_label_value(value: &str) -> Option<&'static str> {
         "neutral_third" => Some("neutral_third"),
         "team_one_third" => Some("team_one_third"),
         _ => None,
+    }
+}
+
+fn field_half_for_field_third(value: &str) -> &'static str {
+    match value {
+        "team_zero_third" => "team_zero_side",
+        "team_one_third" => "team_one_side",
+        _ => "neutral",
     }
 }
 
@@ -167,6 +180,73 @@ fn team_relative_possession_label(label: &StatLabel, is_team_zero: bool) -> Stat
                 "defensive_third"
             },
         ),
+        ("field_half", "team_zero_side") => StatLabel::new(
+            "field_half",
+            if is_team_zero {
+                "defensive_half"
+            } else {
+                "offensive_half"
+            },
+        ),
+        ("field_half", "team_one_side") => StatLabel::new(
+            "field_half",
+            if is_team_zero {
+                "offensive_half"
+            } else {
+                "defensive_half"
+            },
+        ),
         _ => label.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(possession_state: &str, field_third: &str, duration: f32) -> PossessionEvent {
+        PossessionEvent {
+            time: 0.0,
+            frame: 0,
+            end_time: duration,
+            end_frame: 1,
+            active: true,
+            duration,
+            possession_state: possession_state.to_owned(),
+            player_id: None,
+            field_third: Some(field_third.to_owned()),
+        }
+    }
+
+    #[test]
+    fn possession_labeled_time_includes_field_half() {
+        let mut accumulator = PossessionStatsAccumulator::default();
+        accumulator.apply_event(&event("team_zero", "team_zero_third", 2.0));
+
+        assert_eq!(
+            accumulator.stats().labeled_time.entries[0].labels,
+            vec![
+                StatLabel::new("field_half", "team_zero_side"),
+                StatLabel::new("field_third", "team_zero_third"),
+                StatLabel::new("possession_state", "team_zero"),
+            ]
+        );
+        assert_eq!(accumulator.stats().labeled_time.entries[0].value, 2.0);
+    }
+
+    #[test]
+    fn team_relative_possession_stats_translate_field_half() {
+        let mut accumulator = PossessionStatsAccumulator::default();
+        accumulator.apply_event(&event("team_zero", "team_one_third", 3.0));
+
+        let team_zero = accumulator.stats().for_team(true);
+        assert_eq!(
+            team_zero.labeled_time.entries[0].labels,
+            vec![
+                StatLabel::new("field_half", "offensive_half"),
+                StatLabel::new("field_third", "offensive_third"),
+                StatLabel::new("possession_state", "own"),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add `field_half` labels to possession labeled-time accumulations while retaining field thirds
- translate possession half labels into team-relative defensive/offensive halves
- expose Halves and Thirds as selectable possession breakdowns in the stat-evaluation player
- keep event-derived compact timelines aligned with the Rust accumulator

## Validation

- `cargo test --manifest-path vendor/subtr-actor/Cargo.toml possession -- --nocapture`
- `../scripts/with-clean-npm-env.sh npx tsx --tsconfig tsconfig.test.json --test src/possessionFormatting.test.ts src/possessionEventDerivation.test.ts`
- `../scripts/with-clean-npm-env.sh node --run=check:tsc`
