### PR TITLE
[codex] Tighten BakkesMod FFI unsafe scopes

### DIFF
--- a/bakkesmod/rust/src/ffi.rs
+++ b/bakkesmod/rust/src/ffi.rs
@@ -76,10 +76,9 @@ pub(crate) fn build_replay_annotations(path: &CStr) -> SubtrActorResult<SaReplay
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotations_create(
     replay_path: *const c_char,
 ) -> *mut SaReplayAnnotations {
-    if replay_path.is_null() {
+    let Some(replay_path) = (unsafe { raw_c_str(replay_path) }) else {
         return ptr::null_mut();
-    }
-    let replay_path = unsafe { CStr::from_ptr(replay_path) };
+    };
     match build_replay_annotations(replay_path) {
         Ok(annotations) => Box::into_raw(Box::new(annotations)),
         Err(_) => ptr::null_mut(),
@@ -92,9 +91,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotations_create(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotations_destroy(
     annotations: *mut SaReplayAnnotations,
 ) {
-    if !annotations.is_null() {
-        drop(unsafe { Box::from_raw(annotations) });
-    }
+    unsafe { drop_raw_box(annotations) };
 }
 
 /// Returns the number of precomputed replay annotation events.
@@ -102,7 +99,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotations_destroy(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_count(
     annotations: *const SaReplayAnnotations,
 ) -> usize {
-    unsafe { annotations.as_ref() }
+    unsafe { raw_ref(annotations) }
         .map(|annotations| annotations.events.len())
         .unwrap_or(0)
 }
@@ -112,7 +109,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_count(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_player_count(
     annotations: *const SaReplayAnnotations,
 ) -> usize {
-    unsafe { annotations.as_ref() }
+    unsafe { raw_ref(annotations) }
         .map(|annotations| annotations.players.len())
         .unwrap_or(0)
 }
@@ -124,17 +121,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_players(
     out_players: *mut SaReplayPlayerInfo,
     max_players: usize,
 ) -> usize {
-    let Some(annotations) = (unsafe { annotations.as_ref() }) else {
+    let Some(annotations) = (unsafe { raw_ref(annotations) }) else {
         return 0;
     };
-    if max_players == 0 || out_players.is_null() {
-        return 0;
-    }
-    let count = annotations.players.len().min(max_players);
-    unsafe {
-        ptr::copy_nonoverlapping(annotations.players.as_ptr(), out_players, count);
-    }
-    count
+    unsafe { copy_to_raw(&annotations.players, out_players, max_players) }
 }
 
 /// Copies replay players and current-frame core stats for replay playback.
@@ -145,7 +135,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_frame_pla
     out_players: *mut SaPlayerFrame,
     max_players: usize,
 ) -> usize {
-    let Some(annotations) = (unsafe { annotations.as_ref() }) else {
+    let Some(annotations) = (unsafe { raw_ref(annotations) }) else {
         return 0;
     };
     if max_players == 0 || out_players.is_null() {
@@ -155,28 +145,30 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_frame_pla
         return 0;
     };
 
-    let count = frame.players.len().min(max_players);
-    for (index, player) in frame.players.iter().take(count).enumerate() {
-        let player_info = annotations.players.get(index);
-        let player_frame = SaPlayerFrame {
-            player_index: player_info
-                .map(|info| info.player_index)
-                .unwrap_or(index as u32),
-            player_name: player_info.map(|info| info.name).unwrap_or(ptr::null()),
-            is_team_0: player.is_team_0 as u8,
-            has_match_stats: 1,
-            match_goals: player.core.goals,
-            match_assists: player.core.assists,
-            match_saves: player.core.saves,
-            match_shots: player.core.shots,
-            match_score: player.core.score,
-            ..SaPlayerFrame::default()
-        };
-        unsafe {
-            *out_players.add(index) = player_frame;
-        }
-    }
-    count
+    let players: Vec<_> = frame
+        .players
+        .iter()
+        .take(max_players)
+        .enumerate()
+        .map(|(index, player)| {
+            let player_info = annotations.players.get(index);
+            SaPlayerFrame {
+                player_index: player_info
+                    .map(|info| info.player_index)
+                    .unwrap_or(index as u32),
+                player_name: player_info.map(|info| info.name).unwrap_or(ptr::null()),
+                is_team_0: player.is_team_0 as u8,
+                has_match_stats: 1,
+                match_goals: player.core.goals,
+                match_assists: player.core.assists,
+                match_saves: player.core.saves,
+                match_shots: player.core.shots,
+                match_score: player.core.score,
+                ..SaPlayerFrame::default()
+            }
+        })
+        .collect();
+    unsafe { copy_to_raw(&players, out_players, max_players) }
 }
 
 pub(crate) fn serialize_replay_annotation_frame(
@@ -197,13 +189,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_frame_json_len(
     annotations: *const SaReplayAnnotations,
     replay_time: f32,
 ) -> usize {
-    unsafe {
-        annotations
-            .as_ref()
-            .and_then(|annotations| serialize_replay_annotation_frame(annotations, replay_time))
-            .map(|bytes| bytes.len())
-            .unwrap_or(0)
-    }
+    unsafe { raw_ref(annotations) }
+        .and_then(|annotations| serialize_replay_annotation_frame(annotations, replay_time))
+        .map(|bytes| bytes.len())
+        .unwrap_or(0)
 }
 
 /// Writes the replay stats frame at `replay_time` into caller-owned storage.
@@ -218,21 +207,13 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_replay_annotation_frame_jso
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        let Some(annotations) = annotations.as_ref() else {
-            return 0;
-        };
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-
-        let Some(bytes) = serialize_replay_annotation_frame(annotations, replay_time) else {
-            return 0;
-        };
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    let Some(annotations) = (unsafe { raw_ref(annotations) }) else {
+        return 0;
+    };
+    let Some(bytes) = serialize_replay_annotation_frame(annotations, replay_time) else {
+        return 0;
+    };
+    unsafe { copy_to_raw(&bytes, out_bytes, max_bytes) }
 }
 
 /// Returns the scoreboard value for the latest processed replay frame at or before
@@ -243,7 +224,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_score_at_time(
     replay_time: f32,
     out_score: *mut SaReplayScore,
 ) -> i32 {
-    let Some(annotations) = (unsafe { annotations.as_ref() }) else {
+    let Some(annotations) = (unsafe { raw_ref(annotations) }) else {
         return -1;
     };
     if out_score.is_null() {
@@ -253,15 +234,21 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_replay_annotation_score_at_time(
         return -2;
     };
 
-    unsafe {
-        *out_score = SaReplayScore {
-            team_zero_score: frame.team_zero.core.goals,
-            has_team_zero_score: 1,
-            team_one_score: frame.team_one.core.goals,
-            has_team_one_score: 1,
-        };
+    if unsafe {
+        write_one(
+            out_score,
+            SaReplayScore {
+                team_zero_score: frame.team_zero.core.goals,
+                has_team_zero_score: 1,
+                team_one_score: frame.team_one.core.goals,
+                has_team_one_score: 1,
+            },
+        )
+    } {
+        0
+    } else {
+        -1
     }
-    0
 }
 
 /// Drains annotation events whose normal replay-processing timestamp has been
@@ -276,7 +263,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_poll_replay_annotations(
     out_events: *mut SaMechanicEvent,
     max_events: usize,
 ) -> usize {
-    let Some(annotations) = (unsafe { annotations.as_mut() }) else {
+    let Some(annotations) = (unsafe { raw_mut(annotations) }) else {
         return 0;
     };
     if max_events == 0 || out_events.is_null() {
@@ -299,19 +286,16 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_poll_replay_annotations(
     annotations.last_poll_time = replay_time;
 
     let max_time = replay_time + LOOKAHEAD_SECONDS;
-    let mut copied = 0;
-    while annotations.cursor < annotations.events.len() && copied < max_events {
+    let start = annotations.cursor;
+    while annotations.cursor < annotations.events.len() && annotations.cursor - start < max_events {
         let event = annotations.events[annotations.cursor];
         if event.time > max_time {
             break;
         }
-        unsafe {
-            out_events.add(copied).write(event);
-        }
         annotations.cursor += 1;
-        copied += 1;
     }
-    copied
+    let events = &annotations.events[start..annotations.cursor];
+    unsafe { copy_to_raw(events, out_events, max_events) }
 }
 
 #[unsafe(no_mangle)]
@@ -322,11 +306,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_poll_replay_annotations(
 /// `engine` must either be null or a pointer returned by
 /// `subtr_actor_bakkesmod_engine_create` that has not already been destroyed.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_engine_destroy(engine: *mut SaEngine) {
-    unsafe {
-        if !engine.is_null() {
-            drop(Box::from_raw(engine));
-        }
-    }
+    unsafe { drop_raw_box(engine) };
 }
 
 #[unsafe(no_mangle)]
@@ -337,10 +317,8 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_engine_destroy(engine: *mut SaEng
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_engine_reset(engine: *mut SaEngine) {
-    unsafe {
-        if let Some(engine) = engine.as_mut() {
-            *engine = SaEngine::default();
-        }
+    if let Some(engine) = unsafe { raw_mut(engine) } {
+        *engine = SaEngine::default();
     }
 }
 
@@ -358,23 +336,21 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_engine_reset(engine: *mut SaEngin
 ///
 /// `engine` must be a valid engine pointer.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_finish(engine: *mut SaEngine) -> i32 {
-    unsafe {
-        let Some(engine) = engine.as_mut() else {
-            return -1;
-        };
-        if !engine.live_replay_meta_initialized {
-            return 0;
-        }
-        if engine.live_graph_finished {
-            return 0;
-        }
-        if engine.graph.finish().is_err() {
-            return -2;
-        }
-        refresh_timeline_graph_state(engine);
-        engine.live_graph_finished = true;
-        0
+    let Some(engine) = (unsafe { raw_mut(engine) }) else {
+        return -1;
+    };
+    if !engine.live_replay_meta_initialized {
+        return 0;
     }
+    if engine.live_graph_finished {
+        return 0;
+    }
+    if engine.graph.finish().is_err() {
+        return -2;
+    }
+    refresh_timeline_graph_state(engine);
+    engine.live_graph_finished = true;
+    0
 }
 
 #[unsafe(no_mangle)]
@@ -392,51 +368,43 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_process_frame(
     engine: *mut SaEngine,
     frame: *const SaLiveFrame,
 ) -> i32 {
-    unsafe {
-        let Some(engine) = engine.as_mut() else {
-            return -1;
-        };
-        let Some(frame) = frame.as_ref() else {
-            return -1;
-        };
-        if frame.players.is_null() && frame.player_count != 0 {
-            return -1;
-        }
-
-        let players = if frame.player_count == 0 {
-            &[]
-        } else {
-            slice::from_raw_parts(frame.players, frame.player_count)
-        };
-        if has_duplicate_player_indices(players) {
-            return -1;
-        }
-        let Ok(explicit_events) = frame_event_slices(frame) else {
-            return -1;
-        };
-        if sync_live_replay_meta(engine, players).is_err() {
-            return -2;
-        }
-        let mut live_events = engine.live_events.clone();
-        let mut live_event_history = engine.live_event_history.clone();
-        let frame_input = frame_input_from_live_state(
-            &mut live_events,
-            &mut live_event_history,
-            engine.live_replay_meta.as_ref(),
-            frame,
-            players,
-            &explicit_events,
-        );
-        if engine.graph.evaluate_with_state(&frame_input).is_err() {
-            return -2;
-        }
-
-        engine.live_events = live_events;
-        engine.live_event_history = live_event_history;
-        engine.live_graph_finished = false;
-        refresh_timeline_graph_state(engine);
-        0
+    let Some(engine) = (unsafe { raw_mut(engine) }) else {
+        return -1;
+    };
+    let Some(frame) = (unsafe { raw_ref(frame) }) else {
+        return -1;
+    };
+    let Ok(players) = (unsafe { checked_slice(frame.players, frame.player_count) }) else {
+        return -1;
+    };
+    if has_duplicate_player_indices(players) {
+        return -1;
     }
+    let Ok(explicit_events) = (unsafe { frame_event_slices(frame) }) else {
+        return -1;
+    };
+    if sync_live_replay_meta(engine, players).is_err() {
+        return -2;
+    }
+    let mut live_events = engine.live_events.clone();
+    let mut live_event_history = engine.live_event_history.clone();
+    let frame_input = frame_input_from_live_state(
+        &mut live_events,
+        &mut live_event_history,
+        engine.live_replay_meta.as_ref(),
+        frame,
+        players,
+        &explicit_events,
+    );
+    if engine.graph.evaluate_with_state(&frame_input).is_err() {
+        return -2;
+    }
+
+    engine.live_events = live_events;
+    engine.live_event_history = live_event_history;
+    engine.live_graph_finished = false;
+    refresh_timeline_graph_state(engine);
+    0
 }
 
 #[unsafe(no_mangle)]
@@ -449,12 +417,9 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_process_frame(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_event_count(
     engine: *const SaEngine,
 ) -> usize {
-    unsafe {
-        engine
-            .as_ref()
-            .map(|engine| engine.pending_events.len())
-            .unwrap_or(0)
-    }
+    unsafe { raw_ref(engine) }
+        .map(|engine| engine.pending_events.len())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
@@ -467,12 +432,9 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_event_count(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_team_event_count(
     engine: *const SaEngine,
 ) -> usize {
-    unsafe {
-        engine
-            .as_ref()
-            .map(|engine| engine.pending_team_events.len())
-            .unwrap_or(0)
-    }
+    unsafe { raw_ref(engine) }
+        .map(|engine| engine.pending_team_events.len())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
@@ -485,12 +447,9 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_team_event_count(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_goal_context_event_count(
     engine: *const SaEngine,
 ) -> usize {
-    unsafe {
-        engine
-            .as_ref()
-            .map(|engine| engine.pending_goal_context_events.len())
-            .unwrap_or(0)
-    }
+    unsafe { raw_ref(engine) }
+        .map(|engine| engine.pending_goal_context_events.len())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
@@ -506,10 +465,9 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_pending_goal_context_event_count(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_decoded_stats_player_config_json_len(
     encoded_config: *const c_char,
 ) -> usize {
-    if encoded_config.is_null() {
+    let Some(encoded_config) = (unsafe { raw_c_str(encoded_config) }) else {
         return 0;
-    }
-    let encoded_config = unsafe { CStr::from_ptr(encoded_config) };
+    };
     decode_stats_player_config_json(encoded_config)
         .map(|bytes| bytes.len())
         .unwrap_or(0)
@@ -531,18 +489,13 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_decoded_stats_player_config
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        if encoded_config.is_null() || out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-        let encoded_config = CStr::from_ptr(encoded_config);
-        let Some(bytes) = decode_stats_player_config_json(encoded_config) else {
-            return 0;
-        };
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    let Some(encoded_config) = (unsafe { raw_c_str(encoded_config) }) else {
+        return 0;
+    };
+    let Some(bytes) = decode_stats_player_config_json(encoded_config) else {
+        return 0;
+    };
+    unsafe { copy_to_raw(&bytes, out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -558,10 +511,9 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_decoded_stats_player_config
 pub unsafe extern "C" fn subtr_actor_bakkesmod_encoded_stats_player_config_len(
     json_config: *const c_char,
 ) -> usize {
-    if json_config.is_null() {
+    let Some(json_config) = (unsafe { raw_c_str(json_config) }) else {
         return 0;
-    }
-    let json_config = unsafe { CStr::from_ptr(json_config) };
+    };
     encode_stats_player_config_json(json_config)
         .map(|bytes| bytes.len())
         .unwrap_or(0)
@@ -583,16 +535,11 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_encoded_stats_player_config
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        if json_config.is_null() || out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-        let json_config = CStr::from_ptr(json_config);
-        let Some(bytes) = encode_stats_player_config_json(json_config) else {
-            return 0;
-        };
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    let Some(json_config) = (unsafe { raw_c_str(json_config) }) else {
+        return 0;
+    };
+    let Some(bytes) = encode_stats_player_config_json(json_config) else {
+        return 0;
+    };
+    unsafe { copy_to_raw(&bytes, out_bytes, max_bytes) }
 }

--- a/bakkesmod/rust/src/ffi_graph_output.rs
+++ b/bakkesmod/rust/src/ffi_graph_output.rs
@@ -1,5 +1,41 @@
 use super::*;
 
+unsafe fn live_graph_output_len(engine: *const SaEngine, output_name: &str) -> usize {
+    unsafe { raw_ref(engine) }
+        .and_then(|engine| serialize_live_graph_output(engine, output_name))
+        .map(|bytes| bytes.len())
+        .unwrap_or(0)
+}
+
+unsafe fn write_live_graph_output(
+    engine: *const SaEngine,
+    output_name: &str,
+    out_bytes: *mut u8,
+    max_bytes: usize,
+) -> usize {
+    let Some(engine) = (unsafe { raw_ref(engine) }) else {
+        return 0;
+    };
+    let Some(bytes) = serialize_live_graph_output(engine, output_name) else {
+        return 0;
+    };
+    unsafe { copy_to_raw(&bytes, out_bytes, max_bytes) }
+}
+
+unsafe fn write_bytes(bytes: &[u8], out_bytes: *mut u8, max_bytes: usize) -> usize {
+    unsafe { copy_to_raw(bytes, out_bytes, max_bytes) }
+}
+
+unsafe fn drain_pending<T: Copy>(
+    pending: &mut Vec<T>,
+    out_events: *mut T,
+    max_events: usize,
+) -> usize {
+    let count = unsafe { copy_to_raw(pending, out_events, max_events) };
+    pending.drain(..count);
+    count
+}
+
 #[unsafe(no_mangle)]
 /// Returns the UTF-8 byte length of the current serialized graph event bundle.
 ///
@@ -11,13 +47,7 @@ use super::*;
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_events_json_len(engine: *const SaEngine) -> usize {
-    unsafe {
-        engine
-            .as_ref()
-            .and_then(|engine| serialize_live_graph_output(engine, "events"))
-            .map(|bytes| bytes.len())
-            .unwrap_or(0)
-    }
+    unsafe { live_graph_output_len(engine, "events") }
 }
 
 #[unsafe(no_mangle)]
@@ -35,21 +65,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_events_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return 0;
-        };
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-
-        let Some(bytes) = serialize_live_graph_output(engine, "events") else {
-            return 0;
-        };
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    unsafe { write_live_graph_output(engine, "events", out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -63,13 +79,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_events_json(
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_frame_json_len(engine: *const SaEngine) -> usize {
-    unsafe {
-        engine
-            .as_ref()
-            .and_then(|engine| serialize_live_graph_output(engine, "frame"))
-            .map(|bytes| bytes.len())
-            .unwrap_or(0)
-    }
+    unsafe { live_graph_output_len(engine, "frame") }
 }
 
 #[unsafe(no_mangle)]
@@ -87,21 +97,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_frame_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return 0;
-        };
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-
-        let Some(bytes) = serialize_live_graph_output(engine, "frame") else {
-            return 0;
-        };
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    unsafe { write_live_graph_output(engine, "frame", out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -116,13 +112,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_frame_json(
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_timeline_json_len(engine: *const SaEngine) -> usize {
-    unsafe {
-        engine
-            .as_ref()
-            .and_then(|engine| serialize_live_graph_output(engine, "timeline"))
-            .map(|bytes| bytes.len())
-            .unwrap_or(0)
-    }
+    unsafe { live_graph_output_len(engine, "timeline") }
 }
 
 #[unsafe(no_mangle)]
@@ -141,21 +131,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_timeline_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return 0;
-        };
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-
-        let Some(bytes) = serialize_live_graph_output(engine, "timeline") else {
-            return 0;
-        };
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    unsafe { write_live_graph_output(engine, "timeline", out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -171,13 +147,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_timeline_json(
 /// `engine` must either be null or a valid pointer returned by
 /// `subtr_actor_bakkesmod_engine_create`.
 pub unsafe extern "C" fn subtr_actor_bakkesmod_stats_json_len(engine: *const SaEngine) -> usize {
-    unsafe {
-        engine
-            .as_ref()
-            .and_then(|engine| serialize_live_graph_output(engine, "stats"))
-            .map(|bytes| bytes.len())
-            .unwrap_or(0)
-    }
+    unsafe { live_graph_output_len(engine, "stats") }
 }
 
 #[unsafe(no_mangle)]
@@ -195,21 +165,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_stats_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return 0;
-        };
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-
-        let Some(bytes) = serialize_live_graph_output(engine, "stats") else {
-            return 0;
-        };
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    unsafe { write_live_graph_output(engine, "stats", out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -248,15 +204,8 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_stats_module_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-        let bytes = serialize_named_stats_module(engine, module_name);
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    let bytes = unsafe { serialize_named_stats_module(engine, module_name) };
+    unsafe { write_bytes(&bytes, out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -295,15 +244,8 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_stats_module_frame_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-        let bytes = serialize_named_stats_module_frame(engine, module_name);
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    let bytes = unsafe { serialize_named_stats_module_frame(engine, module_name) };
+    unsafe { write_bytes(&bytes, out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -342,15 +284,8 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_stats_module_config_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-        let bytes = serialize_named_stats_module_config(engine, module_name);
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    let bytes = unsafe { serialize_named_stats_module_config(engine, module_name) };
+    unsafe { write_bytes(&bytes, out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -369,17 +304,15 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_graph_output_json_len(
     engine: *const SaEngine,
     output_name: *const c_char,
 ) -> usize {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return 0;
-        };
-        let Some(output_name) = c_string_arg(output_name) else {
-            return 0;
-        };
-        serialize_live_graph_output(engine, &output_name)
-            .map(|bytes| bytes.len())
-            .unwrap_or(0)
-    }
+    let Some(engine) = (unsafe { raw_ref(engine) }) else {
+        return 0;
+    };
+    let Some(output_name) = (unsafe { c_string_arg(output_name) }) else {
+        return 0;
+    };
+    serialize_live_graph_output(engine, &output_name)
+        .map(|bytes| bytes.len())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
@@ -400,23 +333,16 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_graph_output_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return 0;
-        };
-        let Some(output_name) = c_string_arg(output_name) else {
-            return 0;
-        };
-        let Some(bytes) = serialize_live_graph_output(engine, &output_name) else {
-            return 0;
-        };
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    let Some(engine) = (unsafe { raw_ref(engine) }) else {
+        return 0;
+    };
+    let Some(output_name) = (unsafe { c_string_arg(output_name) }) else {
+        return 0;
+    };
+    let Some(bytes) = serialize_live_graph_output(engine, &output_name) else {
+        return 0;
+    };
+    unsafe { write_bytes(&bytes, out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -457,15 +383,8 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_analysis_node_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        let bytes = serialize_named_analysis_node(engine, node_name);
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    let bytes = unsafe { serialize_named_analysis_node(engine, node_name) };
+    unsafe { write_bytes(&bytes, out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -481,7 +400,7 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_analysis_node_json(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_analysis_node_names_json_len(
     engine: *const SaEngine,
 ) -> usize {
-    serialize_analysis_node_names(engine).len()
+    unsafe { serialize_analysis_node_names(engine).len() }
 }
 
 #[unsafe(no_mangle)]
@@ -500,15 +419,8 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_analysis_node_names_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        let bytes = serialize_analysis_node_names(engine);
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-        let count = max_bytes.min(bytes.len());
-        ptr::copy_nonoverlapping(bytes.as_ptr(), out_bytes, count);
-        count
-    }
+    let bytes = unsafe { serialize_analysis_node_names(engine) };
+    unsafe { write_bytes(&bytes, out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -524,12 +436,9 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_analysis_node_names_json(
 pub unsafe extern "C" fn subtr_actor_bakkesmod_graph_info_json_len(
     engine: *const SaEngine,
 ) -> usize {
-    unsafe {
-        engine
-            .as_ref()
-            .map(|engine| engine.graph_info_json.len())
-            .unwrap_or(0)
-    }
+    unsafe { raw_ref(engine) }
+        .map(|engine| engine.graph_info_json.len())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
@@ -548,18 +457,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_write_graph_info_json(
     out_bytes: *mut u8,
     max_bytes: usize,
 ) -> usize {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return 0;
-        };
-        if out_bytes.is_null() || max_bytes == 0 {
-            return 0;
-        }
-
-        let count = max_bytes.min(engine.graph_info_json.len());
-        ptr::copy_nonoverlapping(engine.graph_info_json.as_ptr(), out_bytes, count);
-        count
-    }
+    let Some(engine) = (unsafe { raw_ref(engine) }) else {
+        return 0;
+    };
+    unsafe { write_bytes(&engine.graph_info_json, out_bytes, max_bytes) }
 }
 
 #[unsafe(no_mangle)]
@@ -576,19 +477,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_drain_events(
     out_events: *mut SaMechanicEvent,
     max_events: usize,
 ) -> usize {
-    unsafe {
-        let Some(engine) = engine.as_mut() else {
-            return 0;
-        };
-        if out_events.is_null() || max_events == 0 {
-            return 0;
-        }
-
-        let count = max_events.min(engine.pending_events.len());
-        ptr::copy_nonoverlapping(engine.pending_events.as_ptr(), out_events, count);
-        engine.pending_events.drain(..count);
-        count
-    }
+    let Some(engine) = (unsafe { raw_mut(engine) }) else {
+        return 0;
+    };
+    unsafe { drain_pending(&mut engine.pending_events, out_events, max_events) }
 }
 
 #[unsafe(no_mangle)]
@@ -605,19 +497,10 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_drain_team_events(
     out_events: *mut SaTeamEvent,
     max_events: usize,
 ) -> usize {
-    unsafe {
-        let Some(engine) = engine.as_mut() else {
-            return 0;
-        };
-        if out_events.is_null() || max_events == 0 {
-            return 0;
-        }
-
-        let count = max_events.min(engine.pending_team_events.len());
-        ptr::copy_nonoverlapping(engine.pending_team_events.as_ptr(), out_events, count);
-        engine.pending_team_events.drain(..count);
-        count
-    }
+    let Some(engine) = (unsafe { raw_mut(engine) }) else {
+        return 0;
+    };
+    unsafe { drain_pending(&mut engine.pending_team_events, out_events, max_events) }
 }
 
 #[unsafe(no_mangle)]
@@ -634,21 +517,14 @@ pub unsafe extern "C" fn subtr_actor_bakkesmod_drain_goal_context_events(
     out_events: *mut SaGoalContextEvent,
     max_events: usize,
 ) -> usize {
+    let Some(engine) = (unsafe { raw_mut(engine) }) else {
+        return 0;
+    };
     unsafe {
-        let Some(engine) = engine.as_mut() else {
-            return 0;
-        };
-        if out_events.is_null() || max_events == 0 {
-            return 0;
-        }
-
-        let count = max_events.min(engine.pending_goal_context_events.len());
-        ptr::copy_nonoverlapping(
-            engine.pending_goal_context_events.as_ptr(),
+        drain_pending(
+            &mut engine.pending_goal_context_events,
             out_events,
-            count,
-        );
-        engine.pending_goal_context_events.drain(..count);
-        count
+            max_events,
+        )
     }
 }

--- a/bakkesmod/rust/src/ffi_raw.rs
+++ b/bakkesmod/rust/src/ffi_raw.rs
@@ -1,0 +1,77 @@
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::{ptr, slice};
+
+pub(crate) unsafe fn raw_ref<'a, T>(value: *const T) -> Option<&'a T> {
+    // SAFETY: The caller guarantees that any non-null pointer is valid for
+    // shared access for the returned lifetime.
+    unsafe { value.as_ref() }
+}
+
+pub(crate) unsafe fn raw_mut<'a, T>(value: *mut T) -> Option<&'a mut T> {
+    // SAFETY: The caller guarantees that any non-null pointer is valid for
+    // unique mutable access for the returned lifetime.
+    unsafe { value.as_mut() }
+}
+
+pub(crate) unsafe fn raw_c_str<'a>(value: *const c_char) -> Option<&'a CStr> {
+    if value.is_null() {
+        return None;
+    }
+    // SAFETY: The caller guarantees `value` points to a valid null-terminated
+    // C string.
+    Some(unsafe { CStr::from_ptr(value) })
+}
+
+pub(crate) unsafe fn raw_c_string(value: *const c_char) -> Option<String> {
+    // SAFETY: Forwarding the caller's C-string validity guarantee.
+    unsafe { raw_c_str(value) }?
+        .to_str()
+        .ok()
+        .map(str::to_owned)
+}
+
+pub(crate) unsafe fn raw_slice<'a, T>(items: *const T, count: usize) -> Result<&'a [T], ()> {
+    if items.is_null() && count != 0 {
+        return Err(());
+    }
+    if count == 0 {
+        Ok(&[])
+    } else {
+        // SAFETY: The caller guarantees `items` points to at least `count`
+        // initialized elements.
+        Ok(unsafe { slice::from_raw_parts(items, count) })
+    }
+}
+
+pub(crate) unsafe fn write_one<T>(out: *mut T, value: T) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    // SAFETY: The caller guarantees `out` is valid writable storage for one T.
+    unsafe {
+        out.write(value);
+    }
+    true
+}
+
+pub(crate) unsafe fn copy_to_raw<T: Copy>(items: &[T], out: *mut T, max_items: usize) -> usize {
+    if out.is_null() || max_items == 0 {
+        return 0;
+    }
+    let count = items.len().min(max_items);
+    // SAFETY: The caller guarantees `out` points to writable storage for at
+    // least `max_items` elements. `count` is bounded by `max_items`.
+    unsafe {
+        ptr::copy_nonoverlapping(items.as_ptr(), out, count);
+    }
+    count
+}
+
+pub(crate) unsafe fn drop_raw_box<T>(value: *mut T) {
+    if !value.is_null() {
+        // SAFETY: The caller guarantees `value` came from Box::into_raw and has
+        // not already been freed.
+        drop(unsafe { Box::from_raw(value) });
+    }
+}

--- a/bakkesmod/rust/src/graph_output.rs
+++ b/bakkesmod/rust/src/graph_output.rs
@@ -64,17 +64,15 @@ pub(crate) unsafe fn serialize_named_analysis_node(
     engine: *const SaEngine,
     node_name: *const c_char,
 ) -> Vec<u8> {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return Vec::new();
-        };
-        let Some(node_name) = c_string_arg(node_name) else {
-            return Vec::new();
-        };
-        match builtin_analysis_node_json(&node_name, &engine.graph) {
-            Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
-            Err(_) => Vec::new(),
-        }
+    let Some(engine) = (unsafe { raw_ref(engine) }) else {
+        return Vec::new();
+    };
+    let Some(node_name) = (unsafe { c_string_arg(node_name) }) else {
+        return Vec::new();
+    };
+    match builtin_analysis_node_json(&node_name, &engine.graph) {
+        Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
+        Err(_) => Vec::new(),
     }
 }
 
@@ -98,37 +96,30 @@ pub(crate) fn callable_analysis_node_names(engine: &SaEngine) -> Vec<String> {
     callable_analysis_node_names_for_graph(&engine.graph)
 }
 
-pub(crate) fn serialize_analysis_node_names(engine: *const SaEngine) -> Vec<u8> {
-    let Some(engine) = (unsafe { engine.as_ref() }) else {
+pub(crate) unsafe fn serialize_analysis_node_names(engine: *const SaEngine) -> Vec<u8> {
+    let Some(engine) = (unsafe { raw_ref(engine) }) else {
         return Vec::new();
     };
     serde_json::to_vec(&callable_analysis_node_names(engine)).unwrap_or_default()
 }
 
 pub(crate) unsafe fn c_string_arg(value: *const c_char) -> Option<String> {
-    unsafe {
-        if value.is_null() {
-            return None;
-        }
-        CStr::from_ptr(value).to_str().ok().map(str::to_owned)
-    }
+    unsafe { raw_c_string(value) }
 }
 
 pub(crate) unsafe fn serialize_named_stats_module(
     engine: *const SaEngine,
     module_name: *const c_char,
 ) -> Vec<u8> {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return Vec::new();
-        };
-        let Some(module_name) = c_string_arg(module_name) else {
-            return Vec::new();
-        };
-        match builtin_stats_module_json(&module_name, &engine.graph) {
-            Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
-            Err(_) => Vec::new(),
-        }
+    let Some(engine) = (unsafe { raw_ref(engine) }) else {
+        return Vec::new();
+    };
+    let Some(module_name) = (unsafe { c_string_arg(module_name) }) else {
+        return Vec::new();
+    };
+    match builtin_stats_module_json(&module_name, &engine.graph) {
+        Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
+        Err(_) => Vec::new(),
     }
 }
 
@@ -136,20 +127,18 @@ pub(crate) unsafe fn serialize_named_stats_module_frame(
     engine: *const SaEngine,
     module_name: *const c_char,
 ) -> Vec<u8> {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return Vec::new();
-        };
-        let Some(module_name) = c_string_arg(module_name) else {
-            return Vec::new();
-        };
-        let Some(replay_meta) = engine.live_replay_meta.as_ref() else {
-            return Vec::new();
-        };
-        match builtin_stats_module_frame_json(&module_name, &engine.graph, replay_meta) {
-            Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
-            Err(_) => Vec::new(),
-        }
+    let Some(engine) = (unsafe { raw_ref(engine) }) else {
+        return Vec::new();
+    };
+    let Some(module_name) = (unsafe { c_string_arg(module_name) }) else {
+        return Vec::new();
+    };
+    let Some(replay_meta) = engine.live_replay_meta.as_ref() else {
+        return Vec::new();
+    };
+    match builtin_stats_module_frame_json(&module_name, &engine.graph, replay_meta) {
+        Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
+        Err(_) => Vec::new(),
     }
 }
 
@@ -157,17 +146,15 @@ pub(crate) unsafe fn serialize_named_stats_module_config(
     engine: *const SaEngine,
     module_name: *const c_char,
 ) -> Vec<u8> {
-    unsafe {
-        let Some(engine) = engine.as_ref() else {
-            return Vec::new();
-        };
-        let Some(module_name) = c_string_arg(module_name) else {
-            return Vec::new();
-        };
-        match builtin_stats_module_config_json(&module_name, &engine.graph) {
-            Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
-            Err(_) => Vec::new(),
-        }
+    let Some(engine) = (unsafe { raw_ref(engine) }) else {
+        return Vec::new();
+    };
+    let Some(module_name) = (unsafe { c_string_arg(module_name) }) else {
+        return Vec::new();
+    };
+    match builtin_stats_module_config_json(&module_name, &engine.graph) {
+        Ok(value) => serde_json::to_vec(&value).unwrap_or_default(),
+        Err(_) => Vec::new(),
     }
 }
 

--- a/bakkesmod/rust/src/lib.rs
+++ b/bakkesmod/rust/src/lib.rs
@@ -6,6 +6,7 @@ use std::ffi::{CStr, CString};
 use std::io::{Read, Write};
 use std::os::raw::c_char;
 use std::ptr;
+#[cfg(test)]
 use std::slice;
 
 use base64::Engine as _;
@@ -45,6 +46,7 @@ use subtr_actor::{GoalTag, GoalTagMetadata};
 mod abi;
 mod ffi;
 mod ffi_graph_output;
+mod ffi_raw;
 mod graph_output;
 mod live_events;
 mod live_processor;
@@ -53,6 +55,7 @@ mod timeline_drain;
 pub use abi::*;
 pub use ffi::*;
 pub use ffi_graph_output::*;
+pub(crate) use ffi_raw::*;
 pub(crate) use graph_output::*;
 pub(crate) use live_events::*;
 pub(crate) use live_processor::*;

--- a/bakkesmod/rust/src/live_processor.rs
+++ b/bakkesmod/rust/src/live_processor.rs
@@ -66,32 +66,25 @@ impl<'a> SaLiveProcessorView<'a> {
 }
 
 pub(crate) unsafe fn checked_slice<'a, T>(items: *const T, count: usize) -> Result<&'a [T], ()> {
-    unsafe {
-        if items.is_null() && count != 0 {
-            return Err(());
-        }
-        if count == 0 {
-            Ok(&[])
-        } else {
-            Ok(slice::from_raw_parts(items, count))
-        }
-    }
+    // SAFETY: Forwarding the caller's slice validity guarantee.
+    unsafe { raw_slice(items, count) }
 }
 
 pub(crate) unsafe fn frame_event_slices(frame: &SaLiveFrame) -> Result<SaFrameEventSlices<'_>, ()> {
-    unsafe {
-        Ok(SaFrameEventSlices {
-            touches: checked_slice(frame.touches, frame.touch_count)?,
-            dodge_refreshes: checked_slice(frame.dodge_refreshes, frame.dodge_refresh_count)?,
-            boost_pad_events: checked_slice(frame.boost_pad_events, frame.boost_pad_event_count)?,
-            goals: checked_slice(frame.goals, frame.goal_count)?,
-            player_stat_events: checked_slice(
-                frame.player_stat_events,
-                frame.player_stat_event_count,
-            )?,
-            demolishes: checked_slice(frame.demolishes, frame.demolish_count)?,
-        })
-    }
+    Ok(SaFrameEventSlices {
+        touches: unsafe { checked_slice(frame.touches, frame.touch_count) }?,
+        dodge_refreshes: unsafe {
+            checked_slice(frame.dodge_refreshes, frame.dodge_refresh_count)
+        }?,
+        boost_pad_events: unsafe {
+            checked_slice(frame.boost_pad_events, frame.boost_pad_event_count)
+        }?,
+        goals: unsafe { checked_slice(frame.goals, frame.goal_count) }?,
+        player_stat_events: unsafe {
+            checked_slice(frame.player_stat_events, frame.player_stat_event_count)
+        }?,
+        demolishes: unsafe { checked_slice(frame.demolishes, frame.demolish_count) }?,
+    })
 }
 
 impl ProcessorView for SaLiveProcessorView<'_> {


### PR DESCRIPTION
## Summary

- centralize BakkesMod FFI raw pointer conversions, raw slice creation, raw copies, and raw box drops in `ffi_raw`
- replace repeated broad unsafe blocks in exported FFI functions with narrow helper calls
- keep required Rust 2024 `#[unsafe(no_mangle)]` annotations and unsafe extern entry points where caller-provided raw pointers remain part of the ABI contract

## Validation

- `cargo fmt --check`
- `RUSTFLAGS='-Wrust-2024-compatibility' cargo check --workspace`\n- `cargo test -p subtr-actor-bakkesmod`\n- `cargo clippy --all-targets --all-features -- -D warnings`