### PR TITLE
feat(viewer): add publishable package output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,16 +161,39 @@
         packages.js-stats-player-pages = pkgs.buildNpmPackage rec {
           pname = "subtr-actor-js-pages";
           version = projectVersion;
-          src = ./.;
+          src = pkgs.runCommand "subtr-actor-js-pages-source" { nativeBuildInputs = [ pkgs.nodejs ]; } ''
+            mkdir -p "$out"
+            cp -R ${./.}/. "$out"/
+            chmod -R u+w "$out"
+            cd "$out"
+            node <<'EOF'
+            const fs = require("node:fs");
+
+            const packagePath = "js/stat-evaluation-player/package.json";
+            const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+            delete packageJson.devDependencies["@rlrml/viewer"];
+            fs.writeFileSync(packagePath, `''${JSON.stringify(packageJson, null, 2)}\n`);
+
+            const lockPath = "js/stat-evaluation-player/package-lock.json";
+            const lockJson = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+            delete lockJson.packages[""].devDependencies["@rlrml/viewer"];
+            delete lockJson.packages["../viewer"];
+            delete lockJson.packages["node_modules/@rlrml/viewer"];
+            fs.writeFileSync(lockPath, `''${JSON.stringify(lockJson, null, 2)}\n`);
+            EOF
+          '';
           npmRoot = "js/stat-evaluation-player";
-          npmDeps = pkgs.importNpmLock { npmRoot = ./js/stat-evaluation-player; };
+          npmDeps = pkgs.importNpmLock { npmRoot = "${src}/js/stat-evaluation-player"; };
           npmConfigHook = pkgs.importNpmLock.npmConfigHook;
           preBuild = ''
             rm -rf js/pkg
             mkdir -p js/pkg
             cp -r ${self.packages.${system}.js-web-wasm}/. js/pkg/
             ln -sfn ../stat-evaluation-player/node_modules js/player/node_modules
+            ln -sfn ../stat-evaluation-player/node_modules js/viewer/node_modules
             ln -sfn ../stat-evaluation-player/node_modules js/pages/node_modules
+            mkdir -p js/stat-evaluation-player/node_modules/@rlrml
+            ln -sfn ../../../viewer js/stat-evaluation-player/node_modules/@rlrml/viewer
           '';
           buildPhase = ''
             runHook preBuild
@@ -187,6 +210,7 @@
             runHook preInstall
             mkdir -p $out
             cp -r js/stat-evaluation-player/dist/. $out/
+            cp -r js/viewer/public/. $out/
             mkdir -p $out/stats
             cp -r js/pages/dist/. $out/stats/
             mkdir -p $out/review
@@ -241,6 +265,41 @@
           installPhase = ''
             runHook preInstall
             pushd js/player
+            staged="$(node ./scripts/prepare-package.mjs)"
+            popd
+            mkdir -p $out
+            cp -R "$staged"/. $out/
+            runHook postInstall
+          '';
+        };
+        # The publishable npm package layout for @rlrml/viewer. It is built as
+        # an ES module library and carries its public assets (models/draco) so
+        # downstream apps can vendor a single package output from this exact
+        # submodule revision.
+        packages.js-viewer-pkg = pkgs.buildNpmPackage {
+          pname = "rlrml-viewer-npm-pkg";
+          version = projectVersion;
+          src = ./.;
+          npmRoot = "js/viewer";
+          npmDeps = pkgs.importNpmLock { npmRoot = ./js/viewer; };
+          npmConfigHook = pkgs.importNpmLock.npmConfigHook;
+          npmInstallFlags = [ "--ignore-scripts" ];
+          preBuild = ''
+            rm -rf js/pkg
+            mkdir -p js/pkg
+            cp -r ${self.packages.${system}.js-web-wasm}/. js/pkg/
+            ln -sfn ../viewer/node_modules js/player/node_modules
+          '';
+          buildPhase = ''
+            runHook preBuild
+            pushd js/viewer
+            npm run build:dist
+            popd
+            runHook postBuild
+          '';
+          installPhase = ''
+            runHook preInstall
+            pushd js/viewer
             staged="$(node ./scripts/prepare-package.mjs)"
             popd
             mkdir -p $out

--- a/js/viewer/package.json
+++ b/js/viewer/package.json
@@ -1,16 +1,38 @@
 {
   "name": "@rlrml/viewer",
   "version": "0.12.0",
-  "private": true,
   "description": "High-fidelity 3D Rocket League replay viewer powered by subtr-actor (seeded from ballcam.tv with permission)",
   "type": "module",
-  "main": "./src/lib.ts",
-  "types": "./src/lib.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/lib.d.ts",
+  "files": [
+    "dist",
+    "public",
+    "docs",
+    "README.md",
+    "LICENSE"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/lib.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./public/*": "./public/*",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "check:tsc": "tsc --noEmit",
-    "build:types": "tsc --project tsconfig.build.json"
+    "build:types": "tsc --project tsconfig.build.json",
+    "build:player": "sh -lc 'test -f ../pkg/rl_replay_subtr_actor.js || (cd .. && ./scripts/with-clean-npm-env.sh node --run=build); ln -sfn ../viewer/node_modules ../player/node_modules; cd ../player && ../scripts/with-clean-npm-env.sh node --run=build:dist'",
+    "build:dist": "../scripts/with-clean-npm-env.sh node --run=build:player && vite build --config vite.package.config.ts && tsc --project tsconfig.build.json",
+    "prepare:package": "node ./scripts/prepare-package.mjs"
   },
   "dependencies": {
     "@rlrml/player": "file:../player",

--- a/js/viewer/scripts/prepare-package.mjs
+++ b/js/viewer/scripts/prepare-package.mjs
@@ -1,0 +1,51 @@
+import { cp, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.resolve(scriptDir, "..");
+const repoJsDir = path.resolve(packageDir, "..");
+const distDir = path.resolve(packageDir, "dist");
+
+async function main() {
+  const sourcePackage = JSON.parse(
+    await readFile(path.resolve(packageDir, "package.json"), "utf8"),
+  );
+  const bindingsPackage = JSON.parse(
+    await readFile(path.resolve(repoJsDir, "package.json"), "utf8"),
+  );
+  const playerPackage = JSON.parse(
+    await readFile(path.resolve(repoJsDir, "player", "package.json"), "utf8"),
+  );
+  const publishPackage = {
+    ...sourcePackage,
+    dependencies: {
+      ...sourcePackage.dependencies,
+      "@rlrml/player": playerPackage.version,
+      "@rlrml/subtr-actor": bindingsPackage.version,
+    },
+  };
+  delete publishPackage.scripts;
+  delete publishPackage.devDependencies;
+
+  const outputDir = await mkdtemp(path.join(os.tmpdir(), "subtr-actor-viewer-package-"));
+
+  await cp(distDir, path.join(outputDir, "dist"), { recursive: true });
+  await cp(path.resolve(packageDir, "public"), path.join(outputDir, "public"), {
+    recursive: true,
+  });
+  await cp(path.resolve(packageDir, "docs"), path.join(outputDir, "docs"), {
+    recursive: true,
+  });
+  await cp(path.resolve(packageDir, "README.md"), path.join(outputDir, "README.md"));
+  await cp(path.resolve(repoJsDir, "LICENSE"), path.join(outputDir, "LICENSE"));
+  await writeFile(
+    path.join(outputDir, "package.json"),
+    `${JSON.stringify(publishPackage, null, 2)}\n`,
+  );
+
+  process.stdout.write(outputDir);
+}
+
+await main();

--- a/js/viewer/src/lib.ts
+++ b/js/viewer/src/lib.ts
@@ -73,6 +73,9 @@ export type { FpsOverlayOptions, FpsSample } from "./plugins/fps-overlay.js";
 //   viewer.addPlugin(fromReplayPlayerPlugin(createTimelineOverlayPlugin()))
 export { fromReplayPlayerPlugin } from "./plugins/replay-player-bridge.js";
 export {
+  BOOST_RAW_MAX,
+  boostAmountToPercent,
+  boostPercentToAmount,
   createBoostPadOverlayPlugin,
   createBoostPickupAnimationPlugin,
   createCanvasRecorderPlugin,

--- a/js/viewer/vite.package.config.ts
+++ b/js/viewer/vite.package.config.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import { defineConfig } from "vite";
+import wasm from "vite-plugin-wasm";
+
+export default defineConfig({
+  plugins: [wasm()],
+  build: {
+    copyPublicDir: false,
+    lib: {
+      entry: path.resolve(import.meta.dirname, "src/lib.ts"),
+      formats: ["es"],
+      fileName: () => "index.js",
+    },
+    rollupOptions: {
+      external: [
+        "@rlrml/player",
+        "@rlrml/subtr-actor",
+        "camera-controls",
+        "eventemitter3",
+        "three",
+        /^three\//,
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Adds a publishable `@rlrml/viewer` package layout so downstream consumers can depend on the viewer without vendoring its source tree.

- switches the viewer package manifest from source/private metadata to `dist` package metadata
- adds a Vite library build plus declaration emit and package staging script
- adds the `js-viewer-pkg` flake output, parallel to `js-player-pkg`
- includes viewer public assets in the static page bundle so hosted stat/review pages can serve `/models` and `/draco`
- keeps the Nix stat/review page build on the local viewer source without making npm install viewer dev dependencies in the store
- re-exports boost unit helpers from `@rlrml/viewer` for consumers migrating off direct `@rlrml/player` imports

## Validation

- `npm run build:dist` in `js/viewer`
- `npm run prepare:package` in `js/viewer`
- `nix build path:/home/imalison/Projects/rocket-sense-subtr-viewer/vendor/subtr-actor#js-viewer-pkg --out-link /home/imalison/Projects/rocket-sense-subtr-viewer/result-subtr-actor-viewer-pkg-test`
- `nix build path:/home/imalison/Projects/rocket-sense-subtr-viewer/vendor/subtr-actor#js-stats-player-pages --out-link /home/imalison/Projects/rocket-sense-subtr-viewer/result-subtr-actor-static-test`
