### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ This is a rough changelog derived from git tags and commit history. It focuses o
 notable user-visible or maintenance-relevant changes rather than every formatting,
 README, or refactor-only commit.
 
+## v1.0.1 - 2026-06-13
+
+### Replay player
+
+- Publish a final `@rlrml/player` patch release with Ballcam-style smoothing:
+  velocity-based sample correction during replay normalization and a smoother
+  attached ball-cam path that blends car-cam and ball-cam poses directly.
+- Add normalization and replay-load options to disable or tune motion smoothing
+  for consumers that need exact raw sample inspection.
+
+### Viewer
+
+- Improve high-fidelity viewer parity with Ballcam by matching server-compiled
+  replay motion smoothing, defaulting renderer interpolation to linear, and
+  removing the extra final camera low-pass that made ball cam chase the target.
+
 ## v1.0.0 - 2026-06-11
 
 This is the first stable release. It restructures the entire stats-timeline

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "rl-replay-subtr-actor"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "boxcars",
  "console_error_panic_hook",
@@ -1311,7 +1311,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subtr-actor"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "boxcars",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "subtr-actor-bakkesmod"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base64",
  "boxcars",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "subtr-actor-py"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "boxcars",
  "numpy",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "subtr-actor-tools"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "boxcars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "bakkesmod/rust", "crates/subtr-actor-tools", "js", "python"]
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ivan Malison <ivanmalison@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/rlrml/subtr-actor"

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -25,7 +25,7 @@ boxcars.workspace = true
 
 [dependencies.subtr-actor]
 path = ".."
-version = "1.0.0"
+version = "1.0.1"
 
 [dependencies.web-sys]
 version = "0.3.85"

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rlrml/subtr-actor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rlrml/subtr-actor",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rlrml/subtr-actor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "WebAssembly bindings for subtr-actor - Rocket League replay processing and analysis",
   "main": "pkg/rl_replay_subtr_actor.js",
   "types": "pkg/rl_replay_subtr_actor.d.ts",

--- a/js/pages/package.json
+++ b/js/pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subtr-actor-pages",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/js/player/package-lock.json
+++ b/js/player/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rlrml/player",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rlrml/player",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/js/player/package.json
+++ b/js/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rlrml/player",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Replay player library for subtr-actor Rocket League replay workflows",
   "type": "module",
   "main": "./dist/index.js",

--- a/js/stat-evaluation-player/package-lock.json
+++ b/js/stat-evaluation-player/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rlrml/stats-player",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rlrml/stats-player",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@rlrml/player": "^0.12.0",

--- a/js/stat-evaluation-player/package.json
+++ b/js/stat-evaluation-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rlrml/stats-player",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Stats-focused replay player UI for subtr-actor Rocket League replay workflows",
   "type": "module",
   "main": "./dist/index.js",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0"
 
 [dependencies.subtr-actor]
 path = ".."
-version = "1.0.0"
+version = "1.0.1"
 
 [dependencies.pyo3]
 version = "0.27.2"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtr-actor-py"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python bindings for the Rocket League replay processing library subtr-actor."
 authors = [{ name = "Ivan Malison", email = "ivanmalison@gmail.com" }]
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- bump workspace/package release metadata to 1.0.1
- add changelog notes for the final @rlrml/player smoothing release and viewer smoothing parity

## Verification
- python3 scripts/check_release_versions.py
- cargo metadata --locked --format-version 1
- npm run check:style (js)
- pre-commit cargo clippy --all-targets --all-features -- -D warnings