### PR TITLE
[codex] Migrate workspace to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,14 @@
 [workspace]
 members = [".", "bakkesmod/rust", "crates/subtr-actor-tools", "js", "python"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "1.0.0"
 authors = ["Ivan Malison <ivanmalison@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/rlrml/subtr-actor"
-edition = "2021"
+edition = "2024"
+rust-version = "1.87"
 
 [workspace.dependencies]
 boxcars = ">=0.11.3, <1.0.0"
@@ -19,6 +20,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords = ["rocket-league"]
 categories = ["parsing"]
 description = "Rocket League replay transformer"

--- a/bakkesmod/rust/Cargo.toml
+++ b/bakkesmod/rust/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "C ABI for feeding BakkesMod live Rocket League samples into subtr-actor mechanics detectors"
 
 [lib]

--- a/bakkesmod/rust/src/ffi.rs
+++ b/bakkesmod/rust/src/ffi.rs
@@ -26,7 +26,7 @@ pub(crate) fn refresh_timeline_graph_state(engine: &mut SaEngine) {
 ///
 /// The caller owns the returned pointer and must free it with
 /// `subtr_actor_bakkesmod_engine_destroy`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn subtr_actor_bakkesmod_engine_create() -> *mut SaEngine {
     Box::into_raw(Box::new(SaEngine::default()))
 }
@@ -72,7 +72,7 @@ pub(crate) fn build_replay_annotations(path: &CStr) -> SubtrActorResult<SaReplay
 ///
 /// Returns null on failure. The returned handle must be destroyed with
 /// `subtr_actor_bakkesmod_replay_annotations_destroy`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotations_create(
     replay_path: *const c_char,
 ) -> *mut SaReplayAnnotations {
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotations_create(
 
 /// Destroys a replay annotation handle allocated by
 /// `subtr_actor_bakkesmod_replay_annotations_create`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotations_destroy(
     annotations: *mut SaReplayAnnotations,
 ) {
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotations_destroy(
 }
 
 /// Returns the number of precomputed replay annotation events.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_count(
     annotations: *const SaReplayAnnotations,
 ) -> usize {
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_count(
 }
 
 /// Returns the number of replay players available for annotation labels.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_player_count(
     annotations: *const SaReplayAnnotations,
 ) -> usize {
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_player_count(
 }
 
 /// Copies replay player metadata into `out_players`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_players(
     annotations: *const SaReplayAnnotations,
     out_players: *mut SaReplayPlayerInfo,
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_players(
 }
 
 /// Copies replay players and current-frame core stats for replay playback.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_frame_players(
     annotations: *const SaReplayAnnotations,
     replay_time: f32,
@@ -192,16 +192,18 @@ pub(crate) fn serialize_replay_annotation_frame(
 /// The JSON payload is a `ReplayStatsFrame` from the preprocessed replay
 /// timeline. It is the replay-mode counterpart of
 /// `subtr_actor_bakkesmod_frame_json_len`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_frame_json_len(
     annotations: *const SaReplayAnnotations,
     replay_time: f32,
 ) -> usize {
-    annotations
-        .as_ref()
-        .and_then(|annotations| serialize_replay_annotation_frame(annotations, replay_time))
-        .map(|bytes| bytes.len())
-        .unwrap_or(0)
+    unsafe {
+        annotations
+            .as_ref()
+            .and_then(|annotations| serialize_replay_annotation_frame(annotations, replay_time))
+            .map(|bytes| bytes.len())
+            .unwrap_or(0)
+    }
 }
 
 /// Writes the replay stats frame at `replay_time` into caller-owned storage.
@@ -209,31 +211,33 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_frame_json_len(
 /// Returns the number of bytes written. Call
 /// `subtr_actor_bakkesmod_replay_annotation_frame_json_len` first to size the
 /// destination buffer.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_frame_json(
     annotations: *const SaReplayAnnotations,
     replay_time: f32,
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    let Some(annotations) = annotations.as_ref() else {
-        return 0;
-    };
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
-    }
+    unsafe {
+        let Some(annotations) = annotations.as_ref() else {
+            return 0;
+        };
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
 
-    let Some(bytes) = serialize_replay_annotation_frame(annotations, replay_time) else {
-        return 0;
-    };
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
+        let Some(bytes) = serialize_replay_annotation_frame(annotations, replay_time) else {
+            return 0;
+        };
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
+    }
 }
 
 /// Returns the scoreboard value for the latest processed replay frame at or before
 /// `replay_time`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_score_at_time(
     annotations: *const SaReplayAnnotations,
     replay_time: f32,
@@ -265,7 +269,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_score_at_time(
 ///
 /// The cursor resets automatically after seeking backwards. Events are copied
 /// into `out_events` and the return value is the number of copied events.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn subtr_actor_bakkesmod_poll_replay_annotations(
     annotations: *mut SaReplayAnnotations,
     replay_time: f32,
@@ -310,7 +314,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_poll_replay_annotations(
     copied
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Destroys an engine allocated by `subtr_actor_bakkesmod_engine_create`.
 ///
 /// # Safety
@@ -318,12 +322,14 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_poll_replay_annotations(
 /// `engine` must either be null or a pointer returned by
 /// `subtr_actor_bakkesmod_engine_create` that has not already been destroyed.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_engine_destroy(engine: *mut SaEngine) {
-    if !engine.is_null() {
-        drop(Box::from_raw(engine));
+    unsafe {
+        if !engine.is_null() {
+            drop(Box::from_raw(engine));
+        }
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Resets an existing engine to its initial state.
 ///
 /// # Safety
@@ -331,12 +337,14 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_engine_destroy(engine: *mut SaEng
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_engine_reset(engine: *mut SaEngine) {
-    if let Some(engine) = engine.as_mut() {
-        *engine = SaEngine::default();
+    unsafe {
+        if let Some(engine) = engine.as_mut() {
+            *engine = SaEngine::default();
+        }
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Finishes live graph evaluation and refreshes exported graph views.
 ///
 /// This mirrors replay collectors' end-of-replay `AnalysisGraph::finish` call,
@@ -350,24 +358,26 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_engine_reset(engine: *mut SaEngin
 ///
 /// `engine` must be a valid engine pointer.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_finish(engine: *mut SaEngine) -> i32 {
-    let Some(engine) = engine.as_mut() else {
-        return -1;
-    };
-    if !engine.live_replay_meta_initialized {
-        return 0;
+    unsafe {
+        let Some(engine) = engine.as_mut() else {
+            return -1;
+        };
+        if !engine.live_replay_meta_initialized {
+            return 0;
+        }
+        if engine.live_graph_finished {
+            return 0;
+        }
+        if engine.graph.finish().is_err() {
+            return -2;
+        }
+        refresh_timeline_graph_state(engine);
+        engine.live_graph_finished = true;
+        0
     }
-    if engine.live_graph_finished {
-        return 0;
-    }
-    if engine.graph.finish().is_err() {
-        return -2;
-    }
-    refresh_timeline_graph_state(engine);
-    engine.live_graph_finished = true;
-    0
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Feeds one sampled Rocket League frame into the live mechanics engine.
 ///
 /// Returns `0` on success, `-1` for invalid pointers, and `-2` if detector
@@ -382,52 +392,54 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_process_frame(
     engine: *mut SaEngine,
     frame: *const SaLiveFrame,
 ) -> i32 {
-    let Some(engine) = engine.as_mut() else {
-        return -1;
-    };
-    let Some(frame) = frame.as_ref() else {
-        return -1;
-    };
-    if frame.players.is_null() && frame.player_count != 0 {
-        return -1;
-    }
+    unsafe {
+        let Some(engine) = engine.as_mut() else {
+            return -1;
+        };
+        let Some(frame) = frame.as_ref() else {
+            return -1;
+        };
+        if frame.players.is_null() && frame.player_count != 0 {
+            return -1;
+        }
 
-    let players = if frame.player_count == 0 {
-        &[]
-    } else {
-        slice::from_raw_parts(frame.players, frame.player_count)
-    };
-    if has_duplicate_player_indices(players) {
-        return -1;
-    }
-    let Ok(explicit_events) = frame_event_slices(frame) else {
-        return -1;
-    };
-    if sync_live_replay_meta(engine, players).is_err() {
-        return -2;
-    }
-    let mut live_events = engine.live_events.clone();
-    let mut live_event_history = engine.live_event_history.clone();
-    let frame_input = frame_input_from_live_state(
-        &mut live_events,
-        &mut live_event_history,
-        engine.live_replay_meta.as_ref(),
-        frame,
-        players,
-        &explicit_events,
-    );
-    if engine.graph.evaluate_with_state(&frame_input).is_err() {
-        return -2;
-    }
+        let players = if frame.player_count == 0 {
+            &[]
+        } else {
+            slice::from_raw_parts(frame.players, frame.player_count)
+        };
+        if has_duplicate_player_indices(players) {
+            return -1;
+        }
+        let Ok(explicit_events) = frame_event_slices(frame) else {
+            return -1;
+        };
+        if sync_live_replay_meta(engine, players).is_err() {
+            return -2;
+        }
+        let mut live_events = engine.live_events.clone();
+        let mut live_event_history = engine.live_event_history.clone();
+        let frame_input = frame_input_from_live_state(
+            &mut live_events,
+            &mut live_event_history,
+            engine.live_replay_meta.as_ref(),
+            frame,
+            players,
+            &explicit_events,
+        );
+        if engine.graph.evaluate_with_state(&frame_input).is_err() {
+            return -2;
+        }
 
-    engine.live_events = live_events;
-    engine.live_event_history = live_event_history;
-    engine.live_graph_finished = false;
-    refresh_timeline_graph_state(engine);
-    0
+        engine.live_events = live_events;
+        engine.live_event_history = live_event_history;
+        engine.live_graph_finished = false;
+        refresh_timeline_graph_state(engine);
+        0
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the number of pending events currently buffered by the engine.
 ///
 /// # Safety
@@ -437,13 +449,15 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_process_frame(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_event_count(
     engine: *const SaEngine,
 ) -> usize {
-    engine
-        .as_ref()
-        .map(|engine| engine.pending_events.len())
-        .unwrap_or(0)
+    unsafe {
+        engine
+            .as_ref()
+            .map(|engine| engine.pending_events.len())
+            .unwrap_or(0)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the number of pending team-owned events currently buffered by the engine.
 ///
 /// # Safety
@@ -453,13 +467,15 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_event_count(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_team_event_count(
     engine: *const SaEngine,
 ) -> usize {
-    engine
-        .as_ref()
-        .map(|engine| engine.pending_team_events.len())
-        .unwrap_or(0)
+    unsafe {
+        engine
+            .as_ref()
+            .map(|engine| engine.pending_team_events.len())
+            .unwrap_or(0)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the number of pending goal-context events currently buffered by the engine.
 ///
 /// # Safety
@@ -469,13 +485,15 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_team_event_count(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_goal_context_event_count(
     engine: *const SaEngine,
 ) -> usize {
-    engine
-        .as_ref()
-        .map(|engine| engine.pending_goal_context_events.len())
-        .unwrap_or(0)
+    unsafe {
+        engine
+            .as_ref()
+            .map(|engine| engine.pending_goal_context_events.len())
+            .unwrap_or(0)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of a decoded stats-player config JSON payload.
 ///
 /// Accepts the compressed base64url `cfg` value emitted by the web stats
@@ -497,7 +515,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_decoded_stats_player_config_json_
         .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes a decoded stats-player config JSON payload into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -513,19 +531,21 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_decoded_stats_player_config
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    if encoded_config.is_null() || out_bytes.is_null() || max_bytes == 0 {
-        return 0;
+    unsafe {
+        if encoded_config.is_null() || out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
+        let encoded_config = CStr::from_ptr(encoded_config);
+        let Some(bytes) = decode_stats_player_config_json(encoded_config) else {
+            return 0;
+        };
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
     }
-    let encoded_config = unsafe { CStr::from_ptr(encoded_config) };
-    let Some(bytes) = decode_stats_player_config_json(encoded_config) else {
-        return 0;
-    };
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the byte length of the compressed base64url stats-player cfg value.
 ///
 /// The output format matches the web stats evaluation player's `cfg` payload:
@@ -547,7 +567,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_encoded_stats_player_config_len(
         .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes the compressed base64url stats-player cfg value into caller storage.
 ///
 /// Returns the number of bytes written. Call
@@ -563,14 +583,16 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_encoded_stats_player_config
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    if json_config.is_null() || out_bytes.is_null() || max_bytes == 0 {
-        return 0;
+    unsafe {
+        if json_config.is_null() || out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
+        let json_config = CStr::from_ptr(json_config);
+        let Some(bytes) = encode_stats_player_config_json(json_config) else {
+            return 0;
+        };
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
     }
-    let json_config = unsafe { CStr::from_ptr(json_config) };
-    let Some(bytes) = encode_stats_player_config_json(json_config) else {
-        return 0;
-    };
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
 }

--- a/bakkesmod/rust/src/ffi_graph_output.rs
+++ b/bakkesmod/rust/src/ffi_graph_output.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of the current serialized graph event bundle.
 ///
 /// The JSON payload is a `ReplayStatsTimelineEvents` value produced by the live
@@ -11,14 +11,16 @@ use super::*;
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_events_json_len(engine: *const SaEngine) -> usize {
-    engine
-        .as_ref()
-        .and_then(|engine| serialize_live_graph_output(engine, "events"))
-        .map(|bytes| bytes.len())
-        .unwrap_or(0)
+    unsafe {
+        engine
+            .as_ref()
+            .and_then(|engine| serialize_live_graph_output(engine, "events"))
+            .map(|bytes| bytes.len())
+            .unwrap_or(0)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes the current serialized graph event bundle into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -33,22 +35,24 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_events_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    let Some(engine) = engine.as_ref() else {
-        return 0;
-    };
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
-    }
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return 0;
+        };
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
 
-    let Some(bytes) = serialize_live_graph_output(engine, "events") else {
-        return 0;
-    };
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
+        let Some(bytes) = serialize_live_graph_output(engine, "events") else {
+            return 0;
+        };
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of the current serialized graph frame snapshot.
 ///
 /// The JSON payload is a `ReplayStatsFrame` value produced by the live analysis
@@ -59,14 +63,16 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_events_json(
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_frame_json_len(engine: *const SaEngine) -> usize {
-    engine
-        .as_ref()
-        .and_then(|engine| serialize_live_graph_output(engine, "frame"))
-        .map(|bytes| bytes.len())
-        .unwrap_or(0)
+    unsafe {
+        engine
+            .as_ref()
+            .and_then(|engine| serialize_live_graph_output(engine, "frame"))
+            .map(|bytes| bytes.len())
+            .unwrap_or(0)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes the current serialized graph frame snapshot into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -81,22 +87,24 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_frame_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    let Some(engine) = engine.as_ref() else {
-        return 0;
-    };
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
-    }
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return 0;
+        };
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
 
-    let Some(bytes) = serialize_live_graph_output(engine, "frame") else {
-        return 0;
-    };
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
+        let Some(bytes) = serialize_live_graph_output(engine, "frame") else {
+            return 0;
+        };
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of the current serialized live stats timeline.
 ///
 /// The JSON payload is a `ReplayStatsTimeline` value produced by the live
@@ -108,14 +116,16 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_frame_json(
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_timeline_json_len(engine: *const SaEngine) -> usize {
-    engine
-        .as_ref()
-        .and_then(|engine| serialize_live_graph_output(engine, "timeline"))
-        .map(|bytes| bytes.len())
-        .unwrap_or(0)
+    unsafe {
+        engine
+            .as_ref()
+            .and_then(|engine| serialize_live_graph_output(engine, "timeline"))
+            .map(|bytes| bytes.len())
+            .unwrap_or(0)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes the current serialized live stats timeline into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -131,22 +141,24 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_timeline_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    let Some(engine) = engine.as_ref() else {
-        return 0;
-    };
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
-    }
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return 0;
+        };
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
 
-    let Some(bytes) = serialize_live_graph_output(engine, "timeline") else {
-        return 0;
-    };
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
+        let Some(bytes) = serialize_live_graph_output(engine, "timeline") else {
+            return 0;
+        };
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of the current serialized live stats snapshot.
 ///
 /// The JSON payload exposes the same builtin stats module surface as
@@ -159,14 +171,16 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_timeline_json(
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_stats_json_len(engine: *const SaEngine) -> usize {
-    engine
-        .as_ref()
-        .and_then(|engine| serialize_live_graph_output(engine, "stats"))
-        .map(|bytes| bytes.len())
-        .unwrap_or(0)
+    unsafe {
+        engine
+            .as_ref()
+            .and_then(|engine| serialize_live_graph_output(engine, "stats"))
+            .map(|bytes| bytes.len())
+            .unwrap_or(0)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes the current serialized live stats snapshot into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -181,22 +195,24 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_stats_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    let Some(engine) = engine.as_ref() else {
-        return 0;
-    };
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
-    }
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return 0;
+        };
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
 
-    let Some(bytes) = serialize_live_graph_output(engine, "stats") else {
-        return 0;
-    };
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
+        let Some(bytes) = serialize_live_graph_output(engine, "stats") else {
+            return 0;
+        };
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of one named builtin stats module JSON payload.
 ///
 /// `module_name` must be one of the UTF-8 names reported by
@@ -211,10 +227,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_stats_module_json_len(
     engine: *const SaEngine,
     module_name: *const c_char,
 ) -> usize {
-    serialize_named_stats_module(engine, module_name).len()
+    unsafe { serialize_named_stats_module(engine, module_name).len() }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes one named builtin stats module JSON payload into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -232,16 +248,18 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_stats_module_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
+    unsafe {
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
+        let bytes = serialize_named_stats_module(engine, module_name);
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
     }
-    let bytes = serialize_named_stats_module(engine, module_name);
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of one named builtin stats module frame JSON payload.
 ///
 /// Known modules with no per-frame snapshot return JSON `null`; unknown modules
@@ -256,10 +274,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_stats_module_frame_json_len(
     engine: *const SaEngine,
     module_name: *const c_char,
 ) -> usize {
-    serialize_named_stats_module_frame(engine, module_name).len()
+    unsafe { serialize_named_stats_module_frame(engine, module_name).len() }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes one named builtin stats module frame JSON payload into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -277,16 +295,18 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_stats_module_frame_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
+    unsafe {
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
+        let bytes = serialize_named_stats_module_frame(engine, module_name);
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
     }
-    let bytes = serialize_named_stats_module_frame(engine, module_name);
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of one named builtin stats module config JSON payload.
 ///
 /// Known modules with no snapshot config return JSON `null`; unknown modules and
@@ -301,10 +321,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_stats_module_config_json_len(
     engine: *const SaEngine,
     module_name: *const c_char,
 ) -> usize {
-    serialize_named_stats_module_config(engine, module_name).len()
+    unsafe { serialize_named_stats_module_config(engine, module_name).len() }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes one named builtin stats module config JSON payload into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -322,16 +342,18 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_stats_module_config_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
+    unsafe {
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
+        let bytes = serialize_named_stats_module_config(engine, module_name);
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
     }
-    let bytes = serialize_named_stats_module_config(engine, module_name);
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of one named live graph output JSON payload.
 ///
 /// `output_name` must be one of `events`, `frame`, `timeline`, `stats`,
@@ -347,18 +369,20 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_graph_output_json_len(
     engine: *const SaEngine,
     output_name: *const c_char,
 ) -> usize {
-    let Some(engine) = engine.as_ref() else {
-        return 0;
-    };
-    let Some(output_name) = c_string_arg(output_name) else {
-        return 0;
-    };
-    serialize_live_graph_output(engine, &output_name)
-        .map(|bytes| bytes.len())
-        .unwrap_or(0)
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return 0;
+        };
+        let Some(output_name) = c_string_arg(output_name) else {
+            return 0;
+        };
+        serialize_live_graph_output(engine, &output_name)
+            .map(|bytes| bytes.len())
+            .unwrap_or(0)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes one named live graph output JSON payload into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -376,24 +400,26 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_graph_output_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    let Some(engine) = engine.as_ref() else {
-        return 0;
-    };
-    let Some(output_name) = c_string_arg(output_name) else {
-        return 0;
-    };
-    let Some(bytes) = serialize_live_graph_output(engine, &output_name) else {
-        return 0;
-    };
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return 0;
+        };
+        let Some(output_name) = c_string_arg(output_name) else {
+            return 0;
+        };
+        let Some(bytes) = serialize_live_graph_output(engine, &output_name) else {
+            return 0;
+        };
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
     }
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of one named live analysis-node JSON payload.
 ///
 /// `node_name` must be one of the names reported by
@@ -410,10 +436,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_analysis_node_json_len(
     engine: *const SaEngine,
     node_name: *const c_char,
 ) -> usize {
-    serialize_named_analysis_node(engine, node_name).len()
+    unsafe { serialize_named_analysis_node(engine, node_name).len() }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes one named live analysis-node JSON payload into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -431,16 +457,18 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_analysis_node_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    let bytes = serialize_named_analysis_node(engine, node_name);
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
+    unsafe {
+        let bytes = serialize_named_analysis_node(engine, node_name);
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
     }
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of the callable analysis-node name registry.
 ///
 /// The payload is a JSON string array containing every supported name for
@@ -456,7 +484,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_analysis_node_names_json_len(
     serialize_analysis_node_names(engine).len()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes the callable analysis-node name registry into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -472,16 +500,18 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_analysis_node_names_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    let bytes = serialize_analysis_node_names(engine);
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
+    unsafe {
+        let bytes = serialize_analysis_node_names(engine);
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
+        let count = max_bytes.min(bytes.len());
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
+        count
     }
-    let count = max_bytes.min(bytes.len());
-    ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-    count
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of the serialized live graph metadata.
 ///
 /// The JSON payload includes the builtin analysis-node registry, the actual
@@ -494,13 +524,15 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_analysis_node_names_json(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_graph_info_json_len(
     engine: *const SaEngine,
 ) -> usize {
-    engine
-        .as_ref()
-        .map(|engine| engine.graph_info_json.len())
-        .unwrap_or(0)
+    unsafe {
+        engine
+            .as_ref()
+            .map(|engine| engine.graph_info_json.len())
+            .unwrap_or(0)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Writes the serialized live graph metadata into caller-owned storage.
 ///
 /// Returns the number of bytes written. Call
@@ -516,19 +548,21 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_graph_info_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    let Some(engine) = engine.as_ref() else {
-        return 0;
-    };
-    if out_bytes.is_null() || max_bytes == 0 {
-        return 0;
-    }
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return 0;
+        };
+        if out_bytes.is_null() || max_bytes == 0 {
+            return 0;
+        }
 
-    let count = max_bytes.min(engine.graph_info_json.len());
-    ptr::copy_nonoverlapping(engine.graph_info_json.as_ptr(), out_bytes, count);
-    count
+        let count = max_bytes.min(engine.graph_info_json.len());
+        ptr::copy_nonoverlapping(engine.graph_info_json.as_ptr(), out_bytes, count);
+        count
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Copies and removes pending events from the engine.
 ///
 /// Returns the number of events copied into `out_events`.
@@ -542,20 +576,22 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_drain_events(
     out_events: *mut SaMechanicEvent,
     max_events: usize,
 ) -> usize {
-    let Some(engine) = engine.as_mut() else {
-        return 0;
-    };
-    if out_events.is_null() || max_events == 0 {
-        return 0;
-    }
+    unsafe {
+        let Some(engine) = engine.as_mut() else {
+            return 0;
+        };
+        if out_events.is_null() || max_events == 0 {
+            return 0;
+        }
 
-    let count = max_events.min(engine.pending_events.len());
-    ptr::copy_nonoverlapping(engine.pending_events.as_ptr(), out_events, count);
-    engine.pending_events.drain(..count);
-    count
+        let count = max_events.min(engine.pending_events.len());
+        ptr::copy_nonoverlapping(engine.pending_events.as_ptr(), out_events, count);
+        engine.pending_events.drain(..count);
+        count
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Copies and removes pending team-owned events from the engine.
 ///
 /// Returns the number of events copied into `out_events`.
@@ -569,20 +605,22 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_drain_team_events(
     out_events: *mut SaTeamEvent,
     max_events: usize,
 ) -> usize {
-    let Some(engine) = engine.as_mut() else {
-        return 0;
-    };
-    if out_events.is_null() || max_events == 0 {
-        return 0;
-    }
+    unsafe {
+        let Some(engine) = engine.as_mut() else {
+            return 0;
+        };
+        if out_events.is_null() || max_events == 0 {
+            return 0;
+        }
 
-    let count = max_events.min(engine.pending_team_events.len());
-    ptr::copy_nonoverlapping(engine.pending_team_events.as_ptr(), out_events, count);
-    engine.pending_team_events.drain(..count);
-    count
+        let count = max_events.min(engine.pending_team_events.len());
+        ptr::copy_nonoverlapping(engine.pending_team_events.as_ptr(), out_events, count);
+        engine.pending_team_events.drain(..count);
+        count
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Copies and removes pending goal-context events from the engine.
 ///
 /// Returns the number of events copied into `out_events`.
@@ -596,19 +634,21 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_drain_goal_context_events(
     out_events: *mut SaGoalContextEvent,
     max_events: usize,
 ) -> usize {
-    let Some(engine) = engine.as_mut() else {
-        return 0;
-    };
-    if out_events.is_null() || max_events == 0 {
-        return 0;
-    }
+    unsafe {
+        let Some(engine) = engine.as_mut() else {
+            return 0;
+        };
+        if out_events.is_null() || max_events == 0 {
+            return 0;
+        }
 
-    let count = max_events.min(engine.pending_goal_context_events.len());
-    ptr::copy_nonoverlapping(
-        engine.pending_goal_context_events.as_ptr(),
-        out_events,
-        count,
-    );
-    engine.pending_goal_context_events.drain(..count);
-    count
+        let count = max_events.min(engine.pending_goal_context_events.len());
+        ptr::copy_nonoverlapping(
+            engine.pending_goal_context_events.as_ptr(),
+            out_events,
+            count,
+        );
+        engine.pending_goal_context_events.drain(..count);
+        count
+    }
 }

--- a/bakkesmod/rust/src/graph_output.rs
+++ b/bakkesmod/rust/src/graph_output.rs
@@ -64,15 +64,17 @@ pub(crate) unsafe fn serialize_named_analysis_node(
     engine: *const SaEngine,
     node_name: *const c_char,
 ) -> Vec<u8> {
-    let Some(engine) = engine.as_ref() else {
-        return Vec::new();
-    };
-    let Some(node_name) = c_string_arg(node_name) else {
-        return Vec::new();
-    };
-    match builtin_analysis_node_json(&node_name, &engine.graph) {
-        Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
-        Err(_) => Vec::new(),
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return Vec::new();
+        };
+        let Some(node_name) = c_string_arg(node_name) else {
+            return Vec::new();
+        };
+        match builtin_analysis_node_json(&node_name, &engine.graph) {
+            Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
+            Err(_) => Vec::new(),
+        }
     }
 }
 
@@ -104,25 +106,29 @@ pub(crate) fn serialize_analysis_node_names(engine: *const SaEngine) -> Vec<u8> 
 }
 
 pub(crate) unsafe fn c_string_arg(value: *const c_char) -> Option<String> {
-    if value.is_null() {
-        return None;
+    unsafe {
+        if value.is_null() {
+            return None;
+        }
+        CStr::from_ptr(value).to_str().ok().map(str::to_owned)
     }
-    CStr::from_ptr(value).to_str().ok().map(str::to_owned)
 }
 
 pub(crate) unsafe fn serialize_named_stats_module(
     engine: *const SaEngine,
     module_name: *const c_char,
 ) -> Vec<u8> {
-    let Some(engine) = engine.as_ref() else {
-        return Vec::new();
-    };
-    let Some(module_name) = c_string_arg(module_name) else {
-        return Vec::new();
-    };
-    match builtin_stats_module_json(&module_name, &engine.graph) {
-        Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
-        Err(_) => Vec::new(),
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return Vec::new();
+        };
+        let Some(module_name) = c_string_arg(module_name) else {
+            return Vec::new();
+        };
+        match builtin_stats_module_json(&module_name, &engine.graph) {
+            Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
+            Err(_) => Vec::new(),
+        }
     }
 }
 
@@ -130,18 +136,20 @@ pub(crate) unsafe fn serialize_named_stats_module_frame(
     engine: *const SaEngine,
     module_name: *const c_char,
 ) -> Vec<u8> {
-    let Some(engine) = engine.as_ref() else {
-        return Vec::new();
-    };
-    let Some(module_name) = c_string_arg(module_name) else {
-        return Vec::new();
-    };
-    let Some(replay_meta) = engine.live_replay_meta.as_ref() else {
-        return Vec::new();
-    };
-    match builtin_stats_module_frame_json(&module_name, &engine.graph, replay_meta) {
-        Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
-        Err(_) => Vec::new(),
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return Vec::new();
+        };
+        let Some(module_name) = c_string_arg(module_name) else {
+            return Vec::new();
+        };
+        let Some(replay_meta) = engine.live_replay_meta.as_ref() else {
+            return Vec::new();
+        };
+        match builtin_stats_module_frame_json(&module_name, &engine.graph, replay_meta) {
+            Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
+            Err(_) => Vec::new(),
+        }
     }
 }
 
@@ -149,15 +157,17 @@ pub(crate) unsafe fn serialize_named_stats_module_config(
     engine: *const SaEngine,
     module_name: *const c_char,
 ) -> Vec<u8> {
-    let Some(engine) = engine.as_ref() else {
-        return Vec::new();
-    };
-    let Some(module_name) = c_string_arg(module_name) else {
-        return Vec::new();
-    };
-    match builtin_stats_module_config_json(&module_name, &engine.graph) {
-        Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
-        Err(_) => Vec::new(),
+    unsafe {
+        let Some(engine) = engine.as_ref() else {
+            return Vec::new();
+        };
+        let Some(module_name) = c_string_arg(module_name) else {
+            return Vec::new();
+        };
+        match builtin_stats_module_config_json(&module_name, &engine.graph) {
+            Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
+            Err(_) => Vec::new(),
+        }
     }
 }
 

--- a/bakkesmod/rust/src/lib.rs
+++ b/bakkesmod/rust/src/lib.rs
@@ -8,27 +8,17 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::slice;
 
-use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
 use base64::Engine as _;
+use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
 use boxcars::{ParserBuilder, Quaternion, RemoteId, RigidBody, Vector3f};
 use flate2::{
+    Compression,
     read::{DeflateDecoder, ZlibDecoder},
     write::DeflateEncoder,
-    Compression,
 };
 #[cfg(test)]
 use subtr_actor::ReplayFrameInputBuilder;
 use subtr_actor::{
-    boost_amount_to_percent, builtin_analysis_node_json, builtin_stats_graph_snapshot_json,
-    builtin_stats_module_config_json, builtin_stats_module_frame_json, builtin_stats_module_json,
-    builtin_stats_module_names, car_hitbox_for_body_id, default_car_hitbox,
-    default_stats_timeline_config,
-    geometry::apply_velocities_to_rigid_body,
-    hitbox_family_for_body_id,
-    stats::analysis_graph::{
-        builtin_analysis_node_aliases, builtin_analysis_node_names, graph_with_all_analysis_nodes,
-        AnalysisGraph, StatsTimelineEventsState, StatsTimelineFrameState,
-    },
     BackboardBounceEvent, BallFrameState, BallSample, BoostPadEvent, BoostPadEventKind,
     BoostPickupEvent, BumpEvent, CarHitbox, CorePlayerScoreboardEvent, DemoEventSample,
     DemolishAttribute, DemolishInfo, DodgeRefreshedEvent, Event, EventPayload, EventTiming,
@@ -38,7 +28,16 @@ use subtr_actor::{
     ReplayMeta, ReplayStatsFrame, ReplayStatsTimeline, ReplayStatsTimelineEvents, RushEvent,
     ShotEventMetadata, StatsTimelineCollector, StatsTimelineEventCollector, SubtrActorError,
     SubtrActorErrorVariant, SubtrActorResult, TimelineEvent, TimelineEventKind, TouchEvent,
-    TouchStateCalculator, WhiffEvent,
+    TouchStateCalculator, WhiffEvent, boost_amount_to_percent, builtin_analysis_node_json,
+    builtin_stats_graph_snapshot_json, builtin_stats_module_config_json,
+    builtin_stats_module_frame_json, builtin_stats_module_json, builtin_stats_module_names,
+    car_hitbox_for_body_id, default_car_hitbox, default_stats_timeline_config,
+    geometry::apply_velocities_to_rigid_body,
+    hitbox_family_for_body_id,
+    stats::analysis_graph::{
+        AnalysisGraph, StatsTimelineEventsState, StatsTimelineFrameState,
+        builtin_analysis_node_aliases, builtin_analysis_node_names, graph_with_all_analysis_nodes,
+    },
 };
 #[cfg(test)]
 use subtr_actor::{GoalTag, GoalTagMetadata};

--- a/bakkesmod/rust/src/lib_tests/header_config.rs
+++ b/bakkesmod/rust/src/lib_tests/header_config.rs
@@ -864,7 +864,7 @@ fn checked_in_header_matches_event_abi_struct_field_types() {
 }
 
 macro_rules! assert_layout {
-    ($ty:ty, size = $size:expr, align = $align:expr) => {
+    ($ty:ty, size = $size:expr_2021, align = $align:expr_2021) => {
         assert_eq!(
             std::mem::size_of::<$ty>(),
             $size,
@@ -881,7 +881,7 @@ macro_rules! assert_layout {
 }
 
 macro_rules! assert_offset {
-    ($ty:ty, $field:tt, $offset:expr) => {
+    ($ty:ty, $field:tt, $offset:expr_2021) => {
         assert_eq!(
             std::mem::offset_of!($ty, $field),
             $offset,

--- a/bakkesmod/rust/src/live_processor.rs
+++ b/bakkesmod/rust/src/live_processor.rs
@@ -66,25 +66,32 @@ impl<'a> SaLiveProcessorView<'a> {
 }
 
 pub(crate) unsafe fn checked_slice<'a, T>(items: *const T, count: usize) -> Result<&'a [T], ()> {
-    if items.is_null() && count != 0 {
-        return Err(());
-    }
-    if count == 0 {
-        Ok(&[])
-    } else {
-        Ok(slice::from_raw_parts(items, count))
+    unsafe {
+        if items.is_null() && count != 0 {
+            return Err(());
+        }
+        if count == 0 {
+            Ok(&[])
+        } else {
+            Ok(slice::from_raw_parts(items, count))
+        }
     }
 }
 
 pub(crate) unsafe fn frame_event_slices(frame: &SaLiveFrame) -> Result<SaFrameEventSlices<'_>, ()> {
-    Ok(SaFrameEventSlices {
-        touches: checked_slice(frame.touches, frame.touch_count)?,
-        dodge_refreshes: checked_slice(frame.dodge_refreshes, frame.dodge_refresh_count)?,
-        boost_pad_events: checked_slice(frame.boost_pad_events, frame.boost_pad_event_count)?,
-        goals: checked_slice(frame.goals, frame.goal_count)?,
-        player_stat_events: checked_slice(frame.player_stat_events, frame.player_stat_event_count)?,
-        demolishes: checked_slice(frame.demolishes, frame.demolish_count)?,
-    })
+    unsafe {
+        Ok(SaFrameEventSlices {
+            touches: checked_slice(frame.touches, frame.touch_count)?,
+            dodge_refreshes: checked_slice(frame.dodge_refreshes, frame.dodge_refresh_count)?,
+            boost_pad_events: checked_slice(frame.boost_pad_events, frame.boost_pad_event_count)?,
+            goals: checked_slice(frame.goals, frame.goal_count)?,
+            player_stat_events: checked_slice(
+                frame.player_stat_events,
+                frame.player_stat_event_count,
+            )?,
+            demolishes: checked_slice(frame.demolishes, frame.demolish_count)?,
+        })
+    }
 }
 
 impl ProcessorView for SaLiveProcessorView<'_> {

--- a/crates/subtr-actor-tools/Cargo.toml
+++ b/crates/subtr-actor-tools/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 description = "Ad-hoc diagnostics and Ballchasing comparison tooling for subtr-actor development"
 

--- a/crates/subtr-actor-tools/src/ballchasing/compare.rs
+++ b/crates/subtr-actor-tools/src/ballchasing/compare.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::comparison::{
-    build_actual_comparable_stats, build_expected_comparable_stats, compute_comparable_stats,
-    MatchConfig, StatMatcher,
+    MatchConfig, StatMatcher, build_actual_comparable_stats, build_expected_comparable_stats,
+    compute_comparable_stats,
 };
 use super::report::BallchasingComparisonReport;
 use subtr_actor::*;

--- a/crates/subtr-actor-tools/src/ballchasing/comparison/conversion_test.rs
+++ b/crates/subtr-actor-tools/src/ballchasing/comparison/conversion_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_actual_comparable_stats, collect_final_replay_meta, compute_comparable_stats,
-    raw_boost_amount_as_comparable_units, ComputedComparableStats,
+    ComputedComparableStats, build_actual_comparable_stats, collect_final_replay_meta,
+    compute_comparable_stats, raw_boost_amount_as_comparable_units,
 };
 use subtr_actor::*;
 

--- a/crates/subtr-actor-tools/src/ballchasing/comparison/mod.rs
+++ b/crates/subtr-actor-tools/src/ballchasing/comparison/mod.rs
@@ -4,7 +4,7 @@ mod conversion;
 mod model;
 
 pub(crate) use config::StatMatcher;
-pub use config::{recommended_match_config, MatchConfig};
+pub use config::{MatchConfig, recommended_match_config};
 pub(crate) use conversion::{
     build_actual_comparable_stats, build_expected_comparable_stats, compute_comparable_stats,
 };

--- a/crates/subtr-actor-tools/src/ballchasing/mod.rs
+++ b/crates/subtr-actor-tools/src/ballchasing/mod.rs
@@ -3,12 +3,11 @@ mod comparison;
 mod report;
 
 pub use compare::{
-    compare_fixture_directory, compare_replay_against_ballchasing,
-    compare_replay_against_ballchasing_json,
+    BallchasingComparableStats, BallchasingComparisonBreakdown, compare_fixture_directory,
+    compare_replay_against_ballchasing, compare_replay_against_ballchasing_json,
     compare_replay_against_ballchasing_json_with_breakdown,
     compare_replay_against_ballchasing_with_breakdown, parse_replay_bytes, parse_replay_file,
-    BallchasingComparableStats, BallchasingComparisonBreakdown,
 };
 pub use comparison::recommended_match_config as recommended_ballchasing_match_config;
-pub use comparison::{recommended_match_config, MatchConfig};
+pub use comparison::{MatchConfig, recommended_match_config};
 pub use report::BallchasingComparisonReport;

--- a/crates/subtr-actor-tools/src/bin/analysis_graph.rs
+++ b/crates/subtr-actor-tools/src/bin/analysis_graph.rs
@@ -2,7 +2,8 @@ use subtr_actor::build_legacy_timeline_graph;
 
 fn main() {
     let mut graph = build_legacy_timeline_graph();
-    match graph.render_ascii_dag() {
+    let rendered = graph.render_ascii_dag();
+    match rendered {
         Ok(rendered) => println!("{rendered}"),
         Err(error) => {
             eprintln!("{error:?}");

--- a/crates/subtr-actor-tools/src/bin/analyze_touch_gaps.rs
+++ b/crates/subtr-actor-tools/src/bin/analyze_touch_gaps.rs
@@ -3,8 +3,9 @@ use clap::Parser;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use subtr_actor::{
+    Collector, PlayerId, ProcessorView, TimeAdvance, TouchCandidateScoring,
     ball_trajectory_deviation_with_gravity, touch_candidate_contact_gap_rank_with_hitbox,
-    vec_to_glam, Collector, PlayerId, ProcessorView, TimeAdvance, TouchCandidateScoring,
+    vec_to_glam,
 };
 
 const FIELD_HALF_WIDTH: f32 = 4096.0;
@@ -672,14 +673,20 @@ fn print_high_confidence_impulse_summary(
         println!(
             "{:>7.2}uu vel_dev={:>7.2} impulse_frame={:<6} best_frame={:<6} time={:>8.3} ball=({:>7.1},{:>7.1},{:>6.1}) player={} replay={}",
             sample.window_best_gap.unwrap_or_default(),
-            sample.sample.trajectory_velocity_deviation.unwrap_or_default(),
+            sample
+                .sample
+                .trajectory_velocity_deviation
+                .unwrap_or_default(),
             sample.sample.frame,
             sample.window_best_frame,
             sample.sample.time,
             sample.sample.ball_position.x,
             sample.sample.ball_position.y,
             sample.sample.ball_position.z,
-            sample.window_best_player_name.as_deref().unwrap_or("<unknown>"),
+            sample
+                .window_best_player_name
+                .as_deref()
+                .unwrap_or("<unknown>"),
             sample.window_best_replay,
         );
     }

--- a/crates/subtr-actor-tools/src/bin/ballchasing_compare.rs
+++ b/crates/subtr-actor-tools/src/bin/ballchasing_compare.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use clap::Parser;
 use reqwest::blocking::Client;
 use serde_json::Value;

--- a/crates/subtr-actor-tools/src/bin/boost_pickup_discrepancies.rs
+++ b/crates/subtr-actor-tools/src/bin/boost_pickup_discrepancies.rs
@@ -2,13 +2,13 @@ use std::collections::HashMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use clap::Parser;
 use serde::Serialize;
 use subtr_actor::{
-    stats::analysis_graph::collect_builtin_analysis_graph_for_replay, BoostCalculator,
-    BoostPickupActivity, BoostPickupDetection, BoostPickupEvent, BoostPickupFieldHalf,
-    BoostPickupPadType, PlayerId, ReplayProcessor,
+    BoostCalculator, BoostPickupActivity, BoostPickupDetection, BoostPickupEvent,
+    BoostPickupFieldHalf, BoostPickupPadType, PlayerId, ReplayProcessor,
+    stats::analysis_graph::collect_builtin_analysis_graph_for_replay,
 };
 
 #[derive(Default, Serialize)]

--- a/crates/subtr-actor-tools/src/bin/build_mechanic_review_playlist.rs
+++ b/crates/subtr-actor-tools/src/bin/build_mechanic_review_playlist.rs
@@ -2,23 +2,23 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{Context, anyhow, bail};
 use clap::Parser;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 mod build_mechanic_review_playlist_candidates;
 use build_mechanic_review_playlist_candidates::extract_candidates;
 use subtr_actor::{
+    Collector, GoalEvent, PlayerId, PlayerInfo, ProcessorView, ReplayMeta, ReplayProcessor,
+    SubtrActorResult, TimeAdvance,
     interop::player::{
         PlaybackBound, PlaybackBoundKind, PlaylistAdvanceMode, PlaylistEndMode, PlaylistManifest,
         PlaylistManifestItem, PlaylistManifestReplay, PlaylistManifestReplayLocator,
         PlaylistPlaybackOptions,
     },
     stats::analysis_graph::collect_builtin_analysis_graph_for_replay,
-    Collector, GoalEvent, PlayerId, PlayerInfo, ProcessorView, ReplayMeta, ReplayProcessor,
-    SubtrActorResult, TimeAdvance,
 };
 
 const BALLCHASING_API_BASE_URL: &str = "https://ballchasing.com/api";
@@ -597,11 +597,13 @@ fn resolve_mechanics(config: &Config) -> anyhow::Result<Vec<&'static str>> {
         let names: Vec<&str> = match normalized.as_str() {
             "default" => DEFAULT_MECHANICS.to_vec(),
             "all" => ALL_MECHANICS.to_vec(),
-            name if ALL_MECHANICS.contains(&name) => vec![ALL_MECHANICS
-                .iter()
-                .copied()
-                .find(|candidate| *candidate == name)
-                .expect("mechanic is known")],
+            name if ALL_MECHANICS.contains(&name) => vec![
+                ALL_MECHANICS
+                    .iter()
+                    .copied()
+                    .find(|candidate| *candidate == name)
+                    .expect("mechanic is known"),
+            ],
             other => bail!(
                 "unknown mechanic {other}; supported mechanics are: {}, default, all",
                 ALL_MECHANICS.join(", ")
@@ -646,11 +648,7 @@ fn confidence_pct(confidence: f32) -> u32 {
 }
 
 fn player_team_label(is_team_0: bool) -> &'static str {
-    if is_team_0 {
-        "blue"
-    } else {
-        "orange"
-    }
+    if is_team_0 { "blue" } else { "orange" }
 }
 
 fn followup_goal_for_candidate<'a>(

--- a/crates/subtr-actor-tools/src/bin/build_mechanic_review_playlist_candidates/mod.rs
+++ b/crates/subtr-actor-tools/src/bin/build_mechanic_review_playlist_candidates/mod.rs
@@ -1,12 +1,12 @@
 use anyhow::anyhow;
 use subtr_actor::{
-    stats::analysis_graph::AnalysisGraph, BallCarryCalculator, BallCarryKind,
-    CeilingShotCalculator, Collector, DodgeResetCalculator, DoubleTapCalculator, FlickCalculator,
-    FlipResetTracker, HalfFlipCalculator, MustyFlickCalculator, OneTimerCalculator,
-    SpeedFlipCalculator, WavedashCalculator,
+    BallCarryCalculator, BallCarryKind, CeilingShotCalculator, Collector, DodgeResetCalculator,
+    DoubleTapCalculator, FlickCalculator, FlipResetTracker, HalfFlipCalculator,
+    MustyFlickCalculator, OneTimerCalculator, SpeedFlipCalculator, WavedashCalculator,
+    stats::analysis_graph::AnalysisGraph,
 };
 
-use super::{event_json, player_id_string, Config, MechanicCandidate};
+use super::{Config, MechanicCandidate, event_json, player_id_string};
 
 fn confidence_pct(confidence: f32) -> u32 {
     (confidence * 100.0).round().clamp(0.0, 100.0) as u32

--- a/crates/subtr-actor-tools/src/bin/generate_event_docs.rs
+++ b/crates/subtr-actor-tools/src/bin/generate_event_docs.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use clap::Parser;
 use subtr_actor::{
-    event_producers, DetectionConfidence, EmittedEvent, EventDefinition, EventProducerDefinition,
-    GoalTagDefinition, KnownIssueRef, ProducerDefinition, ALL_GOAL_TAG_DEFINITIONS,
+    ALL_GOAL_TAG_DEFINITIONS, DetectionConfidence, EmittedEvent, EventDefinition,
+    EventProducerDefinition, GoalTagDefinition, KnownIssueRef, ProducerDefinition, event_producers,
 };
 
 #[derive(Debug, Parser)]

--- a/crates/subtr-actor-tools/src/bin/kickoff_timing_dump.rs
+++ b/crates/subtr-actor-tools/src/bin/kickoff_timing_dump.rs
@@ -20,7 +20,8 @@ fn main() -> anyhow::Result<()> {
     // TSV header
     println!("replay\ttaker\ttaker_id\tspawn\tapproach\ttime_to_ball\toutcome");
     for path in paths {
-        if let Err(error) = dump_replay(&path) {
+        let dumped = dump_replay(&path);
+        if let Err(error) = dumped {
             eprintln!("skip {path}: {error:?}");
         }
     }

--- a/crates/subtr-actor-tools/src/bin/kickoff_touch_audit.rs
+++ b/crates/subtr-actor-tools/src/bin/kickoff_touch_audit.rs
@@ -9,9 +9,9 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::path::{Path, PathBuf};
 use subtr_actor::{
+    Collector, EventPayload, PlayerId, ProcessorView, StatsTimelineCollector, TimeAdvance,
     ball_trajectory_deviation_with_gravity, touch_candidate_contact_gap_rank_with_hitbox,
-    vec_to_glam, Collector, EventPayload, PlayerId, ProcessorView, StatsTimelineCollector,
-    TimeAdvance,
+    vec_to_glam,
 };
 
 #[derive(Debug, Parser)]
@@ -320,7 +320,8 @@ fn main() -> Result<()> {
             .to_owned();
         match parse_replay(path) {
             Ok(replay) => {
-                if let Err(e) = audit(&label, &args, &replay) {
+                let audited = audit(&label, &args, &replay);
+                if let Err(e) = audited {
                     eprintln!("error {label}: {e:?}");
                 }
             }

--- a/crates/subtr-actor-tools/src/bin/kickoff_win_strength_dump.rs
+++ b/crates/subtr-actor-tools/src/bin/kickoff_win_strength_dump.rs
@@ -19,8 +19,8 @@ fn main() -> anyhow::Result<()> {
     // TSV header
     println!("replay\tstart_time\toutcome\twin_strength\tband\texit_speed\texit_y_velocity");
     for path in &paths {
-        if let Err(error) = dump_replay(path, &mut strengths, &mut band_counts, &mut outcome_counts)
-        {
+        let dumped = dump_replay(path, &mut strengths, &mut band_counts, &mut outcome_counts);
+        if let Err(error) = dumped {
             eprintln!("skip {path}: {error:?}");
         }
     }

--- a/crates/subtr-actor-tools/src/bin/visualize_boost_pads.rs
+++ b/crates/subtr-actor-tools/src/bin/visualize_boost_pads.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use clap::Parser;
-use subtr_actor::{standard_soccar_boost_pad_layout, BoostPadSize};
+use subtr_actor::{BoostPadSize, standard_soccar_boost_pad_layout};
 
 const FIELD_HALF_WIDTH: f32 = 4096.0;
 const FIELD_HALF_LENGTH: f32 = 5120.0;

--- a/crates/subtr-actor-tools/tests/ballchasing_template_test.rs
+++ b/crates/subtr-actor-tools/tests/ballchasing_template_test.rs
@@ -4,10 +4,10 @@ use std::collections::{HashMap, HashSet};
 
 use serde_json::Value;
 use subtr_actor::{
-    boost_amount_to_percent, standard_soccar_boost_pad_layout, stats, BoostPadEventKind,
-    BoostPadSize, BoostStatsAccumulator, Collector, FrameInput, LivePlayTracker, PlayerId,
-    PlayerInfo, ProcessorView, ReplayProcessor, StatsTimelineCollector, TimeAdvance,
-    BOOST_KICKOFF_START_AMOUNT,
+    BOOST_KICKOFF_START_AMOUNT, BoostPadEventKind, BoostPadSize, BoostStatsAccumulator, Collector,
+    FrameInput, LivePlayTracker, PlayerId, PlayerInfo, ProcessorView, ReplayProcessor,
+    StatsTimelineCollector, TimeAdvance, boost_amount_to_percent, standard_soccar_boost_pad_layout,
+    stats,
 };
 
 macro_rules! ballchasing_fixture_test {

--- a/crates/subtr-actor-tools/tests/replay_plausibility_test.rs
+++ b/crates/subtr-actor-tools/tests/replay_plausibility_test.rs
@@ -1,7 +1,7 @@
 use glam::{Quat, Vec3};
-use subtr_actor::{quat_to_glam, vec_to_glam, PlayerFrame, ReplayDataCollector};
+use subtr_actor::{PlayerFrame, ReplayDataCollector, quat_to_glam, vec_to_glam};
 use subtr_actor_tools::replay_plausibility::{
-    evaluate_replay_plausibility, ReplayPlausibilityReport,
+    ReplayPlausibilityReport, evaluate_replay_plausibility,
 };
 
 const MIN_ANGULAR_VELOCITY_SPEED: f32 = 30.0;

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rl-replay-subtr-actor"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "WebAssembly bindings for subtr-actor - Rocket League replay processing and analysis"

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -2,10 +2,10 @@
 
 use js_sys::{Array, Function, Object, Reflect, Uint8Array};
 use subtr_actor::{
-    collector::replay_data::{ReplayData, ReplayDataCollector},
-    collector::CallbackCollector,
     Collector, FrameRateDecorator, NDArrayCollector, ReplayProcessor, StatsCollector,
     StatsTimelineEventCollector, SubtrActorError, SubtrActorErrorVariant, SubtrActorResult,
+    collector::CallbackCollector,
+    collector::replay_data::{ReplayData, ReplayDataCollector},
 };
 use wasm_bindgen::prelude::*;
 

--- a/js/stat-evaluation-player/src/generated/KickoffTakerEvent.ts
+++ b/js/stat-evaluation-player/src/generated/KickoffTakerEvent.ts
@@ -5,4 +5,12 @@ import type { KickoffSpawnPosition } from "./KickoffSpawnPosition.ts";
 import type { KickoffTakerOutcome } from "./KickoffTakerOutcome.ts";
 import type { RemoteIdTs } from "./RemoteIdTs.ts";
 
-export type KickoffTakerEvent = { player: RemoteIdTs, is_team_0: boolean, start_position: [number, number, number], spawn_position: KickoffSpawnPosition, start_boost: number | null, boost_after: number | null, time_to_ball: number | null, boost_collected: number, boost_used: number, ball_direction: KickoffBallDirection, first_touch_time: number | null, first_touch_frame: number | null, outcome: KickoffTakerOutcome, approach: KickoffApproach, };
+export type KickoffTakerEvent = { player: RemoteIdTs, is_team_0: boolean, start_position: [number, number, number], spawn_position: KickoffSpawnPosition, start_boost: number | null,
+/**
+ * Boost remaining at the moment the taker contacts the ball (the
+ * counterpart to `boost_used`, which is spent reaching that contact).
+ * For takers that never touch the ball (fake / missed) this falls back to
+ * the end-of-kickoff sample. Invariant when the taker touches:
+ * `start_boost + boost_collected == boost_used + boost_after`.
+ */
+boost_after: number | null, time_to_ball: number | null, boost_collected: number, boost_used: number, ball_direction: KickoffBallDirection, first_touch_time: number | null, first_touch_frame: number | null, outcome: KickoffTakerOutcome, approach: KickoffApproach, };

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -3,6 +3,7 @@ name = "subtr-actor-py"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 boxcars.workspace = true

--- a/src/collector/ndarray/analysis_builtins.rs
+++ b/src/collector/ndarray/analysis_builtins.rs
@@ -9,8 +9,8 @@ macro_rules! build_analysis_player_event_indicator {
         $dependency:ident,
         $calculator:ty,
         $events:ident,
-        $player_matches:expr,
-        $column_name:expr $(,)?
+        $player_matches:expr_2021,
+        $column_name:expr_2021 $(,)?
     ) => {
         build_analysis_player_feature_adder!(
             $struct_name,

--- a/src/collector/ndarray/builtins.rs
+++ b/src/collector/ndarray/builtins.rs
@@ -155,14 +155,18 @@ fn default_rb_state_quaternion<F: TryFrom<f32>>() -> RigidBodyQuaternionArrayRes
 where
     <F as TryFrom<f32>>::Error: std::fmt::Debug,
 {
-    convert_all_floats!(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,)
+    convert_all_floats!(
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    )
 }
 
 fn default_rb_state_basis<F: TryFrom<f32>>() -> RigidBodyBasisArrayResult<F>
 where
     <F as TryFrom<f32>>::Error: std::fmt::Debug,
 {
-    convert_all_floats!(0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,)
+    convert_all_floats!(
+        0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    )
 }
 
 fn default_rb_state_no_velocities<F: TryFrom<f32>>() -> SubtrActorResult<[F; 7]>
@@ -197,9 +201,11 @@ build_global_feature_adder!(
 build_global_feature_adder!(
     ReplicatedGameStateTimeRemaining,
     |_, processor: &dyn ProcessorView, _frame, _index, _current_time| {
-        convert_all_floats!(processor
-            .get_replicated_game_state_time_remaining()
-            .unwrap_or(0) as f32)
+        convert_all_floats!(
+            processor
+                .get_replicated_game_state_time_remaining()
+                .unwrap_or(0) as f32
+        )
     },
     "kickoff countdown"
 );
@@ -318,7 +324,8 @@ global_feature_adder!(
 build_player_feature_adder!(
     PlayerRigidBody,
     |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
-        if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
+        let rigid_body = processor.get_normalized_player_rigid_body(player_id);
+        if let Ok(rb) = rigid_body {
             get_rigid_body_properties(&rb)
         } else {
             default_rb_state()
@@ -341,7 +348,8 @@ build_player_feature_adder!(
 build_player_feature_adder!(
     PlayerRigidBodyNoVelocities,
     |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
-        if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
+        let rigid_body = processor.get_normalized_player_rigid_body(player_id);
+        if let Ok(rb) = rigid_body {
             get_rigid_body_properties_no_velocities(&rb)
         } else {
             default_rb_state_no_velocities()
@@ -359,7 +367,8 @@ build_player_feature_adder!(
 build_player_feature_adder!(
     VelocityAddedPlayerRigidBodyNoVelocities,
     |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, current_time: f32| {
-        if let Ok(rb) = processor.get_velocity_applied_player_rigid_body(player_id, current_time) {
+        let rigid_body = processor.get_velocity_applied_player_rigid_body(player_id, current_time);
+        if let Ok(rb) = rigid_body {
             get_rigid_body_properties_no_velocities(&rb)
         } else {
             default_rb_state_no_velocities()
@@ -664,7 +673,8 @@ build_player_feature_adder!(
 build_player_feature_adder!(
     PlayerRigidBodyQuaternions,
     |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
-        if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
+        let rigid_body = processor.get_normalized_player_rigid_body(player_id);
+        if let Ok(rb) = rigid_body {
             let rotation = rb.rotation;
             let location = rb.location;
             convert_all_floats!(
@@ -686,7 +696,8 @@ build_player_feature_adder!(
 build_player_feature_adder!(
     PlayerRigidBodyQuaternionVelocities,
     |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
-        if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
+        let rigid_body = processor.get_normalized_player_rigid_body(player_id);
+        if let Ok(rb) = rigid_body {
             get_rigid_body_properties_quaternion(&rb)
         } else {
             default_rb_state_quaternion()
@@ -710,7 +721,8 @@ build_player_feature_adder!(
 build_player_feature_adder!(
     PlayerRigidBodyBasis,
     |_, player_id: &PlayerId, processor: &dyn ProcessorView, _frame, _index, _current_time: f32| {
-        if let Ok(rb) = processor.get_normalized_player_rigid_body(player_id) {
+        let rigid_body = processor.get_normalized_player_rigid_body(player_id);
+        if let Ok(rb) = rigid_body {
             get_rigid_body_properties_basis(&rb)
         } else {
             default_rb_state_basis()

--- a/src/collector/ndarray/traits.rs
+++ b/src/collector/ndarray/traits.rs
@@ -658,7 +658,7 @@ where
 /// Declares a new global feature-adder type and wires it into the ndarray traits.
 #[macro_export]
 macro_rules! build_global_feature_adder {
-    ($struct_name:ident, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+    ($struct_name:ident, $prop_getter:expr_2021, $( $column_names:expr_2021 ),* $(,)?) => {
 
         #[derive(derive_new::new)]
         pub struct $struct_name<F> {
@@ -684,7 +684,7 @@ macro_rules! build_global_feature_adder {
 /// Implements the ndarray feature-adder traits for an existing global feature type.
 #[macro_export]
 macro_rules! global_feature_adder {
-    ($struct_name:ident, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+    ($struct_name:ident, $prop_getter:expr_2021, $( $column_names:expr_2021 ),* $(,)?) => {
         macro_rules! _global_feature_adder {
             ($count:ident) => {
                 impl<F: TryFrom<f32>> LengthCheckedFeatureAdder<F, $count> for $struct_name<F>
@@ -719,7 +719,7 @@ macro_rules! global_feature_adder {
 /// Declares a new analysis-backed global feature-adder type.
 #[macro_export]
 macro_rules! build_analysis_global_feature_adder {
-    ($struct_name:ident, $dependency_getter:expr, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+    ($struct_name:ident, $dependency_getter:expr_2021, $prop_getter:expr_2021, $( $column_names:expr_2021 ),* $(,)?) => {
 
         #[derive(derive_new::new)]
         pub struct $struct_name<F> {
@@ -746,7 +746,7 @@ macro_rules! build_analysis_global_feature_adder {
 /// Implements the ndarray traits for an existing analysis-backed global feature type.
 #[macro_export]
 macro_rules! analysis_global_feature_adder {
-    ($struct_name:ident, $dependency_getter:expr, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+    ($struct_name:ident, $dependency_getter:expr_2021, $prop_getter:expr_2021, $( $column_names:expr_2021 ),* $(,)?) => {
         macro_rules! _analysis_global_feature_adder {
             ($count:ident) => {
                 impl<F: TryFrom<f32>> LengthCheckedAnalysisFeatureAdder<F, $count> for $struct_name<F>
@@ -786,7 +786,7 @@ macro_rules! analysis_global_feature_adder {
 /// Declares a new per-player feature-adder type and wires it into the ndarray traits.
 #[macro_export]
 macro_rules! build_player_feature_adder {
-    ($struct_name:ident, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+    ($struct_name:ident, $prop_getter:expr_2021, $( $column_names:expr_2021 ),* $(,)?) => {
         #[derive(derive_new::new)]
         pub struct $struct_name<F> {
             _zero: std::marker::PhantomData<F>,
@@ -811,7 +811,7 @@ macro_rules! build_player_feature_adder {
 /// Implements the ndarray feature-adder traits for an existing per-player feature type.
 #[macro_export]
 macro_rules! player_feature_adder {
-    ($struct_name:ident, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+    ($struct_name:ident, $prop_getter:expr_2021, $( $column_names:expr_2021 ),* $(,)?) => {
         macro_rules! _player_feature_adder {
             ($count:ident) => {
                 impl<F: TryFrom<f32>> LengthCheckedPlayerFeatureAdder<F, $count> for $struct_name<F>
@@ -847,7 +847,7 @@ macro_rules! player_feature_adder {
 /// Declares a new analysis-backed per-player feature-adder type.
 #[macro_export]
 macro_rules! build_analysis_player_feature_adder {
-    ($struct_name:ident, $dependency_getter:expr, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+    ($struct_name:ident, $dependency_getter:expr_2021, $prop_getter:expr_2021, $( $column_names:expr_2021 ),* $(,)?) => {
         #[derive(derive_new::new)]
         pub struct $struct_name<F> {
             _zero: std::marker::PhantomData<F>,
@@ -873,7 +873,7 @@ macro_rules! build_analysis_player_feature_adder {
 /// Implements the ndarray traits for an existing analysis-backed per-player feature type.
 #[macro_export]
 macro_rules! analysis_player_feature_adder {
-    ($struct_name:ident, $dependency_getter:expr, $prop_getter:expr, $( $column_names:expr ),* $(,)?) => {
+    ($struct_name:ident, $dependency_getter:expr_2021, $prop_getter:expr_2021, $( $column_names:expr_2021 ),* $(,)?) => {
         macro_rules! _analysis_player_feature_adder {
             ($count:ident) => {
                 impl<F: TryFrom<f32>> LengthCheckedAnalysisPlayerFeatureAdder<F, $count> for $struct_name<F>
@@ -919,7 +919,7 @@ pub fn convert_float_conversion_error<T>(_: T) -> SubtrActorError {
 /// Converts a fixed list of values with a caller-supplied error mapper.
 #[macro_export]
 macro_rules! convert_all {
-    ($err:expr, $( $item:expr ),* $(,)?) => {{
+    ($err:expr_2021, $( $item:expr_2021 ),* $(,)?) => {{
 		Ok([
 			$( $item.try_into().map_err($err)? ),*
 		])
@@ -929,7 +929,7 @@ macro_rules! convert_all {
 /// Converts a fixed list of float-like values using [`convert_float_conversion_error`].
 #[macro_export]
 macro_rules! convert_all_floats {
-    ($( $item:expr ),* $(,)?) => {{
+    ($( $item:expr_2021 ),* $(,)?) => {{
         convert_all!(convert_float_conversion_error, $( $item ),*)
     }};
 }

--- a/src/collector/replay_data.rs
+++ b/src/collector/replay_data.rs
@@ -85,11 +85,11 @@ impl BallFrame {
     fn new_from_processor(processor: &dyn ProcessorView, current_time: f32) -> Self {
         if processor.get_ignore_ball_syncing().unwrap_or(false) {
             Self::Empty
-        } else if let Ok(rigid_body) = processor.get_interpolated_ball_rigid_body(current_time, 0.0)
-        {
-            Self::new_from_rigid_body(rigid_body)
         } else {
-            Self::Empty
+            match processor.get_interpolated_ball_rigid_body(current_time, 0.0) {
+                Ok(rigid_body) => Self::new_from_rigid_body(rigid_body),
+                _ => Self::Empty,
+            }
         }
     }
 

--- a/src/collector/stats/builtins.rs
+++ b/src/collector/stats/builtins.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use serde::Serialize;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::stats::analysis_graph::{
-    builtin_analysis_node_names, AnalysisGraph, StatsProjectionState, StatsTimelineEventsState,
-    StatsTimelineFrameState,
+    AnalysisGraph, StatsProjectionState, StatsTimelineEventsState, StatsTimelineFrameState,
+    builtin_analysis_node_names,
 };
 use crate::*;
 use boxcars::{Quaternion, RigidBody, Vector3f};
@@ -1533,7 +1533,7 @@ pub(crate) fn builtin_snapshot_frame_json(
         _ => {
             return SubtrActorError::new_result(SubtrActorErrorVariant::UnknownStatsModuleName(
                 module_name.to_owned(),
-            ))
+            ));
         }
     };
     Ok(Some(value))
@@ -1729,7 +1729,7 @@ pub(crate) fn builtin_snapshot_config_json(
         _ => {
             return SubtrActorError::new_result(SubtrActorErrorVariant::UnknownStatsModuleName(
                 module_name.to_owned(),
-            ))
+            ));
         }
     };
     Ok(value)

--- a/src/collector/stats/collector.rs
+++ b/src/collector/stats/collector.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value};
 use crate::collector::frame_resolution::{
     FinalStatsFrameAction, StatsFramePersistenceController, StatsFrameResolution,
 };
-use crate::stats::analysis_graph::{graph_with_builtin_analysis_nodes, AnalysisGraph};
+use crate::stats::analysis_graph::{AnalysisGraph, graph_with_builtin_analysis_nodes};
 use crate::stats::calculators::ReplayFrameInputBuilder;
 use crate::*;
 
@@ -17,7 +17,7 @@ use super::builtins::{
 use super::playback::{
     CapturedStatsData, CapturedStatsFrame, StatsSnapshotData, StatsSnapshotFrame,
 };
-use super::types::{serialize_to_json_value, CollectedStats, CollectedStatsModule};
+use super::types::{CollectedStats, CollectedStatsModule, serialize_to_json_value};
 
 #[derive(Default)]
 enum SampleMode {

--- a/src/collector/stats/mod.rs
+++ b/src/collector/stats/mod.rs
@@ -8,8 +8,8 @@ pub use builtins::{
     builtin_stats_module_frame_json, builtin_stats_module_json, builtin_stats_module_names,
 };
 pub use collector::{
-    builtin_stats_graph_snapshot_json, FrameTransform, IdentityFrameTransform,
-    ModuleFrameTransform, StatsCollector,
+    FrameTransform, IdentityFrameTransform, ModuleFrameTransform, StatsCollector,
+    builtin_stats_graph_snapshot_json,
 };
 pub use playback::{CapturedStatsData, CapturedStatsFrame, StatsSnapshotData, StatsSnapshotFrame};
 pub use types::CollectedStats;

--- a/src/collector/stats/playback.rs
+++ b/src/collector/stats/playback.rs
@@ -1,5 +1,5 @@
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
 
 use crate::*;

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -15,7 +15,9 @@ pub enum SubtrActorErrorVariant {
     #[error("Frame index out of bounds")]
     FrameIndexOutOfBounds,
 
-    #[error("Players found in frames that were not part of original set. Found: {found:?}, Original: {original:?}")]
+    #[error(
+        "Players found in frames that were not part of original set. Found: {found:?}, Original: {original:?}"
+    )]
     InconsistentPlayerSet {
         found: std::collections::HashSet<PlayerId>,
         original: std::collections::HashSet<PlayerId>,
@@ -33,7 +35,9 @@ pub enum SubtrActorErrorVariant {
     #[error("No boost amount value.")]
     NoBoostAmountValue,
 
-    #[error("The attribute value that was found was not of the expected type {expected_type} {actual_type:?}")]
+    #[error(
+        "The attribute value that was found was not of the expected type {expected_type} {actual_type:?}"
+    )]
     UnexpectedAttributeType {
         expected_type: &'static str,
         actual_type: &'static str,

--- a/src/processor/debug.rs
+++ b/src/processor/debug.rs
@@ -38,10 +38,11 @@ impl<'a> ReplayProcessor<'a> {
 
     /// Returns a formatted dump of a single actor's current attribute state.
     pub fn actor_state_string(&self, actor_id: &boxcars::ActorId) -> String {
-        if let Ok(actor_state) = self.get_actor_state(actor_id) {
-            format!("{:?}", self.map_attribute_keys(&actor_state.attributes))
-        } else {
-            String::from("error")
+        match self.get_actor_state(actor_id) {
+            Ok(actor_state) => {
+                format!("{:?}", self.map_attribute_keys(&actor_state.attributes))
+            }
+            _ => String::from("error"),
         }
     }
 

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn attribute_type_name(attribute: &boxcars::Attribute) -> &'static st
 /// the actual type.
 #[macro_export]
 macro_rules! attribute_match {
-    ($value:expr, $type:path $(,)?) => {{
+    ($value:expr_2021, $type:path $(,)?) => {{
         let attribute = $value;
         if let $type(value) = attribute {
             Ok(value)
@@ -96,7 +96,7 @@ macro_rules! attribute_match {
 /// * `$type` - The expected enum path.
 #[macro_export]
 macro_rules! get_attribute_errors_expected {
-    ($self:ident, $map:expr, $prop:expr, $type:path) => {
+    ($self:ident, $map:expr_2021, $prop:expr_2021, $type:path) => {
         $self
             .get_attribute($map, $prop)
             .and_then(|found| attribute_match!(found, $type))
@@ -116,7 +116,7 @@ macro_rules! get_attribute_errors_expected {
 /// It returns a [`Result`] with a tuple of the matched attribute and its updated
 /// status, after invoking [`attribute_match!`] on the found attribute.
 macro_rules! get_attribute_and_updated {
-    ($self:ident, $map:expr, $prop:expr, $type:path) => {
+    ($self:ident, $map:expr_2021, $prop:expr_2021, $type:path) => {
         $self
             .get_attribute_and_updated($map, $prop)
             .and_then(|(found, updated)| attribute_match!(found, $type).map(|v| (v, updated)))
@@ -132,7 +132,7 @@ macro_rules! get_attribute_and_updated {
 /// * `$prop` - The attribute key.
 /// * `$type` - The expected enum path.
 macro_rules! get_actor_attribute_matching {
-    ($self:ident, $actor:expr, $prop:expr, $type:path) => {
+    ($self:ident, $actor:expr_2021, $prop:expr_2021, $type:path) => {
         $self
             .get_actor_attribute($actor, $prop)
             .and_then(|found| attribute_match!(found, $type))
@@ -148,7 +148,7 @@ macro_rules! get_actor_attribute_matching {
 /// * `$key` - The attribute key.
 /// * `$type` - The expected enum path.
 macro_rules! get_derived_attribute {
-    ($map:expr, $key:expr, $type:path) => {
+    ($map:expr_2021, $key:expr_2021, $type:path) => {
         $map.get($key)
             .ok_or_else(|| {
                 SubtrActorError::new(SubtrActorErrorVariant::DerivedKeyValueNotFound {

--- a/src/processor/updaters/demolishes.rs
+++ b/src/processor/updaters/demolishes.rs
@@ -49,14 +49,17 @@ impl<'a> ReplayProcessor<'a> {
             return;
         }
         self.known_demolishes.push((demolish.clone(), frame_index));
-        if let Ok(info) = self.build_demolish_info(demolish, frame, frame_index) {
-            self.demolishes.push(info);
-        } else {
-            log::warn!(
-                "Error building demolish info: attacker_car={:?}, victim_car={:?}",
-                demolish.attacker_actor_id(),
-                demolish.victim_actor_id(),
-            );
+        match self.build_demolish_info(demolish, frame, frame_index) {
+            Ok(info) => {
+                self.demolishes.push(info);
+            }
+            _ => {
+                log::warn!(
+                    "Error building demolish info: attacker_car={:?}, victim_car={:?}",
+                    demolish.attacker_actor_id(),
+                    demolish.victim_actor_id(),
+                );
+            }
         }
     }
 

--- a/src/processor/updaters/mappings.rs
+++ b/src/processor/updaters/mappings.rs
@@ -113,7 +113,7 @@ impl<'a> ReplayProcessor<'a> {
 
         for update in frame.updated_actors.iter() {
             macro_rules! maintain_link {
-                ($map:expr, $actor_ids:expr, $get_key:expr, $get_value:expr, $type:path $(, skip_value $skip:expr)?) => {{
+                ($map:expr_2021, $actor_ids:expr_2021, $get_key:expr_2021, $get_value:expr_2021, $type:path $(, skip_value $skip:expr_2021)?) => {{
                     if $actor_ids.contains(&update.actor_id) {
                         let value = attribute_match!(&update.attribute, $type)?;
                         let _key = $get_key(update.actor_id, value);
@@ -125,7 +125,7 @@ impl<'a> ReplayProcessor<'a> {
                 }};
             }
             macro_rules! maintain_actor_link {
-                ($map:expr, $actor_ids:expr $(, skip_value $skip:expr)?) => {
+                ($map:expr_2021, $actor_ids:expr_2021 $(, skip_value $skip:expr_2021)?) => {
                     maintain_link!(
                         $map,
                         $actor_ids,
@@ -139,7 +139,7 @@ impl<'a> ReplayProcessor<'a> {
                 };
             }
             macro_rules! maintain_vehicle_key_link {
-                ($map:expr, $actor_ids:expr) => {
+                ($map:expr_2021, $actor_ids:expr_2021) => {
                     maintain_actor_link!($map, $actor_ids)
                 };
             }

--- a/src/stats/accumulators/boost_invariants_tests.rs
+++ b/src/stats/accumulators/boost_invariants_tests.rs
@@ -11,9 +11,11 @@ fn reports_used_split_mismatch() {
 
     let violations = boost_invariant_violations(&stats);
 
-    assert!(violations
-        .iter()
-        .any(|violation| violation.kind == BoostInvariantKind::UsedSplitAmounts));
+    assert!(
+        violations
+            .iter()
+            .any(|violation| violation.kind == BoostInvariantKind::UsedSplitAmounts)
+    );
 }
 
 #[test]
@@ -27,9 +29,11 @@ fn accepts_matching_used_split() {
 
     let violations = boost_invariant_violations(&stats);
 
-    assert!(!violations
-        .iter()
-        .any(|violation| violation.kind == BoostInvariantKind::UsedSplitAmounts));
+    assert!(
+        !violations
+            .iter()
+            .any(|violation| violation.kind == BoostInvariantKind::UsedSplitAmounts)
+    );
 }
 
 #[test]

--- a/src/stats/analysis_graph/graph.rs
+++ b/src/stats/analysis_graph/graph.rs
@@ -1,7 +1,7 @@
-use std::any::{type_name, Any, TypeId};
+use std::any::{Any, TypeId, type_name};
 use std::collections::{HashMap, HashSet};
 
-use crate::stats::calculators::{event_producers, EmittedEvent};
+use crate::stats::calculators::{EmittedEvent, event_producers};
 use crate::*;
 
 #[derive(Clone, Copy)]
@@ -498,35 +498,35 @@ impl AnalysisGraph {
                 .declared_root_states
                 .contains_key(&node.provides_state_type_id())
             {
-                return SubtrActorError::new_result(
-                    SubtrActorErrorVariant::CallbackError(format!(
+                return SubtrActorError::new_result(SubtrActorErrorVariant::CallbackError(
+                    format!(
                         "analysis node graph error: Duplicate providers for root state {}: root and '{}'",
                         node.provides_state_type_name(),
                         node.name(),
-                    )),
-                );
+                    ),
+                ));
             }
             if self
                 .declared_input_states
                 .contains_key(&node.provides_state_type_id())
             {
-                return SubtrActorError::new_result(
-                    SubtrActorErrorVariant::CallbackError(format!(
+                return SubtrActorError::new_result(SubtrActorErrorVariant::CallbackError(
+                    format!(
                         "analysis node graph error: Duplicate providers for input state {}: input and '{}'",
                         node.provides_state_type_name(),
                         node.name(),
-                    )),
-                );
+                    ),
+                ));
             }
             if let Some(existing) = providers.insert(node.provides_state_type_id(), index) {
-                return SubtrActorError::new_result(
-                    SubtrActorErrorVariant::CallbackError(format!(
+                return SubtrActorError::new_result(SubtrActorErrorVariant::CallbackError(
+                    format!(
                         "analysis node graph error: Duplicate providers for state {}: '{}' and '{}'",
                         node.provides_state_type_name(),
                         self.nodes[existing].name(),
                         node.name(),
-                    )),
-                );
+                    ),
+                ));
             }
         }
         Ok(providers)

--- a/src/stats/analysis_graph/graph_tests.rs
+++ b/src/stats/analysis_graph/graph_tests.rs
@@ -5,7 +5,7 @@ use crate::stats::analysis_graph::{
     builtin_analysis_node_names, graph_with_builtin_analysis_nodes, nodes::DoubleTapNode,
 };
 use crate::stats::calculators::{
-    ApproachConfidenceLevel, EventCategory, FrameInput, StatsEvent, DOUBLE_TAP_EVENT_DEFINITION,
+    ApproachConfidenceLevel, DOUBLE_TAP_EVENT_DEFINITION, EventCategory, FrameInput, StatsEvent,
     UNKNOWN_DETECTION_CONFIDENCE,
 };
 

--- a/src/stats/analysis_graph/module_tests.rs
+++ b/src/stats/analysis_graph/module_tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::{
-    builtin_analysis_node_json, builtin_analysis_nodes_json, builtin_stats_module_names,
     AerialGoalCalculator, AirDribbleGoalCalculator, BackboardCalculator, BallCarryCalculator,
     BumpCalculator, CenterCalculator, CounterAttackGoalCalculator, DoubleTapGoalCalculator,
     EmptyNetGoalCalculator, FlickCalculator, FlickGoalCalculator, FlipIntoBallGoalCalculator,
@@ -9,7 +8,8 @@ use crate::{
     OneTimerGoalCalculator, OwnHalfGoalCalculator, PassCalculator, PassingGoalCalculator,
     PlayerVerticalState, PossessionState, RotationCalculator, StatsTimelineCollector,
     SustainedPressureGoalCalculator, TerritorialPressureCalculator, TouchState,
-    WallAerialCalculator, WallAerialShotCalculator,
+    WallAerialCalculator, WallAerialShotCalculator, builtin_analysis_node_json,
+    builtin_analysis_nodes_json, builtin_stats_module_names,
 };
 use std::any::TypeId;
 use std::collections::HashSet;
@@ -118,9 +118,11 @@ fn every_builtin_stats_module_is_graph_callable() {
 
 #[test]
 fn core_alias_and_match_stats_share_one_provider() {
-    assert!(builtin_analysis_node_aliases()
-        .iter()
-        .any(|alias| alias.alias == "core" && alias.node_name == "match_stats"));
+    assert!(
+        builtin_analysis_node_aliases()
+            .iter()
+            .any(|alias| alias.alias == "core" && alias.node_name == "match_stats")
+    );
 
     let mut graph = graph_with_builtin_analysis_nodes(["core", "match_stats"])
         .expect("core alias and match_stats should be accepted together");
@@ -139,9 +141,11 @@ fn core_alias_and_match_stats_share_one_provider() {
 #[test]
 fn air_dribble_alias_and_ball_carry_share_one_provider() {
     assert!(builtin_analysis_node_names().contains(&"air_dribble"));
-    assert!(builtin_analysis_node_aliases()
-        .iter()
-        .any(|alias| alias.alias == "air_dribble" && alias.node_name == "ball_carry"));
+    assert!(
+        builtin_analysis_node_aliases()
+            .iter()
+            .any(|alias| alias.alias == "air_dribble" && alias.node_name == "ball_carry")
+    );
 
     let mut graph = graph_with_builtin_analysis_nodes(["air_dribble", "ball_carry"])
         .expect("air_dribble alias and ball_carry should be accepted together");

--- a/src/stats/analysis_graph/node_macros.rs
+++ b/src/stats/analysis_graph/node_macros.rs
@@ -3,7 +3,7 @@ macro_rules! impl_analysis_node {
         node = $node:ident,
         state = $state:ty,
         name = $name:literal,
-        dependencies = [$($dependency:expr => $dependency_ty:ty),* $(,)?],
+        dependencies = [$($dependency:expr_2021 => $dependency_ty:ty),* $(,)?],
         $(on_replay_meta = |$meta_self:ident, $meta:ident| $on_replay_meta:block,)?
         call = $field:ident.$method:ident
         $(, finish = $finish_field:ident.$finish_method:ident)?
@@ -61,7 +61,7 @@ macro_rules! impl_analysis_node {
         node = $node:ident,
         state = $state:ty,
         name = $name:literal,
-        dependencies = [$($dependency:expr => $dependency_ty:ty),* $(,)?],
+        dependencies = [$($dependency:expr_2021 => $dependency_ty:ty),* $(,)?],
         $(on_replay_meta = |$meta_self:ident, $meta:ident| $on_replay_meta:block,)?
         update_state = $field:ident.$method:ident
         $(, finish = $finish_field:ident.$finish_method:ident)?
@@ -120,12 +120,12 @@ macro_rules! impl_analysis_node {
         node = $node:ident,
         state = $state:ty,
         name = $name:literal,
-        dependencies = [$($dependency:expr),* $(,)?],
+        dependencies = [$($dependency:expr_2021),* $(,)?],
         inputs = {$($binding:ident : $binding_ty:ty),* $(,)?},
         $(on_replay_meta = |$meta_self:ident, $meta:ident| $on_replay_meta:block,)?
         evaluate = |$eval_self:ident| $evaluate:block,
         $(finish = |$finish_self:ident| $finish:block,)?
-        state_ref = |$state_self:ident| $state_ref:expr $(,)?
+        state_ref = |$state_self:ident| $state_ref:expr_2021 $(,)?
     ) => {
         impl Default for $node {
             fn default() -> Self {

--- a/src/stats/analysis_graph/nodes/mod.rs
+++ b/src/stats/analysis_graph/nodes/mod.rs
@@ -164,7 +164,7 @@ pub use speed_flip::SpeedFlipNode;
 pub use stats_projection::{StatsProjectionNode, StatsProjectionState};
 #[allow(unused_imports)]
 pub use stats_timeline_events::{
-    StatsTimelineEventsNode, StatsTimelineEventsState, STATS_TIMELINE_MECHANIC_KINDS,
+    STATS_TIMELINE_MECHANIC_KINDS, StatsTimelineEventsNode, StatsTimelineEventsState,
 };
 #[allow(unused_imports)]
 pub use stats_timeline_frame::{StatsTimelineFrameNode, StatsTimelineFrameState};

--- a/src/stats/calculators/air_dribble_tests.rs
+++ b/src/stats/calculators/air_dribble_tests.rs
@@ -198,11 +198,13 @@ fn rejects_air_dribble_when_player_lands_between_touches() {
 
     harness.finish();
 
-    assert!(harness
-        .calculator
-        .player_air_dribble_stats()
-        .get(&player_id)
-        .is_none());
+    assert!(
+        harness
+            .calculator
+            .player_air_dribble_stats()
+            .get(&player_id)
+            .is_none()
+    );
     assert!(harness.calculator.carry_events().is_empty());
 }
 
@@ -240,11 +242,13 @@ fn rejects_air_dribble_with_fewer_than_three_successive_touches() {
 
     harness.finish();
 
-    assert!(harness
-        .calculator
-        .player_air_dribble_stats()
-        .get(&player_id)
-        .is_none());
+    assert!(
+        harness
+            .calculator
+            .player_air_dribble_stats()
+            .get(&player_id)
+            .is_none()
+    );
     assert!(harness.calculator.carry_events().is_empty());
 }
 
@@ -369,10 +373,12 @@ fn rejects_wall_control_as_air_dribble() {
     harness.finish();
 
     assert!(harness.calculator.player_stats().get(&player_id).is_none());
-    assert!(harness
-        .calculator
-        .player_air_dribble_stats()
-        .get(&player_id)
-        .is_none());
+    assert!(
+        harness
+            .calculator
+            .player_air_dribble_stats()
+            .get(&player_id)
+            .is_none()
+    );
     assert!(harness.calculator.carry_events().is_empty());
 }

--- a/src/stats/calculators/ball_carry_tests.rs
+++ b/src/stats/calculators/ball_carry_tests.rs
@@ -32,11 +32,13 @@ fn keeps_ground_carry_stats_separate_from_air_dribbles() {
 
     let stats = harness.calculator.player_stats().get(&player_id).unwrap();
     assert_eq!(stats.carry_count, 1);
-    assert!(harness
-        .calculator
-        .player_air_dribble_stats()
-        .get(&player_id)
-        .is_none());
+    assert!(
+        harness
+            .calculator
+            .player_air_dribble_stats()
+            .get(&player_id)
+            .is_none()
+    );
     assert_eq!(
         harness.calculator.carry_events()[0].kind,
         BallCarryKind::Carry

--- a/src/stats/calculators/boost_tests.rs
+++ b/src/stats/calculators/boost_tests.rs
@@ -959,11 +959,15 @@ fn matches_two_small_pickups_from_one_observed_boost_increase() {
 
     let events = calculator.pickup_events();
     assert_eq!(events.len(), 2);
-    assert!(events
-        .iter()
-        .all(|event| event.pad_type == BoostPickupPadType::Small));
+    assert!(
+        events
+            .iter()
+            .all(|event| event.pad_type == BoostPickupPadType::Small)
+    );
     // At least one of the two reported pickups is corroborated by the observed boost jump.
-    assert!(events
-        .iter()
-        .any(|event| event.detection == BoostPickupDetection::Both));
+    assert!(
+        events
+            .iter()
+            .any(|event| event.detection == BoostPickupDetection::Both)
+    );
 }

--- a/src/stats/calculators/event_definition.rs
+++ b/src/stats/calculators/event_definition.rs
@@ -408,10 +408,10 @@ macro_rules! define_stats_event {
         $definition:ident,
         $id:literal,
         $label:literal,
-        $category:expr,
+        $category:expr_2021,
         summary = $summary:literal,
         approach = [$($approach:literal),* $(,)?]
-        $(, $modifier:ident = $modval:expr)* $(,)?
+        $(, $modifier:ident = $modval:expr_2021)* $(,)?
     ) => {
         pub const $definition: EventDefinition =
             event_definition($id, $label, $category, $summary, &[$($approach),*])
@@ -429,8 +429,8 @@ macro_rules! define_stats_event {
         $definition:ident,
         $id:literal,
         $label:literal,
-        $category:expr
-        $(, $modifier:ident = $modval:expr)* $(,)?
+        $category:expr_2021
+        $(, $modifier:ident = $modval:expr_2021)* $(,)?
     ) => {
         pub const $definition: EventDefinition =
             pending_event_definition($id, $label, $category)
@@ -445,7 +445,7 @@ macro_rules! define_stats_event {
 }
 
 macro_rules! register_event_producer {
-    ($static_name:ident, $node_name:literal, $emitted_events:expr) => {
+    ($static_name:ident, $node_name:literal, $emitted_events:expr_2021) => {
         #[cfg(not(target_arch = "wasm32"))]
         #[distributed_slice(EVENT_PRODUCERS)]
         static $static_name: EventProducerDefinition = EventProducerDefinition {
@@ -656,7 +656,8 @@ define_stats_event!(
     "one_timer",
     "One Timer",
     EventCategory::Mechanic,
-    summary = "A fast receiver touch from a completed pass that is immediately directed toward goal.",
+    summary =
+        "A fast receiver touch from a completed pass that is immediately directed toward goal.",
     approach = [
         "Consume newly completed pass events on the frame they are recorded.",
         "Require the current ball speed after the receiver's touch to exceed the one-timer speed threshold.",
@@ -682,7 +683,8 @@ define_stats_event!(
     "ball_carry",
     "Ball Carry",
     EventCategory::Mechanic,
-    summary = "A sustained player-ball control sequence, covering grounded carries and air dribbles.",
+    summary =
+        "A sustained player-ball control sequence, covering grounded carries and air dribbles.",
     approach = [
         "Use continuous ball-control tracking to build player-owned sequences while live play is active.",
         "Sample grounded carries from close horizontal/vertical ball gaps over the car, excluding wall contact.",
@@ -695,7 +697,8 @@ define_stats_event!(
     "controlled_play",
     "Controlled Play",
     EventCategory::Mechanic,
-    summary = "A same-player possession episode with multiple touches and sustained close-ball time.",
+    summary =
+        "A same-player possession episode with multiple touches and sustained close-ball time.",
     approach = [
         "Start a player-owned candidate from an attributed touch during live play.",
         "Require at least two distinct touches by the same player with at least one second between the first and last touch.",

--- a/src/stats/calculators/frame_input.rs
+++ b/src/stats/calculators/frame_input.rs
@@ -266,21 +266,22 @@ impl FrameInput {
         let active_demo_events = processor.current_frame_active_demo_events();
         if !active_demo_events.is_empty() {
             active_demo_events.to_vec()
-        } else if let Ok(demos) = processor.get_active_demos() {
-            demos
-                .into_iter()
-                .filter_map(|demo| {
-                    let attacker = processor
-                        .get_player_id_from_car_id(&demo.attacker_actor_id())
-                        .ok()?;
-                    let victim = processor
-                        .get_player_id_from_car_id(&demo.victim_actor_id())
-                        .ok()?;
-                    Some(DemoEventSample { attacker, victim })
-                })
-                .collect()
         } else {
-            Vec::new()
+            match processor.get_active_demos() {
+                Ok(demos) => demos
+                    .into_iter()
+                    .filter_map(|demo| {
+                        let attacker = processor
+                            .get_player_id_from_car_id(&demo.attacker_actor_id())
+                            .ok()?;
+                        let victim = processor
+                            .get_player_id_from_car_id(&demo.victim_actor_id())
+                            .ok()?;
+                        Some(DemoEventSample { attacker, victim })
+                    })
+                    .collect(),
+                _ => Vec::new(),
+            }
         }
     }
 

--- a/src/stats/calculators/goal_tags_tests.rs
+++ b/src/stats/calculators/goal_tags_tests.rs
@@ -464,12 +464,14 @@ fn counter_attack_goal_tags_goal_with_counter_attack_buildup() {
     let events = CounterAttackGoalCalculator::new().tag_goals(&[goal]);
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::CounterAttackGoal]);
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::GoalBuildup));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::GoalBuildup)
+    );
 }
 
 #[test]
@@ -489,12 +491,14 @@ fn sustained_pressure_goal_tags_goal_with_sustained_pressure_buildup() {
     let events = SustainedPressureGoalCalculator::new().tag_goals(&[goal]);
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::SustainedPressureGoal]);
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::GoalBuildup));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::GoalBuildup)
+    );
 }
 
 #[test]
@@ -577,12 +581,14 @@ fn kickoff_goal_tags_goals_attributed_by_a_kickoff_event() {
     let events = calculator.tag_goals(&[goal], &[kickoff_event]);
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::KickoffGoal]);
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::GoalContext));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::GoalContext)
+    );
 }
 
 #[test]
@@ -611,12 +617,14 @@ fn flick_goal_tags_matching_scorer_flick_before_last_touch() {
     assert_eq!(events[0].tag.metadata().confidence, 0.82);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Scorer));
     assert!(has_modifier(&events[0], GoalTagModifier::ByScorer));
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::Flick));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::Flick)
+    );
 }
 
 #[test]
@@ -630,12 +638,16 @@ fn flick_goal_carries_flick_kind_details() {
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlickGoal]);
     let details = &events[0].tag.metadata().details;
-    assert!(details
-        .iter()
-        .any(|detail| detail.key == "kind" && detail.value == "reverse"));
-    assert!(details
-        .iter()
-        .any(|detail| detail.key == "setup_rotation_direction" && detail.value == "left"));
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.key == "kind" && detail.value == "reverse")
+    );
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.key == "setup_rotation_direction" && detail.value == "left")
+    );
 }
 
 #[test]
@@ -646,12 +658,16 @@ fn flick_goal_omits_unknown_setup_rotation_direction_detail() {
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlickGoal]);
     let details = &events[0].tag.metadata().details;
-    assert!(details
-        .iter()
-        .any(|detail| detail.key == "kind" && detail.value == "other"));
-    assert!(!details
-        .iter()
-        .any(|detail| detail.key == "setup_rotation_direction"));
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.key == "kind" && detail.value == "other")
+    );
+    assert!(
+        !details
+            .iter()
+            .any(|detail| detail.key == "setup_rotation_direction")
+    );
 }
 
 #[test]
@@ -693,12 +709,14 @@ fn one_timer_goal_tags_matching_one_timer_before_last_touch() {
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::OneTimerGoal]);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Scorer));
     assert!(has_modifier(&events[0], GoalTagModifier::ByScorer));
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::OneTimer));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::OneTimer)
+    );
 }
 
 #[test]
@@ -741,12 +759,14 @@ fn ceiling_shot_goal_tags_matching_ceiling_shot_before_goal() {
     assert_eq!(events[0].tag.metadata().confidence, 0.84);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Scorer));
     assert!(has_modifier(&events[0], GoalTagModifier::ByScorer));
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::CeilingShot));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::CeilingShot)
+    );
 }
 
 #[test]
@@ -780,12 +800,14 @@ fn double_tap_goal_tags_matching_double_tap_before_goal() {
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::DoubleTapGoal]);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Scorer));
     assert!(has_modifier(&events[0], GoalTagModifier::ByScorer));
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::DoubleTap));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::DoubleTap)
+    );
 }
 
 #[test]
@@ -804,12 +826,14 @@ fn air_dribble_goal_tags_air_dribble_control_that_reaches_last_touch() {
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::AirDribbleGoal]);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Scorer));
     assert!(has_modifier(&events[0], GoalTagModifier::ByScorer));
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::AirDribble));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::AirDribble)
+    );
 }
 
 #[test]
@@ -857,12 +881,14 @@ fn flip_reset_goal_tags_matching_on_ball_reset_before_last_touch() {
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlipResetGoal]);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Scorer));
     assert!(has_modifier(&events[0], GoalTagModifier::ByScorer));
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::FlipReset));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::FlipReset)
+    );
 }
 
 #[test]
@@ -888,12 +914,14 @@ fn flip_into_ball_goal_tags_dodge_scoring_touch() {
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlipIntoBallGoal]);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Scorer));
     assert!(has_modifier(&events[0], GoalTagModifier::ByScorer));
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::FlipIntoBall));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::FlipIntoBall)
+    );
     assert_eq!(
         events[0].tag.metadata().related_events,
         vec![GoalTagEventRef {
@@ -965,9 +993,11 @@ fn flip_into_ball_goal_joins_by_touch_id_when_present() {
     // an id-bearing candidate that is not the scoring touch must not match.
     let mut other_touch = touch_classification_event(9.5, 95, player_id(1), "dodge");
     other_touch.touch_id = Some(6);
-    assert!(FlipIntoBallGoalCalculator::new()
-        .tag_goals(std::slice::from_ref(&goal), &[other_touch.clone()])
-        .is_empty());
+    assert!(
+        FlipIntoBallGoalCalculator::new()
+            .tag_goals(std::slice::from_ref(&goal), &[other_touch.clone()])
+            .is_empty()
+    );
 
     // The candidate carrying the matching id is the scoring touch.
     let mut scoring_touch = other_touch;
@@ -1088,12 +1118,14 @@ fn half_volley_goal_tags_scorer_last_touch_after_floor_bounce() {
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::HalfVolleyGoal]);
     assert!(has_modifier(&events[0], GoalTagModifier::ByScorer));
-    assert!(events[0]
-        .tag
-        .metadata()
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == GoalTagEvidenceKind::HalfVolley));
+    assert!(
+        events[0]
+            .tag
+            .metadata()
+            .evidence
+            .iter()
+            .any(|evidence| evidence.kind == GoalTagEvidenceKind::HalfVolley)
+    );
 }
 
 #[test]

--- a/src/stats/calculators/in_flight.rs
+++ b/src/stats/calculators/in_flight.rs
@@ -504,7 +504,8 @@ impl<K: Eq + Hash + Clone, C: InFlightItem> KeyedInFlightLedger<K, C> {
             self.active.remove(&key);
         }
         for (key, reason) in remove_finalize {
-            if let Some(item) = self.active.remove(&key) {
+            let removed = self.active.remove(&key);
+            if let Some(item) = removed {
                 self.log.log(&item);
                 finalized.push((key, item, reason));
             }

--- a/src/stats/calculators/in_flight_tests.rs
+++ b/src/stats/calculators/in_flight_tests.rs
@@ -142,9 +142,11 @@ fn finalize_all_drains_and_logs_every_item() {
 
     let finalized = ledger.finalize_all(FinalizeReason::Superseded);
     assert_eq!(finalized.len(), 2);
-    assert!(finalized
-        .iter()
-        .all(|(_, reason)| *reason == FinalizeReason::Superseded));
+    assert!(
+        finalized
+            .iter()
+            .all(|(_, reason)| *reason == FinalizeReason::Superseded)
+    );
     assert!(ledger.is_empty());
     // Both are now queryable as having happened (committed, by recognition time).
     assert!(ledger.happened_within(1.0, 1.0, true));

--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -722,6 +722,9 @@ impl KickoffCalculator {
         }
         if let Some(boost_amount) = Self::boost_amount(player) {
             if let Some(previous_boost) = trace.previous_boost {
+                // Collection is tracked from pad-pickup events, not deltas; only
+                // the spent side is sampled here, as a fallback for boost_used
+                // when start/contact boost is unavailable.
                 let delta = boost_amount - previous_boost;
                 if delta < 0.0 {
                     // Only the depletion side is sampled here, as a fallback for
@@ -992,6 +995,22 @@ impl KickoffCalculator {
 
     fn taker_boost_collected(player: &KickoffPlayerSnapshot) -> f32 {
         player.approach_trace.pickup_boost_collected
+    }
+
+    /// Boost the taker has left *at the moment of contact* with the ball.
+    ///
+    /// This is the counterpart to [`taker_boost_used`], which measures boost
+    /// spent over the `start -> first touch` window. The plain finish-frame
+    /// sample (`boost_after`) is taken ~1.25s after the touch, by which point
+    /// the taker has driven on and possibly re-collected boost, so pairing it
+    /// with `boost_used` produces nonsensical combinations (e.g. used 94 /
+    /// after 80). Using `first_touch_boost` keeps the two consistent:
+    /// `start_boost + boost_collected == boost_used + boost_after`.
+    ///
+    /// Falls back to the finish-frame sample for takers who never touched the
+    /// ball (fake / missed outcomes), where there is no contact moment.
+    fn taker_boost_after(player: &KickoffPlayerSnapshot, boost_after: Option<f32>) -> Option<f32> {
+        player.first_touch_boost.or(boost_after)
     }
 
     fn taker_boost_used(player: &KickoffPlayerSnapshot) -> f32 {
@@ -1568,13 +1587,14 @@ impl KickoffCalculator {
                         team_one_touched
                     },
                 );
+                let taker_boost_after = Self::taker_boost_after(player, boost_after);
                 let player_event = KickoffTakerEvent {
                     player: player.player.clone(),
                     is_team_0: player.is_team_0,
                     start_position: player.start_position,
                     spawn_position: player.spawn_position,
                     start_boost: player.start_boost,
-                    boost_after,
+                    boost_after: taker_boost_after,
                     time_to_ball: Self::taker_time_to_ball(player, movement_start_time),
                     boost_collected: Self::taker_boost_collected(player),
                     boost_used: Self::taker_boost_used(player),
@@ -1585,7 +1605,7 @@ impl KickoffCalculator {
                     approach: Self::classify_approach(
                         player,
                         outcome,
-                        boost_after,
+                        taker_boost_after,
                         active.speed_flip_players.contains(&player.player),
                     ),
                 };

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -2157,10 +2157,12 @@ fn kickoff_tie_breaks_expected_taker_by_actual_touch_then_left_goes() {
         event.team_zero_taker.as_ref().map(|player| &player.player),
         Some(&right_player)
     );
-    assert!(event
-        .team_zero_non_takers
-        .iter()
-        .any(|player| player.player == left_player));
+    assert!(
+        event
+            .team_zero_non_takers
+            .iter()
+            .any(|player| player.player == left_player)
+    );
 
     let left_goes_index = KickoffCalculator::expected_taker_by_team(
         &[

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -1070,8 +1070,18 @@ fn kickoff_taker_tracks_time_to_ball_and_approach_boost_totals() {
     let blue_taker_event = event.team_zero_taker.as_ref().unwrap();
     assert_eq!(blue_taker_event.player, blue_taker);
     assert_eq!(blue_taker_event.time_to_ball, Some(0.5));
+    // Collection comes from the deduplicated BoostPickupEvent during the
+    // approach, not from summing per-frame boost deltas.
     assert_eq!(blue_taker_event.boost_collected, 15.0);
-    assert_eq!(blue_taker_event.boost_used, 3.0);
+    // boost_used = start + collected - boost-at-contact.
+    assert_eq!(
+        blue_taker_event.boost_used,
+        (33.0_f32 + 15.0 - 45.0).max(0.0)
+    );
+    // `boost_after` is sampled at contact (45.0 at frame 35), not at the
+    // end-of-kickoff resolution frame (10.0 at frame 50). This keeps the
+    // accounting consistent: start (33) + collected == used + after (45).
+    assert_eq!(blue_taker_event.boost_after, Some(45.0));
 }
 
 #[test]

--- a/src/stats/calculators/kickoff_types.rs
+++ b/src/stats/calculators/kickoff_types.rs
@@ -339,6 +339,11 @@ pub struct KickoffTakerEvent {
     pub start_position: [f32; 3],
     pub spawn_position: KickoffSpawnPosition,
     pub start_boost: Option<f32>,
+    /// Boost remaining at the moment the taker contacts the ball (the
+    /// counterpart to `boost_used`, which is spent reaching that contact).
+    /// For takers that never touch the ball (fake / missed) this falls back to
+    /// the end-of-kickoff sample. Invariant when the taker touches:
+    /// `start_boost + boost_collected == boost_used + boost_after`.
     pub boost_after: Option<f32>,
     pub time_to_ball: Option<f32>,
     pub boost_collected: f32,

--- a/src/stats/calculators/live_play_tests.rs
+++ b/src/stats/calculators/live_play_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{GoalEvent, GAME_STATE_KICKOFF_COUNTDOWN};
+use crate::{GAME_STATE_KICKOFF_COUNTDOWN, GoalEvent};
 
 #[test]
 fn kickoff_waiting_for_first_touch_is_not_live_play() {

--- a/src/stats/calculators/match_stats_tests.rs
+++ b/src/stats/calculators/match_stats_tests.rs
@@ -389,10 +389,12 @@ fn finish_flushes_attributed_goal_without_goal_counter_delta() {
         )
         .unwrap();
 
-    assert!(calculator
-        .timeline()
-        .iter()
-        .all(|event| event.kind != TimelineEventKind::Goal));
+    assert!(
+        calculator
+            .timeline()
+            .iter()
+            .all(|event| event.kind != TimelineEventKind::Goal)
+    );
 
     calculator.finish().unwrap();
 

--- a/src/stats/calculators/mod.rs
+++ b/src/stats/calculators/mod.rs
@@ -324,11 +324,7 @@ pub fn standard_soccar_boost_pad_layout() -> &'static [(glam::Vec3, BoostPadSize
 }
 
 fn normalized_y(is_team_0: bool, position: glam::Vec3) -> f32 {
-    if is_team_0 {
-        position.y
-    } else {
-        -position.y
-    }
+    if is_team_0 { position.y } else { -position.y }
 }
 
 fn is_enemy_side(is_team_0: bool, position: glam::Vec3) -> bool {

--- a/src/stats/calculators/territorial_pressure.rs
+++ b/src/stats/calculators/territorial_pressure.rs
@@ -157,11 +157,7 @@ impl TerritorialPressureCalculator {
     }
 
     fn normalized_ball_y(team_is_team_0: bool, ball_y: f32) -> f32 {
-        if team_is_team_0 {
-            ball_y
-        } else {
-            -ball_y
-        }
+        if team_is_team_0 { ball_y } else { -ball_y }
     }
 
     fn candidate_sample(

--- a/src/stats/calculators/touch_intention.rs
+++ b/src/stats/calculators/touch_intention.rs
@@ -460,11 +460,7 @@ pub(crate) fn fifty_fifty_involves_player(
 }
 
 fn own_goal_line_y(is_team_0: bool) -> f32 {
-    if is_team_0 {
-        -GOAL_LINE_Y
-    } else {
-        GOAL_LINE_Y
-    }
+    if is_team_0 { -GOAL_LINE_Y } else { GOAL_LINE_Y }
 }
 
 fn opponent_goal_line_y(is_team_0: bool) -> f32 {

--- a/src/stats/calculators/touch_state_tests.rs
+++ b/src/stats/calculators/touch_state_tests.rs
@@ -702,14 +702,18 @@ fn aggregate_explicit_touch_cooldown_processes_events_chronologically() {
     );
 
     assert_eq!(touch_state.touch_events.len(), 2);
-    assert!(touch_state
-        .touch_events
-        .iter()
-        .any(|touch| touch.frame == 1));
-    assert!(touch_state
-        .touch_events
-        .iter()
-        .any(|touch| touch.frame == 4));
+    assert!(
+        touch_state
+            .touch_events
+            .iter()
+            .any(|touch| touch.frame == 1)
+    );
+    assert!(
+        touch_state
+            .touch_events
+            .iter()
+            .any(|touch| touch.frame == 4)
+    );
     assert_eq!(touch_state.last_touch_player, Some(player_id));
     assert_eq!(
         touch_state.last_touch.as_ref().map(|touch| touch.frame),
@@ -1028,14 +1032,18 @@ fn player_explicit_touch_events_are_kept_alongside_physics_candidates() {
     );
 
     assert_eq!(touch_state.touch_events.len(), 2);
-    assert!(touch_state
-        .touch_events
-        .iter()
-        .any(|touch| touch.player.as_ref() == Some(&physics_player_id)));
-    assert!(touch_state
-        .touch_events
-        .iter()
-        .any(|touch| touch.player.as_ref() == Some(&explicit_player_id)));
+    assert!(
+        touch_state
+            .touch_events
+            .iter()
+            .any(|touch| touch.player.as_ref() == Some(&physics_player_id))
+    );
+    assert!(
+        touch_state
+            .touch_events
+            .iter()
+            .any(|touch| touch.player.as_ref() == Some(&explicit_player_id))
+    );
 }
 
 #[test]
@@ -1248,22 +1256,30 @@ fn simultaneous_close_candidates_are_all_emitted() {
     );
 
     assert_eq!(touch_state.touch_events.len(), 2);
-    assert!(touch_state
-        .touch_events
-        .iter()
-        .any(|touch| touch.player.as_ref() == Some(&team_zero_player_id)));
-    assert!(touch_state
-        .touch_events
-        .iter()
-        .any(|touch| touch.player.as_ref() == Some(&team_one_player_id)));
-    assert!(touch_state
-        .touch_events
-        .iter()
-        .any(|touch| touch.team_is_team_0));
-    assert!(touch_state
-        .touch_events
-        .iter()
-        .any(|touch| !touch.team_is_team_0));
+    assert!(
+        touch_state
+            .touch_events
+            .iter()
+            .any(|touch| touch.player.as_ref() == Some(&team_zero_player_id))
+    );
+    assert!(
+        touch_state
+            .touch_events
+            .iter()
+            .any(|touch| touch.player.as_ref() == Some(&team_one_player_id))
+    );
+    assert!(
+        touch_state
+            .touch_events
+            .iter()
+            .any(|touch| touch.team_is_team_0)
+    );
+    assert!(
+        touch_state
+            .touch_events
+            .iter()
+            .any(|touch| !touch.team_is_team_0)
+    );
 }
 
 #[test]

--- a/src/stats/calculators/wall_aerial_shot.rs
+++ b/src/stats/calculators/wall_aerial_shot.rs
@@ -1,6 +1,6 @@
 use super::wall_aerial::{
-    wall_aerial_normalize_score, wall_aerial_wall_for_position, WALL_AERIAL_MIN_TOUCH_BALL_Z,
-    WALL_AERIAL_MIN_TOUCH_PLAYER_Z,
+    WALL_AERIAL_MIN_TOUCH_BALL_Z, WALL_AERIAL_MIN_TOUCH_PLAYER_Z, wall_aerial_normalize_score,
+    wall_aerial_wall_for_position,
 };
 use super::*;
 

--- a/tests/clip_air_dribble_test.rs
+++ b/tests/clip_air_dribble_test.rs
@@ -9,7 +9,7 @@
 mod common;
 
 use subtr_actor::{
-    clip_replay_around_times, EventPayload, GoalTagKind, StatsTimelineEventCollector,
+    EventPayload, GoalTagKind, StatsTimelineEventCollector, clip_replay_around_times,
 };
 
 const AIR_DRIBBLE_GOAL_MOUTH_REPLAY: &str = "assets/air-dribble-goal-mouth-2026-05-24.replay";

--- a/tests/clip_boost_pickup_duplicate_test.rs
+++ b/tests/clip_boost_pickup_duplicate_test.rs
@@ -11,7 +11,7 @@ mod common;
 use std::collections::HashMap;
 
 use subtr_actor::stats::analysis_graph::{
-    graph_with_builtin_analysis_nodes, AnalysisNodeCollector,
+    AnalysisNodeCollector, graph_with_builtin_analysis_nodes,
 };
 use subtr_actor::*;
 
@@ -173,9 +173,11 @@ fn clip_suppresses_iced_space_duplicate_reported_small_boost_pickup() {
             && pickup.pad_id == "VehiclePickup_Boost_TA_23"
             && pickup.sequence == 5
     }));
-    assert!(!duplicate_frame_pickups
-        .iter()
-        .any(|pickup| pickup.pad_id == duplicate_pad_id && pickup.sequence == 5));
+    assert!(
+        !duplicate_frame_pickups
+            .iter()
+            .any(|pickup| pickup.pad_id == duplicate_pad_id && pickup.sequence == 5)
+    );
 
     let graph_events_at_duplicate_frame = graph_events_for_iced_space
         .iter()

--- a/tests/clip_contested_kickoff_test.rs
+++ b/tests/clip_contested_kickoff_test.rs
@@ -11,8 +11,8 @@
 mod common;
 
 use subtr_actor::{
-    clip_replay_around_times, EventPayload, KickoffEvent, KickoffType, PlayerId,
-    StatsTimelineCollector,
+    EventPayload, KickoffEvent, KickoffType, PlayerId, StatsTimelineCollector,
+    clip_replay_around_times,
 };
 
 const DOUBLES_REPLAY: &str = "assets/post-eac-ranked-doubles-2026-04-28.replay";

--- a/tests/clip_double_tap_test.rs
+++ b/tests/clip_double_tap_test.rs
@@ -10,8 +10,8 @@
 mod common;
 
 use subtr_actor::{
-    clip_replay_around_times, EventPayload, EventTiming, GoalTagKind, ReplayStatsTimelineScaffold,
-    StatsTimelineEventCollector,
+    EventPayload, EventTiming, GoalTagKind, ReplayStatsTimelineScaffold,
+    StatsTimelineEventCollector, clip_replay_around_times,
 };
 
 const THIRD_GOAL_DOUBLE_TAP_REPLAY: &str =

--- a/tests/clip_fidelity_test.rs
+++ b/tests/clip_fidelity_test.rs
@@ -9,8 +9,8 @@
 
 use std::collections::BTreeMap;
 use subtr_actor::{
-    clip_replay_around, Collector, PlayerId, ProcessorView, ReplayProcessor, SubtrActorResult,
-    TimeAdvance,
+    Collector, PlayerId, ProcessorView, ReplayProcessor, SubtrActorResult, TimeAdvance,
+    clip_replay_around,
 };
 
 const REPLAY: &str = "assets/post-eac-ranked-duel-2026-04-28-a.replay";

--- a/tests/clip_kickoff_approach_flip_test.rs
+++ b/tests/clip_kickoff_approach_flip_test.rs
@@ -15,7 +15,7 @@
 mod common;
 
 use subtr_actor::{
-    clip_replay_around_times, EventPayload, KickoffApproach, PlayerId, StatsTimelineCollector,
+    EventPayload, KickoffApproach, PlayerId, StatsTimelineCollector, clip_replay_around_times,
 };
 
 const REPLAY: &str = "assets/boost-into-ball-misclassification-2026-06-11.replay";

--- a/tests/clip_speed_flip_test.rs
+++ b/tests/clip_speed_flip_test.rs
@@ -9,8 +9,8 @@
 //! clip so the test only ever processes the frames that matter.
 
 use subtr_actor::{
-    clip_replay_around, EventPayload, PlayerId, ReplayClip, ReplayMeta,
-    ReplayStatsTimelineScaffold, SpeedFlipEvent, StatsTimelineEventCollector,
+    EventPayload, PlayerId, ReplayClip, ReplayMeta, ReplayStatsTimelineScaffold, SpeedFlipEvent,
+    StatsTimelineEventCollector, clip_replay_around,
 };
 
 const COLONELPANIC_NO_SPEED_FLIP_REPLAY: &str =

--- a/tests/clip_worldcup_kickoff_test.rs
+++ b/tests/clip_worldcup_kickoff_test.rs
@@ -10,8 +10,8 @@
 mod common;
 
 use subtr_actor::{
-    clip_replay_around_times, EventPayload, KickoffEvent, KickoffOutcome, ReplayClip,
-    StatsTimelineCollector,
+    EventPayload, KickoffEvent, KickoffOutcome, ReplayClip, StatsTimelineCollector,
+    clip_replay_around_times,
 };
 
 const WORLDCUP_REPLAY: &str = "assets/replay-format-2026-06-02-v868-32-net11-worldcup-ball.replay";

--- a/tests/game_state_test.rs
+++ b/tests/game_state_test.rs
@@ -32,12 +32,16 @@ fn test_game_state_column_headers() {
 
     assert_eq!(headers.global_headers.len(), 3);
     assert!(headers.global_headers.contains(&"game state".to_string()));
-    assert!(headers
-        .global_headers
-        .contains(&"kickoff countdown".to_string()));
-    assert!(headers
-        .global_headers
-        .contains(&"ball has been hit".to_string()));
+    assert!(
+        headers
+            .global_headers
+            .contains(&"kickoff countdown".to_string())
+    );
+    assert!(
+        headers
+            .global_headers
+            .contains(&"ball has been hit".to_string())
+    );
 }
 
 #[test]

--- a/tests/hitbox_replay_fixture_test.rs
+++ b/tests/hitbox_replay_fixture_test.rs
@@ -2,9 +2,8 @@ mod common;
 
 use subtr_actor::stats::analysis_graph::graph_with_builtin_analysis_nodes;
 use subtr_actor::{
-    car_hitbox_for_body_id, car_hitbox_for_body_name, Collector, FrameInput,
-    ReplayFrameInputBuilder, ReplayProcessor, SubtrActorResult, TimeAdvance, TouchCandidateScoring,
-    TouchState,
+    Collector, FrameInput, ReplayFrameInputBuilder, ReplayProcessor, SubtrActorResult, TimeAdvance,
+    TouchCandidateScoring, TouchState, car_hitbox_for_body_id, car_hitbox_for_body_name,
 };
 
 const TOUCH_STATE_FIXTURES: &[&str] = &[

--- a/tests/post_eac_replay_fixture_test.rs
+++ b/tests/post_eac_replay_fixture_test.rs
@@ -2,9 +2,9 @@ mod common;
 
 use serde_json::Value;
 use subtr_actor::{
-    builtin_stats_module_names, Collector, EventPayload, FrameRateDecorator, GoalTagKind,
-    NDArrayCollector, PlayerFrame, ReplayDataCollector, ReplayGameType, ReplayProcessor,
-    StatsCollector, StatsFrameResolution, StatsTimelineCollector, StatsTimelineEventCollector,
+    Collector, EventPayload, FrameRateDecorator, GoalTagKind, NDArrayCollector, PlayerFrame,
+    ReplayDataCollector, ReplayGameType, ReplayProcessor, StatsCollector, StatsFrameResolution,
+    StatsTimelineCollector, StatsTimelineEventCollector, builtin_stats_module_names,
 };
 
 struct PostEacFixture {

--- a/tests/replay_data_collector_test.rs
+++ b/tests/replay_data_collector_test.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 use subtr_actor::collector::replay_data::{BallFrame, PlayerFrame, ReplayDataCollector};
-use subtr_actor::{ReplayProcessor, BOOST_KICKOFF_START_AMOUNT};
+use subtr_actor::{BOOST_KICKOFF_START_AMOUNT, ReplayProcessor};
 
 fn parse_replay(path: &str) -> boxcars::Replay {
     let replay_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);

--- a/tests/stats_collector_test.rs
+++ b/tests/stats_collector_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use subtr_actor::{builtin_stats_module_names, StatsCollector, StatsFrameResolution};
+use subtr_actor::{StatsCollector, StatsFrameResolution, builtin_stats_module_names};
 
 const SMALL_STATS_FIXTURE: &str = "assets/post-eac-ranked-duel-2026-04-28-a.replay";
 

--- a/tests/stats_export_test.rs
+++ b/tests/stats_export_test.rs
@@ -1,5 +1,5 @@
 use subtr_actor::stats::export::{
-    ExportedStat, LabeledFloatSums, StatFieldProvider, StatUnit, StatValue, LEGACY_STAT_VARIANT,
+    ExportedStat, LEGACY_STAT_VARIANT, LabeledFloatSums, StatFieldProvider, StatUnit, StatValue,
 };
 use subtr_actor::{
     BackboardPlayerStats, BallHalfStats, BoostStats, CorePlayerStats, DodgeResetStats,


### PR DESCRIPTION
## Summary

- Moves the workspace to Rust edition 2024 and resolver 3.
- Adds a shared workspace rust-version of 1.87, matching APIs already used in the codebase.
- Applies the Rust 2024 migration fixes for macro fragments, temporary/drop scopes, and BakkesMod FFI unsafe annotations.
- Runs rustfmt under the 2024 edition, which accounts for the broad formatting-only churn.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `RUSTFLAGS='-Wrust-2024-compatibility' cargo check --workspace`
- Commit hook: `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace` was run and reached one failure in `problematic_private_duel_big_pad_counts_match_ballchasing_with_inactive_pickups`; the same targeted test also fails on the original `master` worktree with the same inactive-inclusive big pad count mismatch, so this is pre-existing rather than introduced by this branch.
