### PR TITLE
[codex] Apply Ballcam smoothing to old player

### DIFF
--- a/js/player/src/player-internals/spatial.ts
+++ b/js/player/src/player-internals/spatial.ts
@@ -15,10 +15,12 @@ const FREE_CAMERA_TRANSITION_SMOOTHING = 0.14;
 const GROUND_HEIGHT_THRESHOLD_UU = 120;
 const MIN_CAMERA_HEIGHT_UU = 90;
 const PLAYER_FOCUS_HEIGHT_UU = 40;
+const BALL_CAM_AERIAL_HEIGHT_ADJUSTMENT_UU = 100;
 const BALL_CAM_HEIGHT_BIAS_UU = 45;
 const BALL_CAM_LOOK_BLEND = 0.58;
 const BALL_CAM_DIRECTION_BLEND = 0.82;
 const BALL_CAM_MAX_FOV = 132;
+const BALL_CAM_TRANSITION_BASE_DURATION_SECONDS = 0.5;
 const DEFAULT_FORWARD = new THREE.Vector3(-1, 0, 0);
 const DEFAULT_UP = new THREE.Vector3(0, 0, 1);
 const OVERHEAD_UP = new THREE.Vector3(-1, 0, 0);
@@ -31,6 +33,12 @@ const CAMERA_POSITION_EPSILON_SQ = 16;
 const CAMERA_TARGET_EPSILON_SQ = 16;
 const CAMERA_UP_EPSILON_RAD = 0.003;
 const CAMERA_FOV_EPSILON = 0.05;
+
+export interface AttachedCameraBlendState {
+  currentBlend: number;
+  targetBlend: number;
+  lastIsBallCam: boolean | null;
+}
 
 export function interpolatePosition(
   current: Vec3 | null,
@@ -304,10 +312,12 @@ export function updateAttachedCamera(options: {
   nextFrameIndex: number;
   alpha: number;
   dt: number;
+  renderDelta: number;
   attachedPlayerUnavailable?: boolean;
   ballPosition: THREE.Vector3 | null;
   desiredCameraPosition: THREE.Vector3;
   desiredLookTarget: THREE.Vector3;
+  blendState?: AttachedCameraBlendState;
 }): void {
   const {
     cameraViewMode,
@@ -324,10 +334,19 @@ export function updateAttachedCamera(options: {
     nextFrameIndex,
     alpha,
     dt,
+    renderDelta,
     replay,
     sceneState,
+    blendState: providedBlendState,
   } = options;
   const controls = sceneState.controls;
+  const blendState =
+    providedBlendState ??
+    ({
+      currentBlend: ballCamEnabled ? 1 : 0,
+      targetBlend: ballCamEnabled ? 1 : 0,
+      lastIsBallCam: ballCamEnabled,
+    } satisfies AttachedCameraBlendState);
 
   if (cameraViewMode === "free") {
     controls.enabled = true;
@@ -391,9 +410,16 @@ export function updateAttachedCamera(options: {
   const playerFocusPoint = basePosition
     .clone()
     .addScaledVector(DEFAULT_UP, PLAYER_FOCUS_HEIGHT_UU * fieldScale);
-  let targetFov = cameraSettings.fov ?? 110;
+  const carTargetFov = cameraSettings.fov ?? 110;
+  let ballTargetFov = carTargetFov;
 
-  if (ballCamEnabled && ballPosition) {
+  const carCameraPosition = playerFocusPoint.clone().add(followOffset);
+  carCameraPosition.z = Math.max(MIN_CAMERA_HEIGHT_UU * fieldScale, carCameraPosition.z);
+  const carLookTarget = playerFocusPoint.clone();
+  let ballCameraPosition = carCameraPosition;
+  let ballLookTarget = carLookTarget;
+
+  if (ballPosition) {
     const ballFocusPoint = ballPosition
       .clone()
       .addScaledVector(DEFAULT_UP, BALL_CAM_HEIGHT_BIAS_UU * fieldScale);
@@ -405,28 +431,62 @@ export function updateAttachedCamera(options: {
       .addScaledVector(lookDirection, 1 - BALL_CAM_DIRECTION_BLEND)
       .normalize();
 
-    desiredLookTarget.copy(playerFocusPoint).lerp(ballFocusPoint, BALL_CAM_LOOK_BLEND);
-    desiredCameraPosition.copy(chaseAnchor).addScaledVector(ballCamDirection, -distance);
-    desiredCameraPosition.z = Math.max(MIN_CAMERA_HEIGHT_UU * fieldScale, desiredCameraPosition.z);
-    const cameraToPlayer = playerFocusPoint.clone().sub(desiredCameraPosition);
-    const cameraToBall = ballFocusPoint.clone().sub(desiredCameraPosition);
+    ballLookTarget = playerFocusPoint.clone().lerp(ballFocusPoint, BALL_CAM_LOOK_BLEND);
+    ballCameraPosition = chaseAnchor.clone().addScaledVector(ballCamDirection, -distance);
+    const heightBlend = Math.min(
+      1,
+      Math.max(0, (ballFocusPoint.z - playerFocusPoint.z) / (800 * fieldScale)),
+    );
+    ballCameraPosition.z -= heightBlend * BALL_CAM_AERIAL_HEIGHT_ADJUSTMENT_UU * fieldScale;
+    ballCameraPosition.z = Math.max(MIN_CAMERA_HEIGHT_UU * fieldScale, ballCameraPosition.z);
+    const cameraToPlayer = playerFocusPoint.clone().sub(ballCameraPosition);
+    const cameraToBall = ballFocusPoint.clone().sub(ballCameraPosition);
     if (cameraToPlayer.lengthSq() > 0.0001 && cameraToBall.lengthSq() > 0.0001) {
       const separationAngle = cameraToPlayer.angleTo(cameraToBall);
-      targetFov = Math.min(
+      ballTargetFov = Math.min(
         BALL_CAM_MAX_FOV,
-        Math.max(targetFov, THREE.MathUtils.radToDeg(separationAngle) * 1.7),
+        Math.max(ballTargetFov, THREE.MathUtils.radToDeg(separationAngle) * 1.7),
       );
     }
-  } else {
-    desiredCameraPosition.copy(playerFocusPoint).add(followOffset);
-    desiredCameraPosition.z = Math.max(MIN_CAMERA_HEIGHT_UU * fieldScale, desiredCameraPosition.z);
-    desiredLookTarget.copy(playerFocusPoint);
   }
 
-  sceneState.camera.position.lerp(desiredCameraPosition, CAMERA_SMOOTHING);
-  sceneState.camera.up.lerp(DEFAULT_UP, CAMERA_SMOOTHING).normalize();
-  controls.target.lerp(desiredLookTarget, CAMERA_SMOOTHING);
-  sceneState.camera.fov = THREE.MathUtils.lerp(sceneState.camera.fov, targetFov, CAMERA_SMOOTHING);
+  if (blendState.lastIsBallCam !== null && blendState.lastIsBallCam !== ballCamEnabled) {
+    blendState.targetBlend = ballCamEnabled ? 1 : 0;
+  } else {
+    blendState.targetBlend = ballCamEnabled ? 1 : 0;
+    if (blendState.lastIsBallCam === null) {
+      blendState.currentBlend = blendState.targetBlend;
+    }
+  }
+  blendState.lastIsBallCam = ballCamEnabled;
+
+  const transitionSpeed = cameraSettings.transitionSpeed ?? 1.3;
+  const transitionDuration = Math.max(
+    0.15,
+    Math.min(0.6, BALL_CAM_TRANSITION_BASE_DURATION_SECONDS / transitionSpeed),
+  );
+  const transitionStep = Math.max(0, renderDelta) / transitionDuration;
+  if (blendState.currentBlend < blendState.targetBlend) {
+    blendState.currentBlend = Math.min(
+      blendState.currentBlend + transitionStep,
+      blendState.targetBlend,
+    );
+  } else if (blendState.currentBlend > blendState.targetBlend) {
+    blendState.currentBlend = Math.max(
+      blendState.currentBlend - transitionStep,
+      blendState.targetBlend,
+    );
+  }
+  const blend =
+    blendState.currentBlend * blendState.currentBlend * (3 - 2 * blendState.currentBlend);
+
+  desiredCameraPosition.lerpVectors(carCameraPosition, ballCameraPosition, blend);
+  desiredLookTarget.lerpVectors(carLookTarget, ballLookTarget, blend);
+
+  sceneState.camera.position.copy(desiredCameraPosition);
+  sceneState.camera.up.copy(DEFAULT_UP);
+  controls.target.copy(desiredLookTarget);
+  sceneState.camera.fov = THREE.MathUtils.lerp(carTargetFov, ballTargetFov, blend);
   sceneState.camera.updateProjectionMatrix();
   sceneState.camera.lookAt(controls.target);
 }

--- a/js/player/src/player.ts
+++ b/js/player/src/player.ts
@@ -30,6 +30,7 @@ import {
   projectTimelineTimeToReplay,
 } from "./player-internals/timeline";
 import {
+  type AttachedCameraBlendState,
   getFreeCameraPreset,
   interpolateQuaternion,
   interpolatePositionHermite,
@@ -86,6 +87,7 @@ export class ReplayPlayer extends EventTarget {
   private readonly desiredCameraPosition = new THREE.Vector3();
   private readonly desiredLookTarget = new THREE.Vector3();
   private readonly boundWindowResize = () => this.sceneState.resize();
+  private readonly attachedCameraBlendState: AttachedCameraBlendState;
   private readonly liveGameState: number | null;
   private readonly kickoffGameState: number | null;
   private timelineSegmentsCacheKey: string | null = null;
@@ -96,6 +98,7 @@ export class ReplayPlayer extends EventTarget {
   private playing = false;
   private speed = 1;
   private currentTime = 0;
+  private lastCameraRenderAt: number | null = null;
   private playbackStartedAt = 0;
   private playbackStartedTime = 0;
   private cameraDistanceScale: number;
@@ -127,6 +130,11 @@ export class ReplayPlayer extends EventTarget {
     this.attachedPlayerId = initialSettings.attachedPlayerId;
     this.cameraViewMode = initialSettings.cameraViewMode;
     this.ballCamEnabled = initialSettings.ballCamEnabled;
+    this.attachedCameraBlendState = {
+      currentBlend: initialSettings.ballCamEnabled ? 1 : 0,
+      targetBlend: initialSettings.ballCamEnabled ? 1 : 0,
+      lastIsBallCam: initialSettings.ballCamEnabled,
+    };
     this.boostMeterEnabled = initialSettings.boostMeterEnabled;
     this.boostPickupAnimationEnabled = initialSettings.boostPickupAnimationEnabled;
     this.hitboxWireframesEnabled = initialSettings.hitboxWireframesEnabled;
@@ -624,6 +632,16 @@ export class ReplayPlayer extends EventTarget {
     this.scheduleAnimationFrame();
   };
 
+  private getCameraRenderDelta(): number {
+    const now = typeof performance === "undefined" ? Date.now() : performance.now();
+    const previous = this.lastCameraRenderAt;
+    this.lastCameraRenderAt = now;
+    if (previous === null) {
+      return 1 / 60;
+    }
+    return Math.max(0, Math.min(0.1, (now - previous) / 1000));
+  }
+
   private render(): void {
     const frameWindow = getFrameWindow(this.replay, this.currentTime);
     const frameIndex = frameWindow.frameIndex;
@@ -836,6 +854,7 @@ export class ReplayPlayer extends EventTarget {
       nextFrameIndex: frameWindow.nextFrameIndex,
       alpha: frameWindow.alpha,
       dt: frameWindow.dt,
+      renderDelta: this.getCameraRenderDelta(),
       attachedPlayerUnavailable:
         this.attachedPlayerId !== null &&
         getActiveDemoEvent(this.replay.timelineEvents, this.attachedPlayerId, this.currentTime) !==
@@ -843,6 +862,7 @@ export class ReplayPlayer extends EventTarget {
       ballPosition,
       desiredCameraPosition: this.desiredCameraPosition,
       desiredLookTarget: this.desiredLookTarget,
+      blendState: this.attachedCameraBlendState,
     });
     if (this.cameraViewMode === "free" && this.freeCameraTransition) {
       const completed = updateFreeCameraTransition({

--- a/js/player/src/replay-data.ts
+++ b/js/player/src/replay-data.ts
@@ -30,6 +30,16 @@ export interface NormalizeReplayDataOptions {
   onProgress?: (progress: number, details: NormalizeReplayProgress) => void;
   progressReportMinDelta?: number;
   progressReportFrameInterval?: number;
+  /**
+   * Apply Ballcam-style velocity-based correction to normalized ball/player
+   * samples. Defaults to true; set false when inspecting exact raw frame
+   * positions.
+   */
+  motionSmoothing?: boolean;
+  /** Blend toward the measured replay sample during velocity correction. */
+  smoothingBlendFactor?: number;
+  /** Every N corrected samples, use a stronger measured-sample anchor. */
+  smoothingAnchorInterval?: number;
 }
 
 export interface NormalizeReplayDataAsyncOptions extends NormalizeReplayDataOptions {
@@ -65,6 +75,11 @@ const DEFAULT_CAMERA_SETTINGS: CameraSettings = {
 const NORMALIZATION_PROGRESS_REPORT_MIN_DELTA = 0.005;
 const NORMALIZATION_PROGRESS_REPORT_FRAME_INTERVAL = Number.POSITIVE_INFINITY;
 const NORMALIZATION_ASYNC_YIELD_INTERVAL_MS = 16;
+const DEFAULT_MOTION_SMOOTHING = true;
+const MOTION_SMOOTHING_BLEND_FACTOR = 0.15;
+const MOTION_SMOOTHING_ANCHOR_INTERVAL = 10;
+const MAX_POSITION_CORRECTION_DT_SECONDS = 0.1;
+const MAX_POSITION_CORRECTION_DRIFT_UU = 10;
 
 function normalizeVector(value: Vec3): Vec3 | null {
   const magnitude = Math.hypot(value.x, value.y, value.z);
@@ -228,6 +243,113 @@ function fillBoundedPlayerSampleGaps(frames: PlayerSample[]): void {
       gapStart = index;
     }
   }
+}
+
+function distance(left: Vec3, right: Vec3): number {
+  return Math.hypot(left.x - right.x, left.y - right.y, left.z - right.z);
+}
+
+function clonePosition(position: Vec3): Vec3 {
+  return { x: position.x, y: position.y, z: position.z };
+}
+
+function sampleIsAbsent(sample: BallSample | PlayerSample | undefined): boolean {
+  return Boolean(sample && "isPresent" in sample && sample.isPresent === false);
+}
+
+function applyVelocityBasedPositionCorrection(
+  frames: PlaybackFrame[],
+  samples: Array<BallSample | PlayerSample>,
+  options: Required<
+    Pick<
+      NormalizeReplayDataOptions,
+      "motionSmoothing" | "smoothingBlendFactor" | "smoothingAnchorInterval"
+    >
+  >,
+): void {
+  if (!options.motionSmoothing || samples.length < 3 || frames.length < 3) {
+    return;
+  }
+
+  let startIndex = 0;
+  while (
+    startIndex < samples.length &&
+    (!samples[startIndex]?.position ||
+      !samples[startIndex]?.linearVelocity ||
+      sampleIsAbsent(samples[startIndex]))
+  ) {
+    startIndex += 1;
+  }
+  if (startIndex >= samples.length - 1) {
+    return;
+  }
+
+  let smoothed = clonePosition(samples[startIndex]!.position!);
+
+  for (let index = startIndex + 1; index < samples.length; index += 1) {
+    const previous = samples[index - 1]!;
+    const current = samples[index]!;
+    if (!previous.position || !current.position || sampleIsAbsent(current)) {
+      continue;
+    }
+    if (!previous.linearVelocity || !current.linearVelocity) {
+      smoothed = clonePosition(current.position);
+      continue;
+    }
+
+    const currentFrame = frames[index];
+    const previousFrame = frames[index - 1];
+    const dt = currentFrame && previousFrame ? currentFrame.time - previousFrame.time : 0;
+    if (dt <= 0 || dt > MAX_POSITION_CORRECTION_DT_SECONDS) {
+      smoothed = clonePosition(current.position);
+      continue;
+    }
+
+    if (distance(smoothed, current.position) > MAX_POSITION_CORRECTION_DRIFT_UU) {
+      smoothed = clonePosition(current.position);
+      continue;
+    }
+
+    const averageVelocity = {
+      x: (previous.linearVelocity.x + current.linearVelocity.x) / 2,
+      y: (previous.linearVelocity.y + current.linearVelocity.y) / 2,
+      z: (previous.linearVelocity.z + current.linearVelocity.z) / 2,
+    };
+    const predicted = {
+      x: smoothed.x + averageVelocity.x * dt,
+      y: smoothed.y + averageVelocity.y * dt,
+      z: smoothed.z + averageVelocity.z * dt,
+    };
+    const blend =
+      (index - startIndex) % options.smoothingAnchorInterval === 0
+        ? 0.5
+        : options.smoothingBlendFactor;
+
+    smoothed = {
+      x: predicted.x * (1 - blend) + current.position.x * blend,
+      y: predicted.y * (1 - blend) + current.position.y * blend,
+      z: predicted.z * (1 - blend) + current.position.z * blend,
+    };
+    current.position = clonePosition(smoothed);
+  }
+}
+
+function normalizeMotionSmoothingOptions(
+  options: NormalizeReplayDataOptions,
+): Required<
+  Pick<
+    NormalizeReplayDataOptions,
+    "motionSmoothing" | "smoothingBlendFactor" | "smoothingAnchorInterval"
+  >
+> {
+  return {
+    motionSmoothing: options.motionSmoothing ?? DEFAULT_MOTION_SMOOTHING,
+    smoothingBlendFactor: options.smoothingBlendFactor ?? MOTION_SMOOTHING_BLEND_FACTOR,
+    smoothingAnchorInterval: Math.max(
+      1,
+      options.smoothingAnchorInterval ?? MOTION_SMOOTHING_ANCHOR_INTERVAL,
+    ),
+  };
 }
 
 function currentTimeMs(): number {
@@ -869,6 +991,11 @@ export function normalizeReplayData(
   const frames = buildPlaybackFrames(raw, progressTracker);
   const players = buildPlayerTracks(raw, progressTracker);
   const ballFrames = buildBallFrames(raw, progressTracker);
+  const motionSmoothingOptions = normalizeMotionSmoothingOptions(options);
+  applyVelocityBasedPositionCorrection(frames, ballFrames, motionSmoothingOptions);
+  for (const player of players) {
+    applyVelocityBasedPositionCorrection(frames, player.frames, motionSmoothingOptions);
+  }
   const boostPads = buildBoostPads(raw, players, startTime, progressTracker);
   const tickMarks = buildReplayTickMarks(raw, startTime, progressTracker);
   const timelineEvents = buildTimelineEvents(raw, players, tickMarks, startTime, progressTracker);
@@ -898,6 +1025,11 @@ export async function normalizeReplayDataAsync(
   const frames = await buildPlaybackFramesAsync(raw, progressTracker);
   const players = await buildPlayerTracksAsync(raw, progressTracker);
   const ballFrames = await buildBallFramesAsync(raw, progressTracker);
+  const motionSmoothingOptions = normalizeMotionSmoothingOptions(options);
+  applyVelocityBasedPositionCorrection(frames, ballFrames, motionSmoothingOptions);
+  for (const player of players) {
+    applyVelocityBasedPositionCorrection(frames, player.frames, motionSmoothingOptions);
+  }
   const boostPads = await buildBoostPadsAsync(raw, players, startTime, progressTracker);
   const tickMarks = buildReplayTickMarks(raw, startTime, progressTracker);
   const timelineEvents = await buildTimelineEventsAsync(

--- a/js/player/src/types.ts
+++ b/js/player/src/types.ts
@@ -223,6 +223,15 @@ export interface ReplayLoadOptions {
   onProgress?: (progress: ReplayLoadProgress) => void;
   reportEveryNFrames?: number;
   useWorker?: boolean;
+  /**
+   * Apply Ballcam-style velocity-based correction while normalizing replay
+   * samples. Defaults to true; set false to inspect exact raw frame positions.
+   */
+  motionSmoothing?: boolean;
+  /** Blend toward the measured replay sample during velocity correction. */
+  smoothingBlendFactor?: number;
+  /** Every N corrected samples, use a stronger measured-sample anchor. */
+  smoothingAnchorInterval?: number;
 }
 
 export interface ReplayLoadOverlayOptions {

--- a/js/player/src/wasm.ts
+++ b/js/player/src/wasm.ts
@@ -61,6 +61,9 @@ interface ReplayLoadRequest {
   type: "load-replay";
   bytes: ArrayBuffer;
   reportEveryNFrames: number;
+  motionSmoothing?: boolean;
+  smoothingBlendFactor?: number;
+  smoothingAnchorInterval?: number;
 }
 
 interface ReplayProgressMessage {
@@ -166,6 +169,9 @@ async function loadReplayFromBytesWithWorker(
       type: "load-replay",
       bytes: workerBytes.buffer,
       reportEveryNFrames: options.reportEveryNFrames ?? 1000,
+      motionSmoothing: options.motionSmoothing,
+      smoothingBlendFactor: options.smoothingBlendFactor,
+      smoothingAnchorInterval: options.smoothingAnchorInterval,
     };
     worker.postMessage(request, [workerBytes.buffer]);
   });
@@ -201,6 +207,9 @@ export async function loadReplayFromBytes(
   ) as RawReplayFramesData;
   options.onProgress?.({ stage: "normalizing", progress: 0 });
   const replay = await normalizeReplayDataAsync(raw, {
+    motionSmoothing: options.motionSmoothing,
+    smoothingBlendFactor: options.smoothingBlendFactor,
+    smoothingAnchorInterval: options.smoothingAnchorInterval,
     onProgress(progress) {
       options.onProgress?.({ stage: "normalizing", progress });
     },

--- a/js/player/src/wasm.worker.ts
+++ b/js/player/src/wasm.worker.ts
@@ -14,6 +14,9 @@ interface ReplayLoadRequest {
   type: "load-replay";
   bytes: ArrayBuffer;
   reportEveryNFrames: number;
+  motionSmoothing?: boolean;
+  smoothingBlendFactor?: number;
+  smoothingAnchorInterval?: number;
 }
 
 interface ReplayProgressMessage {
@@ -109,6 +112,9 @@ self.onmessage = async (event: MessageEvent<ReplayLoadRequest>) => {
     });
     const rawReplayData = JSON.parse(new TextDecoder().decode(rawBuffer)) as RawReplayFramesData;
     const replay = normalizeReplayData(rawReplayData, {
+      motionSmoothing: event.data.motionSmoothing,
+      smoothingBlendFactor: event.data.smoothingBlendFactor,
+      smoothingAnchorInterval: event.data.smoothingAnchorInterval,
       progressReportFrameInterval: event.data.reportEveryNFrames,
       onProgress(progress) {
         postMessageToMain({


### PR DESCRIPTION
## Summary
- add Ballcam-style velocity-based motion correction to old player replay normalization, with opt-out knobs for raw sample inspection
- thread smoothing options through worker and non-worker replay loads
- update old player attached ball cam to blend car/ball camera poses directly instead of adding an extra camera low-pass

## Verification
- npm run build:types (js/player)
- npm test (js/player)
- npm run check:style (js)
- npm run build:dist (js/player)