### PR TITLE
[codex] Match Ballcam replay and camera smoothing

### DIFF
--- a/js/viewer/scripts/compare-ballcam-rlrf.mts
+++ b/js/viewer/scripts/compare-ballcam-rlrf.mts
@@ -1,0 +1,682 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import initSubtr from "@rlrml/subtr-actor";
+import { loadReplay } from "../src/adapter/wasm.js";
+import { SubtrActorPlayer, type MotionKeyframe } from "../src/adapter/SubtrActorPlayer.js";
+
+type Vec3 = { x: number; y: number; z: number };
+
+interface BinaryTimeline {
+  times: Float32Array;
+  positions: Float32Array;
+  velocities: Float32Array;
+  rotations: Float32Array;
+  angularVelocities: Float32Array;
+  sleeping: Uint8Array;
+}
+
+interface DecodedRlrf {
+  version: number;
+  header: Record<string, unknown>;
+  ballTimeline: BinaryTimeline;
+  playerTimelines: Record<string, BinaryTimeline>;
+}
+
+interface TimeAnchor {
+  frame: number;
+  ballcamTime: number;
+  adapterTime: number;
+}
+
+interface ReplayGap {
+  beforeFrame: number;
+  afterFrame: number;
+  beforeTime: number;
+  afterTime: number;
+  duration: number;
+}
+
+interface BallcamCompaction {
+  gaps: ReplayGap[];
+  prematchEndTime: number | null;
+  rawDuration: number;
+  compactedDuration: number;
+}
+
+const DEFAULT_REPLAY_ID = "6edf95bb-f39c-45e4-ac1a-4bbbb871d574";
+const SCRIPT_DIR = new URL(".", import.meta.url);
+const VIEWER_DIR = new URL("..", SCRIPT_DIR);
+const REPO_ROOT = new URL("../..", VIEWER_DIR);
+const DEFAULT_RLRF = fileURLToPath(
+  new URL(`.cache/ballcam/${DEFAULT_REPLAY_ID}.rlrf`, REPO_ROOT),
+);
+const DEFAULT_REPLAY = fileURLToPath(
+  new URL(".cache/ballcam/5358ED3A11F16434F5C4C298BCD7229C.replay", REPO_ROOT),
+);
+const WASM_PATH = fileURLToPath(
+  new URL("./node_modules/@rlrml/subtr-actor/rl_replay_subtr_actor_bg.wasm", VIEWER_DIR),
+);
+
+const args = parseArgs(process.argv.slice(2));
+const rlrfPath = args.rlrf ?? DEFAULT_RLRF;
+const replayPath = args.replay ?? DEFAULT_REPLAY;
+
+await initSubtr(readFileSync(WASM_PATH));
+
+const rlrf = decodeRlrf(readFileSync(rlrfPath));
+const replayBytes = new Uint8Array(readFileSync(replayPath));
+const { raw } = await loadReplay(replayBytes);
+const compaction = buildBallcamCompaction(raw as never);
+
+console.log("== inputs ==");
+console.log(`  rlrf:   ${rlrfPath}`);
+console.log(`  replay: ${replayPath}`);
+
+console.log("\n== ballcam rlrf ==");
+const metadata = objectRecord(rlrf.header.metadata);
+console.log(`  version: ${rlrf.version}`);
+console.log(`  frameworkVersion: ${metadata.frameworkVersion ?? "(missing)"}`);
+console.log(`  duration: ${fmtNumber(metadata.duration)}s`);
+console.log(`  frameCount: ${metadata.frameCount ?? "(missing)"}`);
+console.log(`  players: ${Object.keys(rlrf.playerTimelines).join(", ")}`);
+printTimelineSummary("ball", rlrf.ballTimeline);
+for (const [name, timeline] of Object.entries(rlrf.playerTimelines)) {
+  printTimelineSummary(name, timeline);
+}
+
+console.log("\n== inferred ballcam compaction from subtr-actor raw ==");
+console.log(`  rawDuration: ${compaction.rawDuration.toFixed(6)}s`);
+console.log(`  compactedDuration: ${compaction.compactedDuration.toFixed(6)}s`);
+console.log(
+  `  prematchEndTime: ${
+    compaction.prematchEndTime == null ? "(none)" : `${compaction.prematchEndTime.toFixed(6)}s`
+  }`,
+);
+console.log(
+  `  gaps: ${
+    compaction.gaps.length === 0
+      ? "(none)"
+      : compaction.gaps
+          .map(
+            (gap) =>
+              `f${gap.beforeFrame}->f${gap.afterFrame} ${gap.duration.toFixed(6)}s`,
+          )
+          .join(", ")
+  }`,
+);
+
+const variants = [
+  {
+    label: "adapter default",
+    options: {},
+    compactByAdapter: false,
+  },
+  {
+    label: "adapter timelineCompaction",
+    options: { timelineCompaction: true },
+    compactByAdapter: true,
+  },
+  {
+    label: "adapter raw/no-filter",
+    options: { motionSmoothing: false, disableFrameFiltering: true },
+    compactByAdapter: false,
+  },
+] as const;
+
+for (const variant of variants) {
+  const player = new SubtrActorPlayer(raw as never, variant.options);
+  const timelines = player.getTimelines();
+  const anchors = buildTimeAnchors(rlrf.header, player.frameTimes);
+  const timeMapper = createSparseTimeMapper(anchors, player.duration);
+
+  console.log(`\n== ${variant.label} =`);
+  console.log(`  duration: ${player.duration.toFixed(6)}s`);
+  console.log(`  rawStartTime: ${player.rawStartTime.toFixed(6)}s`);
+  console.log(`  frameTimes: ${player.frameTimes.length}`);
+  console.log(`  players: ${player.playerList.map((p) => p.name).join(", ")}`);
+  printMotionSummary("ball", timelines.ballTimeline);
+  for (const [name, timeline] of Object.entries(timelines.playerTimelines)) {
+    printMotionSummary(name, timeline);
+  }
+
+  console.log("\n  -- sampled position error vs rlrf --");
+  printComparison("ball direct", compareTimelines(rlrf.ballTimeline, timelines.ballTimeline));
+  if (!variant.compactByAdapter) {
+    printComparison(
+      "ball compacted",
+      compareTimelines(
+        rlrf.ballTimeline,
+        compactMotionTimeline(timelines.ballTimeline, compaction),
+      ),
+    );
+  }
+  printComparison(
+    "ball sparse-remap",
+    compareTimelines(rlrf.ballTimeline, timelines.ballTimeline, timeMapper),
+  );
+  for (const [name, ballcamTimeline] of Object.entries(rlrf.playerTimelines)) {
+    const adapterTimeline = timelines.playerTimelines[name];
+    if (!adapterTimeline) {
+      console.log(`    ${name}: missing from adapter`);
+      continue;
+    }
+    printComparison(`${name} direct`, compareTimelines(ballcamTimeline, adapterTimeline));
+    if (!variant.compactByAdapter) {
+      printComparison(
+        `${name} compacted`,
+        compareTimelines(ballcamTimeline, compactMotionTimeline(adapterTimeline, compaction)),
+      );
+    }
+    printComparison(
+      `${name} sparse-remap`,
+      compareTimelines(ballcamTimeline, adapterTimeline, timeMapper),
+    );
+  }
+
+  console.log("\n  -- gameEventTimeline frame/time anchors --");
+  if (anchors.length === 0) {
+    console.log("    no comparable anchors found");
+  } else {
+    console.log(`    anchors: ${anchors.length}`);
+    for (const anchor of anchors.slice(0, 14)) {
+      const removed = anchor.adapterTime - anchor.ballcamTime;
+      console.log(
+        `    frame ${anchor.frame.toString().padStart(5)}  ballcam=${anchor.ballcamTime
+          .toFixed(6)
+          .padStart(11)}  adapter=${anchor.adapterTime
+          .toFixed(6)
+          .padStart(11)}  removed=${removed.toFixed(6).padStart(10)}`,
+      );
+    }
+    const last = anchors[anchors.length - 1]!;
+    console.log(
+      `    last frame ${last.frame}: ballcam=${last.ballcamTime.toFixed(
+        6,
+      )} adapter=${last.adapterTime.toFixed(6)} removed=${(
+        last.adapterTime - last.ballcamTime
+      ).toFixed(6)}`,
+    );
+  }
+}
+
+function parseArgs(rawArgs: string[]): Record<string, string | undefined> {
+  const parsed: Record<string, string | undefined> = {};
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index]!;
+    if (arg === "--rlrf") parsed.rlrf = rawArgs[++index];
+    else if (arg === "--replay") parsed.replay = rawArgs[++index];
+    else if (arg === "--help" || arg === "-h") {
+      console.log(
+        [
+          "Usage: npx tsx scripts/compare-ballcam-rlrf.mts [--rlrf path] [--replay path]",
+          "",
+          "Defaults compare the downloaded ballcam.tv fixture in .cache/ballcam/.",
+        ].join("\n"),
+      );
+      process.exit(0);
+    }
+  }
+  return parsed;
+}
+
+function decodeRlrf(bytes: Buffer): DecodedRlrf {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const u8 = new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = 0;
+
+  const magic = view.getUint32(offset, true);
+  offset += 4;
+  if (magic !== 0x524c5246) {
+    throw new Error(`Invalid RLRF magic 0x${magic.toString(16)}`);
+  }
+
+  const version = view.getUint32(offset, true);
+  offset += 4;
+
+  const headerLength = view.getUint32(offset, true);
+  offset += 4;
+  const header = JSON.parse(new TextDecoder().decode(u8.subarray(offset, offset + headerLength)));
+  offset += headerLength;
+
+  const [ballTimeline, afterBall] = readTimeline(view, u8, offset);
+  offset = afterBall;
+
+  const playerCount = view.getUint32(offset, true);
+  offset += 4;
+  const playerTimelines: Record<string, BinaryTimeline> = {};
+  for (let index = 0; index < playerCount; index += 1) {
+    const [name, afterName] = readString(view, u8, offset);
+    offset = afterName;
+    const [timeline, afterTimeline] = readPlayerTimeline(view, u8, offset);
+    offset = afterTimeline;
+    playerTimelines[name] = timeline;
+  }
+
+  return { version, header, ballTimeline, playerTimelines };
+}
+
+function readString(
+  view: DataView,
+  u8: Uint8Array,
+  offset: number,
+): [value: string, offset: number] {
+  const length = view.getUint32(offset, true);
+  offset += 4;
+  const value = new TextDecoder().decode(u8.subarray(offset, offset + length));
+  return [value, offset + length];
+}
+
+function readTimeline(
+  view: DataView,
+  u8: Uint8Array,
+  offset: number,
+): [timeline: BinaryTimeline, offset: number] {
+  const count = view.getUint32(offset, true);
+  offset += 4;
+  const [times, afterTimes] = readFloat32Array(view, offset, count);
+  offset = afterTimes;
+  const [positions, afterPositions] = readFloat32Array(view, offset, count * 3);
+  offset = afterPositions;
+  const [velocities, afterVelocities] = readFloat32Array(view, offset, count * 3);
+  offset = afterVelocities;
+  const [rotations, afterRotations] = readFloat32Array(view, offset, count * 4);
+  offset = afterRotations;
+  const [angularVelocities, afterAngularVelocities] = readFloat32Array(view, offset, count * 3);
+  offset = afterAngularVelocities;
+  const sleeping = new Uint8Array(count);
+  sleeping.set(u8.subarray(offset, offset + count));
+  offset += count;
+  return [{ times, positions, velocities, rotations, angularVelocities, sleeping }, offset];
+}
+
+function readPlayerTimeline(
+  view: DataView,
+  u8: Uint8Array,
+  offset: number,
+): [timeline: BinaryTimeline, offset: number] {
+  const [timeline, afterMotion] = readTimeline(view, u8, offset);
+  offset = afterMotion;
+
+  const count = timeline.times.length;
+  offset += count * 4; // steer
+  offset += count * 4; // throttle
+  offset += count; // handbrake
+  offset += count; // isDriving
+  return [timeline, offset];
+}
+
+function readFloat32Array(
+  view: DataView,
+  offset: number,
+  count: number,
+): [values: Float32Array, offset: number] {
+  const values = new Float32Array(count);
+  for (let index = 0; index < count; index += 1) {
+    values[index] = view.getFloat32(offset + index * 4, true);
+  }
+  return [values, offset + count * 4];
+}
+
+function printTimelineSummary(label: string, timeline: BinaryTimeline): void {
+  const count = timeline.times.length;
+  const first = count ? timeline.times[0]! : 0;
+  const last = count ? timeline.times[count - 1]! : 0;
+  const bounds = boundsBinary(timeline);
+  console.log(
+    `  ${label}: ${count} samples, t=${first.toFixed(6)}..${last.toFixed(
+      6,
+    )}, ${formatBounds(bounds)}`,
+  );
+}
+
+function printMotionSummary(label: string, timeline: MotionKeyframe[]): void {
+  const count = timeline.length;
+  const first = count ? timeline[0]!.time : 0;
+  const last = count ? timeline[count - 1]!.time : 0;
+  const bounds = boundsMotion(timeline);
+  console.log(
+    `  ${label}: ${count} samples, t=${first.toFixed(6)}..${last.toFixed(
+      6,
+    )}, ${formatBounds(bounds)}`,
+  );
+}
+
+function printComparison(label: string, stats: ReturnType<typeof compareTimelines>): void {
+  console.log(
+    `    ${label}: n=${stats.count} rms=${stats.rms.toFixed(2)} mean=${stats.mean.toFixed(
+      2,
+    )} p50=${stats.p50.toFixed(2)} p95=${stats.p95.toFixed(2)} max=${stats.max.toFixed(2)}`,
+  );
+}
+
+function compareTimelines(
+  expected: BinaryTimeline,
+  actual: MotionKeyframe[],
+  mapExpectedTimeToActualTime: (time: number) => number | null = (time) => time,
+): {
+  count: number;
+  rms: number;
+  mean: number;
+  p50: number;
+  p95: number;
+  max: number;
+} {
+  const errors: number[] = [];
+  for (let index = 0; index < expected.times.length; index += 1) {
+    const expectedTime = expected.times[index]!;
+    const actualTime = mapExpectedTimeToActualTime(expectedTime);
+    if (actualTime === null) continue;
+
+    const expectedPosition = getBinaryPosition(expected, index);
+    const actualPosition = sampleMotion(actual, actualTime);
+    if (!actualPosition) continue;
+    errors.push(distance(expectedPosition, actualPosition));
+  }
+
+  if (errors.length === 0) {
+    return { count: 0, rms: 0, mean: 0, p50: 0, p95: 0, max: 0 };
+  }
+
+  errors.sort((a, b) => a - b);
+  const sum = errors.reduce((total, value) => total + value, 0);
+  const sumSquares = errors.reduce((total, value) => total + value * value, 0);
+  return {
+    count: errors.length,
+    rms: Math.sqrt(sumSquares / errors.length),
+    mean: sum / errors.length,
+    p50: percentile(errors, 0.5),
+    p95: percentile(errors, 0.95),
+    max: errors[errors.length - 1]!,
+  };
+}
+
+function buildTimeAnchors(
+  header: Record<string, unknown>,
+  adapterFrameTimes: number[],
+): TimeAnchor[] {
+  const events = Array.isArray(header.gameEventTimeline) ? header.gameEventTimeline : [];
+  const anchors: TimeAnchor[] = [];
+
+  for (const event of events) {
+    if (!event || typeof event !== "object") continue;
+    const record = event as Record<string, unknown>;
+    const frame = Number(record.frame);
+    const ballcamTime = Number(record.time);
+    if (!Number.isInteger(frame) || !Number.isFinite(ballcamTime)) continue;
+    const adapterTime = adapterFrameTimes[frame];
+    if (adapterTime == null) continue;
+    anchors.push({ frame, ballcamTime, adapterTime });
+  }
+
+  anchors.sort((left, right) => left.ballcamTime - right.ballcamTime);
+  return anchors.filter((anchor, index) => {
+    if (index === 0) return true;
+    const previous = anchors[index - 1]!;
+    return anchor.ballcamTime !== previous.ballcamTime || anchor.adapterTime !== previous.adapterTime;
+  });
+}
+
+function createSparseTimeMapper(
+  anchors: TimeAnchor[],
+  adapterDuration: number,
+): (ballcamTime: number) => number | null {
+  if (anchors.length < 2) return () => null;
+  const mapAnchors = [
+    { ballcamTime: 0, adapterTime: 0 },
+    ...anchors.map(({ ballcamTime, adapterTime }) => ({ ballcamTime, adapterTime })),
+  ];
+  if (mapAnchors[mapAnchors.length - 1]!.adapterTime < adapterDuration) {
+    const last = mapAnchors[mapAnchors.length - 1]!;
+    mapAnchors.push({
+      ballcamTime: last.ballcamTime + adapterDuration - last.adapterTime,
+      adapterTime: adapterDuration,
+    });
+  }
+
+  return (ballcamTime: number): number | null => {
+    if (ballcamTime < mapAnchors[0]!.ballcamTime) return null;
+    if (ballcamTime > mapAnchors[mapAnchors.length - 1]!.ballcamTime) return null;
+    let lo = 0;
+    let hi = mapAnchors.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (mapAnchors[mid]!.ballcamTime <= ballcamTime) lo = mid;
+      else hi = mid - 1;
+    }
+    const left = mapAnchors[lo]!;
+    const right = mapAnchors[Math.min(lo + 1, mapAnchors.length - 1)]!;
+    if (right.ballcamTime === left.ballcamTime) return left.adapterTime;
+    const alpha = (ballcamTime - left.ballcamTime) / (right.ballcamTime - left.ballcamTime);
+    return left.adapterTime + (right.adapterTime - left.adapterTime) * alpha;
+  };
+}
+
+function buildBallcamCompaction(raw: {
+  frame_data: { metadata_frames: Array<Record<string, unknown>> };
+  goal_events?: Array<Record<string, unknown>>;
+}): BallcamCompaction {
+  const metadataFrames = raw.frame_data.metadata_frames;
+  const startTime = Number(metadataFrames[0]?.time ?? 0);
+  const frameTimes = metadataFrames.map((frame) => Number(frame.time) - startTime);
+  const rawDuration = frameTimes[frameTimes.length - 1] ?? 0;
+  const gaps = detectPostGoalTimeGaps(frameTimes, raw.goal_events ?? []);
+  const prematchRawEndTime = detectFirstKickoffGoTime(frameTimes, metadataFrames);
+  const prematchEndTime =
+    prematchRawEndTime == null ? null : remapGapTime(prematchRawEndTime, gaps);
+  const gapDuration = gaps.reduce((total, gap) => total + gap.duration, 0);
+  const compactedDuration = rawDuration - gapDuration - (prematchEndTime ?? 0);
+  return { gaps, prematchEndTime, rawDuration, compactedDuration };
+}
+
+function detectPostGoalTimeGaps(
+  frameTimes: number[],
+  goalEvents: Array<Record<string, unknown>>,
+): ReplayGap[] {
+  const gaps: ReplayGap[] = [];
+  for (const goal of goalEvents) {
+    const goalFrame = Number(goal.frame);
+    if (!Number.isInteger(goalFrame) || goalFrame < 0 || goalFrame >= frameTimes.length) continue;
+    const goalTime = frameTimes[goalFrame]!;
+    for (let frame = goalFrame + 1; frame < frameTimes.length; frame += 1) {
+      const beforeTime = frameTimes[frame - 1]!;
+      const afterTime = frameTimes[frame]!;
+      if (beforeTime - goalTime > 10) break;
+      const duration = afterTime - beforeTime;
+      if (duration > 0.3) {
+        gaps.push({
+          beforeFrame: frame - 1,
+          afterFrame: frame,
+          beforeTime,
+          afterTime,
+          duration,
+        });
+        break;
+      }
+    }
+  }
+  return gaps;
+}
+
+function detectFirstKickoffGoTime(
+  frameTimes: number[],
+  metadataFrames: Array<Record<string, unknown>>,
+): number | null {
+  let sawCountdown = false;
+  for (let index = 0; index < metadataFrames.length; index += 1) {
+    const remaining = Number(metadataFrames[index]?.replicated_game_state_time_remaining);
+    if (remaining > 0) sawCountdown = true;
+    if (sawCountdown && remaining === 0) return frameTimes[index] ?? null;
+  }
+
+  const firstActiveFrame = metadataFrames.findIndex(
+    (frame) => Number(frame.replicated_game_state_name) === 54,
+  );
+  return firstActiveFrame === -1 ? null : (frameTimes[firstActiveFrame] ?? null);
+}
+
+function compactMotionTimeline(
+  timeline: MotionKeyframe[],
+  compaction: BallcamCompaction,
+): MotionKeyframe[] {
+  const afterGaps = remapGapTimeline(timeline, compaction.gaps);
+  if (compaction.prematchEndTime == null) return afterGaps;
+  return remapPrematchTimeline(afterGaps, compaction.prematchEndTime);
+}
+
+function remapGapTimeline(timeline: MotionKeyframe[], gaps: ReplayGap[]): MotionKeyframe[] {
+  if (gaps.length === 0) return timeline;
+
+  const inserted: MotionKeyframe[] = [];
+  for (const [gapIndex, gap] of gaps.entries()) {
+    const entry = timeline.find((frame) => frame.time >= gap.afterTime);
+    if (!entry) continue;
+    inserted.push({
+      ...entry,
+      time: remapGapTime(gap.afterTime, gaps.slice(0, gapIndex + 1)),
+    });
+  }
+
+  const remapped = timeline
+    .filter((frame) => !isInReplayGap(frame.time, gaps))
+    .map((frame) => ({ ...frame, time: remapGapTime(frame.time, gaps) }));
+
+  for (const entry of inserted) {
+    if (remapped.some((frame) => Math.abs(frame.time - entry.time) < 1e-3)) continue;
+    const index = remapped.findIndex((frame) => frame.time > entry.time);
+    remapped.splice(index === -1 ? remapped.length : index, 0, entry);
+  }
+
+  return remapped;
+}
+
+function remapPrematchTimeline(
+  timeline: MotionKeyframe[],
+  prematchEndTime: number,
+): MotionKeyframe[] {
+  let lastPrematchFrame: MotionKeyframe | null = null;
+  for (const frame of timeline) {
+    if (frame.time < prematchEndTime) lastPrematchFrame = frame;
+    else break;
+  }
+
+  const remapped = timeline
+    .filter((frame) => frame.time >= prematchEndTime)
+    .map((frame) => ({ ...frame, time: frame.time - prematchEndTime }));
+
+  if (lastPrematchFrame && (remapped.length === 0 || remapped[0]!.time > 1e-3)) {
+    remapped.unshift({ ...lastPrematchFrame, time: 0 });
+  }
+
+  return remapped;
+}
+
+function remapGapTime(time: number, gaps: ReplayGap[]): number {
+  let cumulativeRemoved = 0;
+  for (const gap of gaps) {
+    if (time < gap.beforeTime) break;
+    if (time >= gap.afterTime) {
+      cumulativeRemoved += gap.duration;
+      continue;
+    }
+    return gap.beforeTime - cumulativeRemoved;
+  }
+  return time - cumulativeRemoved;
+}
+
+function isInReplayGap(time: number, gaps: ReplayGap[]): boolean {
+  return gaps.some((gap) => time > gap.beforeTime && time < gap.afterTime);
+}
+
+function sampleMotion(timeline: MotionKeyframe[], time: number): Vec3 | null {
+  if (timeline.length === 0) return null;
+  if (time < timeline[0]!.time || time > timeline[timeline.length - 1]!.time) return null;
+
+  let lo = 0;
+  let hi = timeline.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (timeline[mid]!.time <= time) lo = mid;
+    else hi = mid - 1;
+  }
+  const left = timeline[lo]!;
+  const right = timeline[Math.min(lo + 1, timeline.length - 1)]!;
+  if (right.time === left.time) return left.position;
+  const alpha = (time - left.time) / (right.time - left.time);
+  return {
+    x: lerp(left.position.x, right.position.x, alpha),
+    y: lerp(left.position.y, right.position.y, alpha),
+    z: lerp(left.position.z, right.position.z, alpha),
+  };
+}
+
+function boundsBinary(timeline: BinaryTimeline): ReturnType<typeof emptyBounds> {
+  const bounds = emptyBounds();
+  for (let index = 0; index < timeline.times.length; index += 1) {
+    include(bounds, getBinaryPosition(timeline, index));
+  }
+  return bounds;
+}
+
+function boundsMotion(timeline: MotionKeyframe[]): ReturnType<typeof emptyBounds> {
+  const bounds = emptyBounds();
+  for (const frame of timeline) include(bounds, frame.position);
+  return bounds;
+}
+
+function getBinaryPosition(timeline: BinaryTimeline, index: number): Vec3 {
+  return {
+    x: timeline.positions[index * 3]!,
+    y: timeline.positions[index * 3 + 1]!,
+    z: timeline.positions[index * 3 + 2]!,
+  };
+}
+
+function emptyBounds() {
+  return {
+    minX: Number.POSITIVE_INFINITY,
+    maxX: Number.NEGATIVE_INFINITY,
+    minY: Number.POSITIVE_INFINITY,
+    maxY: Number.NEGATIVE_INFINITY,
+    minZ: Number.POSITIVE_INFINITY,
+    maxZ: Number.NEGATIVE_INFINITY,
+  };
+}
+
+function include(bounds: ReturnType<typeof emptyBounds>, value: Vec3): void {
+  bounds.minX = Math.min(bounds.minX, value.x);
+  bounds.maxX = Math.max(bounds.maxX, value.x);
+  bounds.minY = Math.min(bounds.minY, value.y);
+  bounds.maxY = Math.max(bounds.maxY, value.y);
+  bounds.minZ = Math.min(bounds.minZ, value.z);
+  bounds.maxZ = Math.max(bounds.maxZ, value.z);
+}
+
+function formatBounds(bounds: ReturnType<typeof emptyBounds>): string {
+  return `x[${bounds.minX.toFixed(0)},${bounds.maxX.toFixed(0)}] y[${bounds.minY.toFixed(
+    0,
+  )},${bounds.maxY.toFixed(0)}] z[${bounds.minZ.toFixed(0)},${bounds.maxZ.toFixed(0)}]`;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function fmtNumber(value: unknown): string {
+  return typeof value === "number" ? value.toFixed(6) : String(value);
+}
+
+function distance(left: Vec3, right: Vec3): number {
+  const dx = right.x - left.x;
+  const dy = right.y - left.y;
+  const dz = right.z - left.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function percentile(sortedValues: number[], fraction: number): number {
+  const index = Math.min(sortedValues.length - 1, Math.floor(sortedValues.length * fraction));
+  return sortedValues[index]!;
+}
+
+function lerp(left: number, right: number, alpha: number): number {
+  return left + (right - left) * alpha;
+}

--- a/js/viewer/src/adapter/SubtrActorPlayer.ts
+++ b/js/viewer/src/adapter/SubtrActorPlayer.ts
@@ -401,8 +401,7 @@ export class SubtrActorPlayer extends EventEmitter {
   private _timelineProcessingOptions(): TimelineProcessingOptions {
     return {
       motionSmoothing: this.options.motionSmoothing ?? DEFAULT_POSITION_SMOOTHING,
-      smoothingBlendFactor:
-        this.options.smoothingBlendFactor ?? POSITION_SMOOTHING_BLEND_FACTOR,
+      smoothingBlendFactor: this.options.smoothingBlendFactor ?? POSITION_SMOOTHING_BLEND_FACTOR,
       smoothingAnchorInterval:
         this.options.smoothingAnchorInterval ?? POSITION_SMOOTHING_ANCHOR_INTERVAL,
       timelineCompaction: this.options.timelineCompaction ?? DEFAULT_TIMELINE_COMPACTION,
@@ -538,10 +537,7 @@ export class SubtrActorPlayer extends EventEmitter {
     return remapped;
   }
 
-  private _remapPrematch<T extends { time: number }>(
-    timeline: T[],
-    prematchEndTime: number,
-  ): T[] {
+  private _remapPrematch<T extends { time: number }>(timeline: T[], prematchEndTime: number): T[] {
     let lastPrematchFrame: T | null = null;
     for (const frame of timeline) {
       if (frame.time < prematchEndTime) lastPrematchFrame = frame;
@@ -644,12 +640,7 @@ export class SubtrActorPlayer extends EventEmitter {
     for (let index = 1; index < timeline.length; index += 1) {
       const current = timeline[index]!;
       const previous = timeline[lastKeptIndex]!;
-      if (
-        !current.position ||
-        !current.velocity ||
-        !previous.position ||
-        !previous.velocity
-      ) {
+      if (!current.position || !current.velocity || !previous.position || !previous.velocity) {
         filtered.push(current);
         lastKeptIndex = index;
         continue;

--- a/js/viewer/src/adapter/SubtrActorPlayer.ts
+++ b/js/viewer/src/adapter/SubtrActorPlayer.ts
@@ -60,7 +60,12 @@ interface RawReplayData {
   frame_data: {
     ball_data: { frames: RawBallFrame[] };
     players: Array<[unknown, { frames: RawPlayerFrame[] }]>;
-    metadata_frames: Array<{ time: number; seconds_remaining: number }>;
+    metadata_frames: Array<{
+      time: number;
+      seconds_remaining: number;
+      replicated_game_state_name?: number;
+      replicated_game_state_time_remaining?: number;
+    }>;
   };
   meta: {
     team_zero: RawPlayerInfo[];
@@ -68,6 +73,7 @@ interface RawReplayData {
   };
   boost_pads?: RawResolvedBoostPad[];
   boost_pad_events?: RawBoostPadEvent[];
+  goal_events?: Array<{ time: number; frame: number }>;
 }
 interface RawPlayerInfo {
   remote_id: unknown;
@@ -152,6 +158,60 @@ function toRecordedCameraSettings(
 
 /** Supersonic threshold in UU/s (game value ~2200). */
 const SUPERSONIC_SPEED = 2200;
+const DEFAULT_POSITION_SMOOTHING = true;
+const DEFAULT_TIMELINE_COMPACTION = false;
+const POSITION_SMOOTHING_BLEND_FACTOR = 0.15;
+const POSITION_SMOOTHING_ANCHOR_INTERVAL = 10;
+const MAX_POSITION_CORRECTION_DT_SECONDS = 0.1;
+const MAX_POSITION_CORRECTION_DRIFT_UU = 10;
+const FILTER_VELOCITY_THRESHOLD = 0.1;
+const FILTER_POSITION_THRESHOLD = 0.15;
+const MIN_FILTER_SPEED_UU_PER_SECOND = 10;
+
+export interface SubtrActorPlayerOptions {
+  /**
+   * Preprocess compiled ball/player timelines with the same style of
+   * velocity-based correction Ballcam applies before serializing its replay
+   * artifact. Defaults to true; set false for raw sample inspection.
+   */
+  motionSmoothing?: boolean;
+  /** Blend toward the measured replay sample during velocity correction. */
+  smoothingBlendFactor?: number;
+  /** Every N corrected samples, use a stronger measured-sample anchor. */
+  smoothingAnchorInterval?: number;
+  /**
+   * Remove pre-kickoff idle time and post-goal replay gaps from the adapter's
+   * motion timelines, matching Ballcam's compiled .rlrf time axis. Defaults to
+   * false because it intentionally diverges from @rlrml/player's raw normalized
+   * ReplayModel time axis.
+   */
+  timelineCompaction?: boolean;
+  /** Skip Ballcam-style velocity/position consistency filtering. */
+  disableFrameFiltering?: boolean;
+}
+
+interface TimelineProcessingOptions {
+  motionSmoothing: boolean;
+  smoothingBlendFactor: number;
+  smoothingAnchorInterval: number;
+  timelineCompaction: boolean;
+  disableFrameFiltering: boolean;
+}
+
+interface ReplayGap {
+  beforeFrame: number;
+  afterFrame: number;
+  beforeTime: number;
+  afterTime: number;
+  duration: number;
+}
+
+interface TimelineCompaction {
+  gaps: ReplayGap[];
+  prematchEndTime: number | null;
+  removedDuration: number;
+  compactedDuration: number;
+}
 
 function lastBefore<T extends { time: number }>(arr: T[], time: number): T | null {
   if (arr.length === 0) return null;
@@ -242,8 +302,12 @@ export class SubtrActorPlayer extends EventEmitter {
   private _ballFlags: FlagsKeyframe[] = []; // ball has none, kept for symmetry
   private _playerFlags: Record<string, FlagsKeyframe[]> = {};
   private _teams: Record<string, number> = {};
+  private _timelineCompaction: TimelineCompaction | null = null;
 
-  constructor(private raw: RawReplayData) {
+  constructor(
+    private raw: RawReplayData,
+    private options: SubtrActorPlayerOptions = {},
+  ) {
     super();
     this._compile();
   }
@@ -328,9 +392,294 @@ export class SubtrActorPlayer extends EventEmitter {
       );
     });
 
+    this._preprocessMotionTimelines();
     this._compileBoostPads();
 
     this.seek(0);
+  }
+
+  private _timelineProcessingOptions(): TimelineProcessingOptions {
+    return {
+      motionSmoothing: this.options.motionSmoothing ?? DEFAULT_POSITION_SMOOTHING,
+      smoothingBlendFactor:
+        this.options.smoothingBlendFactor ?? POSITION_SMOOTHING_BLEND_FACTOR,
+      smoothingAnchorInterval:
+        this.options.smoothingAnchorInterval ?? POSITION_SMOOTHING_ANCHOR_INTERVAL,
+      timelineCompaction: this.options.timelineCompaction ?? DEFAULT_TIMELINE_COMPACTION,
+      disableFrameFiltering: this.options.disableFrameFiltering ?? false,
+    };
+  }
+
+  private _preprocessMotionTimelines(): void {
+    const options = this._timelineProcessingOptions();
+    if (options.motionSmoothing) {
+      this._applyVelocityBasedPositionCorrection(options);
+    }
+    if (options.timelineCompaction) {
+      this._applyTimelineCompaction();
+    }
+    if (!options.disableFrameFiltering) {
+      this._filterInconsistentFrames();
+    }
+  }
+
+  private _applyTimelineCompaction(): void {
+    const compaction = this._buildTimelineCompaction();
+    if (!compaction || (compaction.gaps.length === 0 && compaction.prematchEndTime === null)) {
+      return;
+    }
+
+    this._timelineCompaction = compaction;
+    this._ballTimeline = this._compactTimeline(this._ballTimeline, compaction);
+    Object.entries(this._playerTimelines).forEach(([name, timeline]) => {
+      this._playerTimelines[name] = this._compactTimeline(timeline, compaction);
+    });
+    Object.entries(this._playerFlags).forEach(([name, timeline]) => {
+      this._playerFlags[name] = this._compactTimeline(timeline, compaction);
+    });
+
+    this.frameTimes = this.frameTimes.map((time) => this._compactTime(time, compaction));
+    this.duration = compaction.compactedDuration;
+  }
+
+  private _buildTimelineCompaction(): TimelineCompaction | null {
+    if (this.frameTimes.length === 0) return null;
+
+    const gaps = this._detectPostGoalTimeGaps();
+    const prematchRawEndTime = this._detectFirstKickoffGoTime();
+    const prematchEndTime =
+      prematchRawEndTime == null ? null : remapGapTime(prematchRawEndTime, gaps);
+    const gapRemovedDuration = gaps.reduce((total, gap) => total + gap.duration, 0);
+    const removedDuration = gapRemovedDuration + (prematchEndTime ?? 0);
+    if (removedDuration <= 0) return null;
+
+    return {
+      gaps,
+      prematchEndTime,
+      removedDuration,
+      compactedDuration: Math.max(0, this.duration - removedDuration),
+    };
+  }
+
+  private _detectPostGoalTimeGaps(): ReplayGap[] {
+    const gaps: ReplayGap[] = [];
+    for (const goal of this.raw.goal_events ?? []) {
+      const goalFrame = goal.frame;
+      if (!Number.isInteger(goalFrame) || goalFrame < 0 || goalFrame >= this.frameTimes.length) {
+        continue;
+      }
+      const goalTime = this.frameTimes[goalFrame]!;
+      for (let frame = goalFrame + 1; frame < this.frameTimes.length; frame += 1) {
+        const beforeTime = this.frameTimes[frame - 1]!;
+        const afterTime = this.frameTimes[frame]!;
+        if (beforeTime - goalTime > 10) break;
+        const duration = afterTime - beforeTime;
+        if (duration > 0.3) {
+          gaps.push({
+            beforeFrame: frame - 1,
+            afterFrame: frame,
+            beforeTime,
+            afterTime,
+            duration,
+          });
+          break;
+        }
+      }
+    }
+    return gaps;
+  }
+
+  private _detectFirstKickoffGoTime(): number | null {
+    const frames = this.raw.frame_data.metadata_frames;
+    let sawCountdown = false;
+    for (let index = 0; index < frames.length; index += 1) {
+      const remaining = frames[index]?.replicated_game_state_time_remaining;
+      if (remaining != null && remaining > 0) sawCountdown = true;
+      if (sawCountdown && remaining === 0) return this.frameTimes[index] ?? null;
+    }
+
+    const firstActiveFrame = frames.findIndex((frame) => frame.replicated_game_state_name === 54);
+    return firstActiveFrame === -1 ? null : (this.frameTimes[firstActiveFrame] ?? null);
+  }
+
+  private _compactTimeline<T extends { time: number }>(
+    timeline: T[],
+    compaction: TimelineCompaction,
+  ): T[] {
+    const afterGaps = this._remapReplayGaps(timeline, compaction.gaps);
+    if (compaction.prematchEndTime === null) return afterGaps;
+    return this._remapPrematch(afterGaps, compaction.prematchEndTime);
+  }
+
+  private _remapReplayGaps<T extends { time: number }>(timeline: T[], gaps: ReplayGap[]): T[] {
+    if (gaps.length === 0) return timeline;
+
+    const inserted: T[] = [];
+    gaps.forEach((gap, gapIndex) => {
+      const entry = timeline.find((frame) => frame.time >= gap.afterTime);
+      if (!entry) return;
+      inserted.push({
+        ...entry,
+        time: remapGapTime(gap.afterTime, gaps.slice(0, gapIndex + 1)),
+      });
+    });
+
+    const remapped = timeline
+      .filter((frame) => !isInReplayGap(frame.time, gaps))
+      .map((frame) => ({ ...frame, time: remapGapTime(frame.time, gaps) }));
+
+    for (const entry of inserted) {
+      if (remapped.some((frame) => Math.abs(frame.time - entry.time) < 1e-3)) continue;
+      let insertAt = remapped.findIndex((frame) => frame.time > entry.time);
+      if (insertAt === -1) insertAt = remapped.length;
+      remapped.splice(insertAt, 0, entry);
+    }
+
+    return remapped;
+  }
+
+  private _remapPrematch<T extends { time: number }>(
+    timeline: T[],
+    prematchEndTime: number,
+  ): T[] {
+    let lastPrematchFrame: T | null = null;
+    for (const frame of timeline) {
+      if (frame.time < prematchEndTime) lastPrematchFrame = frame;
+      else break;
+    }
+
+    const remapped = timeline
+      .filter((frame) => frame.time >= prematchEndTime)
+      .map((frame) => ({ ...frame, time: frame.time - prematchEndTime }));
+
+    if (lastPrematchFrame && (remapped.length === 0 || remapped[0]!.time > 1e-3)) {
+      remapped.unshift({ ...lastPrematchFrame, time: 0 });
+    }
+
+    return remapped;
+  }
+
+  private _compactTime(time: number, compaction: TimelineCompaction): number {
+    const afterGaps = remapGapTime(time, compaction.gaps);
+    if (compaction.prematchEndTime === null) return afterGaps;
+    return Math.max(0, afterGaps - compaction.prematchEndTime);
+  }
+
+  private _applyVelocityBasedPositionCorrection(options: TimelineProcessingOptions): void {
+    const correctTimeline = (timeline: MotionKeyframe[]): void => {
+      if (timeline.length < 3) return;
+
+      let startIndex = 0;
+      while (
+        startIndex < timeline.length &&
+        (!timeline[startIndex].position || !timeline[startIndex].velocity)
+      ) {
+        startIndex += 1;
+      }
+      if (startIndex >= timeline.length - 1) return;
+
+      let smoothed = { ...timeline[startIndex].position };
+
+      for (let index = startIndex + 1; index < timeline.length; index += 1) {
+        const previous = timeline[index - 1]!;
+        const current = timeline[index]!;
+        if (!previous.position || !current.position) continue;
+        if (!previous.velocity || !current.velocity) {
+          smoothed = { ...current.position };
+          continue;
+        }
+
+        const dt = current.time - previous.time;
+        if (dt <= 0 || dt > MAX_POSITION_CORRECTION_DT_SECONDS) {
+          smoothed = { ...current.position };
+          continue;
+        }
+
+        if (distance(smoothed, current.position) > MAX_POSITION_CORRECTION_DRIFT_UU) {
+          smoothed = { ...current.position };
+          continue;
+        }
+
+        const averageVelocity = {
+          x: (previous.velocity.x + current.velocity.x) / 2,
+          y: (previous.velocity.y + current.velocity.y) / 2,
+          z: (previous.velocity.z + current.velocity.z) / 2,
+        };
+        const predicted = {
+          x: smoothed.x + averageVelocity.x * dt,
+          y: smoothed.y + averageVelocity.y * dt,
+          z: smoothed.z + averageVelocity.z * dt,
+        };
+        const blend =
+          (index - startIndex) % options.smoothingAnchorInterval === 0
+            ? 0.5
+            : options.smoothingBlendFactor;
+
+        smoothed = {
+          x: predicted.x * (1 - blend) + current.position.x * blend,
+          y: predicted.y * (1 - blend) + current.position.y * blend,
+          z: predicted.z * (1 - blend) + current.position.z * blend,
+        };
+        current.position = { ...smoothed };
+      }
+    };
+
+    correctTimeline(this._ballTimeline);
+    Object.values(this._playerTimelines).forEach(correctTimeline);
+  }
+
+  private _filterInconsistentFrames(): void {
+    this._ballTimeline = this._filterInconsistentTimeline(this._ballTimeline);
+    Object.entries(this._playerTimelines).forEach(([name, timeline]) => {
+      this._playerTimelines[name] = this._filterInconsistentTimeline(timeline);
+    });
+  }
+
+  private _filterInconsistentTimeline(timeline: MotionKeyframe[]): MotionKeyframe[] {
+    if (timeline.length < 2) return timeline;
+
+    const filtered = [timeline[0]!];
+    let lastKeptIndex = 0;
+
+    for (let index = 1; index < timeline.length; index += 1) {
+      const current = timeline[index]!;
+      const previous = timeline[lastKeptIndex]!;
+      if (
+        !current.position ||
+        !current.velocity ||
+        !previous.position ||
+        !previous.velocity
+      ) {
+        filtered.push(current);
+        lastKeptIndex = index;
+        continue;
+      }
+
+      const previousSpeed = magnitude(previous.velocity);
+      const currentSpeed = magnitude(current.velocity);
+      if (previousSpeed < MIN_FILTER_SPEED_UU_PER_SECOND) {
+        filtered.push(current);
+        lastKeptIndex = index;
+        continue;
+      }
+
+      if (Math.abs(currentSpeed - previousSpeed) / previousSpeed < FILTER_VELOCITY_THRESHOLD) {
+        const dt = current.time - previous.time;
+        if (dt > 0.001) {
+          const expectedDistance = previousSpeed * dt;
+          const actualDistance = distance(previous.position, current.position);
+          const positionError = Math.abs(actualDistance - expectedDistance) / expectedDistance;
+          if (Number.isFinite(positionError) && positionError > FILTER_POSITION_THRESHOLD) {
+            continue;
+          }
+        }
+      }
+
+      filtered.push(current);
+      lastKeptIndex = index;
+    }
+
+    return filtered;
   }
 
   /**
@@ -349,9 +698,13 @@ export class SubtrActorPlayer extends EventEmitter {
             : null;
       if (available === null) return;
       const time = Math.max(0, e.time - this.rawStartTime); // same shift as frame times
+      if (this._timelineCompaction && this._isRemovedByTimelineCompaction(time)) return;
+      const compactedTime = this._timelineCompaction
+        ? this._compactTime(time, this._timelineCompaction)
+        : time;
       const bucket = eventsByPadId.get(e.pad_id);
-      if (bucket) bucket.push({ time, available });
-      else eventsByPadId.set(e.pad_id, [{ time, available }]);
+      if (bucket) bucket.push({ time: compactedTime, available });
+      else eventsByPadId.set(e.pad_id, [{ time: compactedTime, available }]);
     });
 
     (this.raw.boost_pads ?? []).forEach((pad) => {
@@ -373,6 +726,14 @@ export class SubtrActorPlayer extends EventEmitter {
       angularVelocity: vec3RlToThree(rb.angular_velocity),
       sleeping: !!rb.sleeping,
     };
+  }
+
+  private _isRemovedByTimelineCompaction(time: number): boolean {
+    const compaction = this._timelineCompaction;
+    if (!compaction) return false;
+    if (isInReplayGap(time, compaction.gaps)) return true;
+    const afterGaps = remapGapTime(time, compaction.gaps);
+    return compaction.prematchEndTime !== null && afterGaps < compaction.prematchEndTime;
   }
 
   private _idKey(remoteId: unknown): string {
@@ -511,4 +872,32 @@ export class SubtrActorPlayer extends EventEmitter {
   getGamePhaseAt(): null {
     return null;
   }
+}
+
+function magnitude(vector: Vec3): number {
+  return Math.sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z);
+}
+
+function distance(left: Vec3, right: Vec3): number {
+  const dx = right.x - left.x;
+  const dy = right.y - left.y;
+  const dz = right.z - left.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function remapGapTime(time: number, gaps: ReplayGap[]): number {
+  let cumulativeRemoved = 0;
+  for (const gap of gaps) {
+    if (time < gap.beforeTime) break;
+    if (time >= gap.afterTime) {
+      cumulativeRemoved += gap.duration;
+      continue;
+    }
+    return gap.beforeTime - cumulativeRemoved;
+  }
+  return time - cumulativeRemoved;
+}
+
+function isInReplayGap(time: number, gaps: ReplayGap[]): boolean {
+  return gaps.some((gap) => time > gap.beforeTime && time < gap.afterTime);
 }

--- a/js/viewer/src/dev/main.ts
+++ b/js/viewer/src/dev/main.ts
@@ -31,8 +31,7 @@ const log = (msg: string) => {
 async function main() {
   const container = document.getElementById("app") as HTMLDivElement;
   const params = new URLSearchParams(location.search);
-  const motionSmoothingEnabled =
-    params.get("smooth") !== "0" && params.get("smoothing") !== "0";
+  const motionSmoothingEnabled = params.get("smooth") !== "0" && params.get("smoothing") !== "0";
 
   log("parsing replay via subtr-actor WASM…");
   const replayResponse = await fetch(SAMPLE_REPLAY_URL);

--- a/js/viewer/src/dev/main.ts
+++ b/js/viewer/src/dev/main.ts
@@ -17,6 +17,11 @@ import {
   fromReplayPlayerPlugin,
 } from "../lib.js";
 
+const SAMPLE_REPLAY_URL = new URL(
+  "../../../../assets/recent-ranked-doubles-2026-03-10.replay",
+  import.meta.url,
+).href;
+
 const hud = document.getElementById("hud") as HTMLDivElement;
 const log = (msg: string) => {
   hud.textContent = msg;
@@ -25,9 +30,16 @@ const log = (msg: string) => {
 
 async function main() {
   const container = document.getElementById("app") as HTMLDivElement;
+  const params = new URLSearchParams(location.search);
+  const motionSmoothingEnabled =
+    params.get("smooth") !== "0" && params.get("smoothing") !== "0";
 
   log("parsing replay via subtr-actor WASM…");
-  const bytes = new Uint8Array(await (await fetch("/sample.replay")).arrayBuffer());
+  const replayResponse = await fetch(SAMPLE_REPLAY_URL);
+  if (!replayResponse.ok) {
+    throw new Error(`Failed to fetch sample replay: ${replayResponse.status}`);
+  }
+  const bytes = new Uint8Array(await replayResponse.arrayBuffer());
 
   const camPlugin = createCameraPlugin();
   // @rlrml/player's canvas recorder, bridged: extra members (start/stop/
@@ -36,6 +48,11 @@ async function main() {
   const viewer = await createViewer(container, bytes, {
     autoplay: true,
     loop: true,
+    // The dev harness loops the full raw replay so playback visibly advances
+    // even when the sample's skip-window inference marks trailing time hidden.
+    initialSkipPostGoalTransitionsEnabled: false,
+    timelineCompaction: params.get("compact") === "1" || params.get("compact") === "true",
+    motionSmoothing: motionSmoothingEnabled,
     plugins: [
       createFpsOverlayPlugin(),
       createNameTagPlugin(),
@@ -88,6 +105,16 @@ async function main() {
   ballCamBox.checked = camPlugin.getBallCam();
   ballCamBox.onchange = () => camPlugin.setBallCam(ballCamBox.checked);
   ballCamLabel.append(ballCamBox, " ball cam");
+  const smoothLabel = document.createElement("label");
+  const smoothBox = document.createElement("input");
+  smoothBox.type = "checkbox";
+  smoothBox.checked = motionSmoothingEnabled;
+  smoothBox.onchange = () => {
+    const next = new URL(location.href);
+    next.searchParams.set("smooth", smoothBox.checked ? "1" : "0");
+    location.href = next.toString();
+  };
+  smoothLabel.append(smoothBox, " smooth");
   // Stiffness slider: shows the effective value (recorded preset when
   // following); dragging it sets an explicit override that wins over recorded.
   const stiffnessLabel = document.createElement("label");
@@ -109,12 +136,11 @@ async function main() {
   };
   stiffnessLabel.append("stiff ", stiffness, stiffnessValue);
   syncStiffness();
-  camBar.append(select, ballCamLabel, stiffnessLabel);
+  camBar.append(select, ballCamLabel, smoothLabel, stiffnessLabel);
   document.body.append(camBar);
 
   // URL params for headless/dev bring-up:
-  //   ?follow=<player name>  ?cam=free|ballOrbit  ?t=<seconds>
-  const params = new URLSearchParams(location.search);
+  //   ?follow=<player name>  ?cam=free|ballOrbit  ?t=<seconds>  ?compact=1  ?smooth=0
   const camParam = params.get("cam");
   if (camParam === "free" || camParam === "ballOrbit") {
     camPlugin.setMode(camParam);

--- a/js/viewer/src/lib.ts
+++ b/js/viewer/src/lib.ts
@@ -46,7 +46,13 @@ export function createViewerFromParsed(
   parsed: ReplayLoadResult,
   options: ViewerOptions = {},
 ): ViewerPlayer {
-  const adapter = new SubtrActorPlayer(parsed.raw as never);
+  const adapter = new SubtrActorPlayer(parsed.raw as never, {
+    motionSmoothing: options.motionSmoothing,
+    smoothingBlendFactor: options.smoothingBlendFactor,
+    smoothingAnchorInterval: options.smoothingAnchorInterval,
+    timelineCompaction: options.timelineCompaction,
+    disableFrameFiltering: options.disableFrameFiltering,
+  });
   const viewer = new ViewerPlayer(container, adapter, options, parsed.replay);
   // @rlrml/player parity: ReplayPlayer's camera surface (follow / ballcam /
   // distance scale / custom settings) works out of the box, so the factory
@@ -62,7 +68,11 @@ export function createViewerFromParsed(
 
 export { ViewerPlayer } from "./ViewerPlayer.js";
 export { SubtrActorPlayer } from "./adapter/SubtrActorPlayer.js";
-export type { RecordedCameraSettings, ViewerPlayerInfo } from "./adapter/SubtrActorPlayer.js";
+export type {
+  RecordedCameraSettings,
+  SubtrActorPlayerOptions,
+  ViewerPlayerInfo,
+} from "./adapter/SubtrActorPlayer.js";
 export { loadReplay, parseReplay } from "./adapter/wasm.js";
 export type { ReplayLoadResult, ReplayModel, ReplayScene } from "@rlrml/player";
 export { createNameTagPlugin } from "./plugins/name-tags.js";

--- a/js/viewer/src/managers/ActorManager.js
+++ b/js/viewer/src/managers/ActorManager.js
@@ -69,13 +69,10 @@ export class ActorManager {
 
     // Debug: Interpolation settings
     this.interpolationEnabled = true;
-    // 'hermite' by default: replay samples are ~30Hz, and plain lerp gives
-    // piecewise-linear motion with a velocity discontinuity at every sample
-    // (reads as jitter at 60Hz+). Cubic Hermite uses the replay's per-sample
-    // linear velocities as tangents (C1-continuous), with a lerp fallback
-    // when velocity is missing or implausible — the same approach as
-    // @rlrml/player's interpolatePositionHermite.
-    this.interpolationMethod = "hermite";
+    // Match Ballcam's production viewer default. Alternative methods remain
+    // useful for debugging/A-B testing, but the public viewer ships with plain
+    // lerp between replay samples.
+    this.interpolationMethod = "lerp";
     this.smoothingWindowSize = 12;
     this.lastFrameInfo = null;
 

--- a/js/viewer/src/managers/CameraManager.js
+++ b/js/viewer/src/managers/CameraManager.js
@@ -4,8 +4,6 @@ import CameraControls from "camera-controls";
 // Install CameraControls with THREE
 CameraControls.install({ THREE });
 
-const _AXIS_X = new THREE.Vector3(1, 0, 0);
-
 export class CameraManager {
   constructor(camera, domElement) {
     this.camera = camera;
@@ -614,44 +612,26 @@ export class CameraManager {
       alpha,
     );
 
-    // Apply camera angle (pitch adjustment) to the target orientation
-    // followAngle is negative (e.g., -4 degrees) = look down
+    // Match Ballcam: apply the blended pose directly. The car/ball meshes have
+    // already been interpolated for this render tick, so another camera low-pass
+    // makes ball cam visibly chase the target.
+    this.camera.position.copy(finalPos);
+    this.camera.quaternion.copy(finalQuat);
+
+    // Apply camera angle (pitch adjustment) to the target orientation.
+    // followAngle is negative (e.g., -4 degrees) = look down.
     if (this.followAngle !== 0) {
       const angleRad = (this.followAngle * Math.PI) / 180;
-      finalQuat.multiply(this._tempQuatCarCam.setFromAxisAngle(_AXIS_X, -angleRad));
+      this.camera.rotateX(-angleRad);
     }
-
-    // === STIFFNESS (Rocket League camera setting) ===
-    // stiffness 1.0 = camera rigidly locked to the computed pose (the previous
-    // behavior); lower values exponentially smooth the final pose toward the
-    // target, absorbing car/ball interpolation jitter. Framerate-independent.
-    const stiffness = Math.min(1, Math.max(0, this.stiffness));
-    const smoothTime = (1 - stiffness) * 0.15; // seconds of lag at stiffness 0
-    const SNAP_DISTANCE_SQ = 1500 * 1500; // teleports (seek/demo/respawn): snap
-    if (
-      !this._smoothedCamPos ||
-      smoothTime < 1e-3 ||
-      this._smoothedCamPos.distanceToSquared(finalPos) > SNAP_DISTANCE_SQ
-    ) {
-      this._smoothedCamPos = (this._smoothedCamPos || new THREE.Vector3()).copy(finalPos);
-      this._smoothedCamQuat = (this._smoothedCamQuat || new THREE.Quaternion()).copy(finalQuat);
-    } else {
-      const k = 1 - Math.exp(-delta / smoothTime);
-      this._smoothedCamPos.lerp(finalPos, k);
-      this._smoothedCamQuat.slerp(finalQuat, k);
-    }
-
-    // Apply position and rotation to camera
-    this.camera.position.copy(this._smoothedCamPos);
-    this.camera.quaternion.copy(this._smoothedCamQuat);
 
     // Store current state for reference
     if (!this.currentCamPos) this.currentCamPos = new THREE.Vector3();
     if (!this.currentLookTarget) this.currentLookTarget = new THREE.Vector3();
-    this.currentCamPos.copy(this._smoothedCamPos);
+    this.currentCamPos.copy(finalPos);
     // Calculate look target from quaternion for compatibility
-    const lookDir = new THREE.Vector3(0, 0, -1).applyQuaternion(this._smoothedCamQuat);
-    this.currentLookTarget.copy(this._smoothedCamPos).add(lookDir.multiplyScalar(100));
+    const lookDir = new THREE.Vector3(0, 0, -1).applyQuaternion(this.camera.quaternion);
+    this.currentLookTarget.copy(finalPos).add(lookDir.multiplyScalar(100));
 
     this.enforceMinHeight();
   }
@@ -765,11 +745,11 @@ export class CameraManager {
     while (yawDiff > Math.PI) yawDiff -= Math.PI * 2;
     while (yawDiff < -Math.PI) yawDiff += Math.PI * 2;
 
-    // Use swivelSpeed for rotation speed (RL range: 1.0-10.0)
-    // Higher swivelSpeed = faster camera rotation around car
-    // (framerate-independent: scale by the real frame delta, not assumed 60fps)
+    // Use Ballcam's fixed 60 Hz yaw easing. This keeps the follow camera's yaw
+    // behavior independent from render-FPS spikes, matching the production
+    // viewer this implementation was derived from.
     const yawLerpSpeed = isFlipping ? this.swivelSpeed * 0.4 : this.swivelSpeed;
-    this.smoothedCarYaw += yawDiff * Math.min(1, yawLerpSpeed * delta);
+    this.smoothedCarYaw += yawDiff * Math.min(1, yawLerpSpeed * (1 / 60));
 
     // Calculate camera position using smoothed yaw
     const backwardX = -Math.sin(this.smoothedCarYaw);

--- a/js/viewer/src/types.ts
+++ b/js/viewer/src/types.ts
@@ -200,13 +200,29 @@ export interface ViewerOptions {
   /** Boost/supersonic/ball trail effects (default true). */
   effects?: boolean;
   /**
-   * Position interpolation between ~30Hz replay samples (default "hermite").
-   * "hermite" uses the replay's per-sample linear velocities as cubic tangents
-   * (C1-continuous, smooth through sample points, lerp fallback when velocity
-   * is missing/implausible); "linear" is plain lerp (piecewise-linear motion
-   * with a velocity discontinuity at every sample).
+   * Position interpolation between ~30Hz replay samples (default "linear",
+   * matching Ballcam's production viewer). "linear" is plain lerp;
+   * "hermite" uses per-sample linear velocities as cubic tangents with a lerp
+   * fallback when velocity is missing or implausible.
    */
   motionInterpolation?: "hermite" | "linear";
+  /**
+   * Preprocess ball/car timelines with Ballcam-style velocity correction before
+   * render-time interpolation (default true). Set false to inspect raw samples.
+   */
+  motionSmoothing?: boolean;
+  /** Velocity-correction blend toward measured samples (default 0.15). */
+  smoothingBlendFactor?: number;
+  /** Every N corrected samples, use a stronger measured-sample anchor (default 10). */
+  smoothingAnchorInterval?: number;
+  /**
+   * Remove pre-kickoff idle time and post-goal replay gaps from motion playback,
+   * matching Ballcam's compiled .rlrf time axis (default false; changes
+   * currentTime semantics relative to `viewer.replay`).
+   */
+  timelineCompaction?: boolean;
+  /** Disable velocity/position consistency filtering after smoothing (default false). */
+  disableFrameFiltering?: boolean;
 
   // ── @rlrml/player-compatible initial settings (docs/PLAYER_PARITY.md). ──────
   /** Initial playback rate; wins over `speed` when both are set. */


### PR DESCRIPTION
## Summary

This aligns the viewer more closely with Ballcam's production replay playback and follow-camera behavior.

- Adds Ballcam-style velocity correction, consistency filtering, and optional timeline compaction to `SubtrActorPlayer`.
- Adds a local `.rlrf` comparison script that decodes Ballcam's compiled replay artifact and compares it against our adapter output on the matching raw replay.
- Switches the actor interpolation default to Ballcam's production `lerp` default.
- Updates follow/ball-cam camera behavior to match Ballcam's direct blended pose application instead of adding an extra final camera low-pass.
- Adds dev harness toggles for compacted timeline playback and motion smoothing comparison.

## Root Cause

The smoothness gap was not only raw replay data processing. Ballcam serves a compiled `.rlrf` with prematch and post-goal replay gaps removed, and it applies velocity-based motion correction before serialization. The more visible jerkiness in our viewer was caused by our camera path: an extra stiffness-based low-pass made ball cam chase already-interpolated car/ball poses instead of applying the blended Ballcam camera pose directly.

## Validation

- `npm run check:tsc`
- `npm run build`
- `npx tsx scripts/compare-ballcam-rlrf.mts`
- Pre-commit hook: `cargo clippy --all-targets --all-features -- -D warnings`
- Manual browser check at `http://127.0.0.1:5173/?compact=1&smooth=1&follow=Quantavious1234`

Notes:

- `js/viewer` has no `lint` npm script, so TypeScript/build plus the repo pre-commit clippy hook were the lint-equivalent checks available here.
- `npm run build` still reports the existing Vite large chunk warning.
