### PR TITLE
Release JavaScript packages at 1.0.2

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -74,6 +74,8 @@ jobs:
           bindings_version="$(python3 -c 'import json; print(json.load(open("js/package.json"))["version"])')"
           player_name="$(python3 -c 'import json; print(json.load(open("js/player/package.json"))["name"])')"
           player_version="$(python3 -c 'import json; print(json.load(open("js/player/package.json"))["version"])')"
+          viewer_name="$(python3 -c 'import json; print(json.load(open("js/viewer/package.json"))["name"])')"
+          viewer_version="$(python3 -c 'import json; print(json.load(open("js/viewer/package.json"))["version"])')"
           stats_player_name="$(python3 -c 'import json; print(json.load(open("js/stat-evaluation-player/package.json"))["name"])')"
           stats_player_version="$(python3 -c 'import json; print(json.load(open("js/stat-evaluation-player/package.json"))["version"])')"
 
@@ -82,6 +84,8 @@ jobs:
             echo "bindings_version=${bindings_version}"
             echo "player_name=${player_name}"
             echo "player_version=${player_version}"
+            echo "viewer_name=${viewer_name}"
+            echo "viewer_version=${viewer_version}"
             echo "stats_player_name=${stats_player_name}"
             echo "stats_player_version=${stats_player_version}"
           } >> "$GITHUB_OUTPUT"
@@ -108,19 +112,20 @@ jobs:
 
           check_already_published "${{ steps.metadata.outputs.bindings_name }}" "${{ steps.metadata.outputs.bindings_version }}" "bindings_already_published"
           check_already_published "${{ steps.metadata.outputs.player_name }}" "${{ steps.metadata.outputs.player_version }}" "player_already_published"
+          check_already_published "${{ steps.metadata.outputs.viewer_name }}" "${{ steps.metadata.outputs.viewer_version }}" "viewer_already_published"
           check_already_published "${{ steps.metadata.outputs.stats_player_name }}" "${{ steps.metadata.outputs.stats_player_version }}" "stats_player_already_published"
 
       - name: Build WASM package
-        if: steps.publish_state.outputs.bindings_already_published != 'true' || steps.publish_state.outputs.player_already_published != 'true' || steps.publish_state.outputs.stats_player_already_published != 'true'
+        if: steps.publish_state.outputs.bindings_already_published != 'true' || steps.publish_state.outputs.player_already_published != 'true' || steps.publish_state.outputs.viewer_already_published != 'true' || steps.publish_state.outputs.stats_player_already_published != 'true'
         run: npm --prefix js run build
 
       - name: Install player dependencies
-        if: steps.publish_state.outputs.player_already_published != 'true' || steps.publish_state.outputs.stats_player_already_published != 'true'
+        if: steps.publish_state.outputs.player_already_published != 'true' || steps.publish_state.outputs.viewer_already_published != 'true' || steps.publish_state.outputs.stats_player_already_published != 'true'
         working-directory: js/player
         run: npm ci
 
       - name: Build player package
-        if: steps.publish_state.outputs.player_already_published != 'true' || steps.publish_state.outputs.stats_player_already_published != 'true'
+        if: steps.publish_state.outputs.player_already_published != 'true' || steps.publish_state.outputs.viewer_already_published != 'true' || steps.publish_state.outputs.stats_player_already_published != 'true'
         working-directory: js/player
         run: npm run build
 
@@ -128,6 +133,16 @@ jobs:
         if: steps.publish_state.outputs.player_already_published != 'true'
         working-directory: js/player
         run: npm run smoke:install
+
+      - name: Install viewer dependencies
+        if: steps.publish_state.outputs.viewer_already_published != 'true' || steps.publish_state.outputs.stats_player_already_published != 'true'
+        working-directory: js/viewer
+        run: npm ci
+
+      - name: Build viewer package
+        if: steps.publish_state.outputs.viewer_already_published != 'true' || steps.publish_state.outputs.stats_player_already_published != 'true'
+        working-directory: js/viewer
+        run: npm run build:dist
 
       - name: Install stats player dependencies
         if: steps.publish_state.outputs.stats_player_already_published != 'true'
@@ -155,6 +170,20 @@ jobs:
         if: steps.npm_auth.outputs.available == 'true' && steps.publish_state.outputs.player_already_published != 'true'
         shell: bash
         working-directory: js/player
+        run: |
+          set -euo pipefail
+          package_dir="$(npm run --silent prepare:package)"
+          (
+            cd "$package_dir"
+            npm publish --access public
+          )
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish viewer package to npm
+        if: steps.npm_auth.outputs.available == 'true' && steps.publish_state.outputs.viewer_already_published != 'true'
+        shell: bash
+        working-directory: js/viewer
         run: |
           set -euo pipefail
           package_dir="$(npm run --silent prepare:package)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This is a rough changelog derived from git tags and commit history. It focuses o
 notable user-visible or maintenance-relevant changes rather than every formatting,
 README, or refactor-only commit.
 
+## v1.0.2 - 2026-06-13
+
+### JavaScript packages
+
+- Publish `@rlrml/viewer` alongside `@rlrml/player`, `@rlrml/subtr-actor`, and
+  `@rlrml/stats-player` so stats-player installs include every externalized
+  package used by its bundled viewer runtime.
+- Supersede the incomplete `v1.0.1` JavaScript release attempt, which failed
+  before any npm packages were published.
+
 ## v1.0.1 - 2026-06-13
 
 ### Replay player

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "rl-replay-subtr-actor"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "boxcars",
  "console_error_panic_hook",
@@ -1311,7 +1311,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subtr-actor"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "boxcars",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "subtr-actor-bakkesmod"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64",
  "boxcars",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "subtr-actor-py"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "boxcars",
  "numpy",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "subtr-actor-tools"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "boxcars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "bakkesmod/rust", "crates/subtr-actor-tools", "js", "python"]
 resolver = "3"
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ivan Malison <ivanmalison@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/rlrml/subtr-actor"

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -25,7 +25,7 @@ boxcars.workspace = true
 
 [dependencies.subtr-actor]
 path = ".."
-version = "1.0.1"
+version = "1.0.2"
 
 [dependencies.web-sys]
 version = "0.3.85"

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rlrml/subtr-actor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rlrml/subtr-actor",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rlrml/subtr-actor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "WebAssembly bindings for subtr-actor - Rocket League replay processing and analysis",
   "main": "pkg/rl_replay_subtr_actor.js",
   "types": "pkg/rl_replay_subtr_actor.d.ts",

--- a/js/pages/package.json
+++ b/js/pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subtr-actor-pages",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/js/player/package-lock.json
+++ b/js/player/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rlrml/player",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rlrml/player",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/js/player/package.json
+++ b/js/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rlrml/player",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Replay player library for subtr-actor Rocket League replay workflows",
   "type": "module",
   "main": "./dist/index.js",

--- a/js/stat-evaluation-player/package-lock.json
+++ b/js/stat-evaluation-player/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rlrml/stats-player",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rlrml/stats-player",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@rlrml/player": "^0.12.0",

--- a/js/stat-evaluation-player/package.json
+++ b/js/stat-evaluation-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rlrml/stats-player",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Stats-focused replay player UI for subtr-actor Rocket League replay workflows",
   "type": "module",
   "main": "./dist/index.js",

--- a/js/stat-evaluation-player/scripts/prepare-package.mjs
+++ b/js/stat-evaluation-player/scripts/prepare-package.mjs
@@ -17,11 +17,16 @@ async function main() {
   const playerPackage = JSON.parse(
     await readFile(path.resolve(packageDir, "..", "player", "package.json"), "utf8"),
   );
+  const viewerPackage = JSON.parse(
+    await readFile(path.resolve(packageDir, "..", "viewer", "package.json"), "utf8"),
+  );
   const publishPackage = {
     ...sourcePackage,
     dependencies: {
+      ...sourcePackage.dependencies,
       [bindingsPackage.name]: sourcePackage.version,
       [playerPackage.name]: sourcePackage.version,
+      [viewerPackage.name]: sourcePackage.version,
     },
   };
   delete publishPackage.scripts;

--- a/js/stat-evaluation-player/scripts/smoke-install.mjs
+++ b/js/stat-evaluation-player/scripts/smoke-install.mjs
@@ -32,13 +32,18 @@ async function main() {
   const playerPackage = JSON.parse(
     await readFile(path.resolve(jsDir, "player", "package.json"), "utf8"),
   );
+  const viewerPackage = JSON.parse(
+    await readFile(path.resolve(jsDir, "viewer", "package.json"), "utf8"),
+  );
   const scratchDir = await mkdtemp(path.join(os.tmpdir(), "subtr-actor-stats-player-smoke-"));
   let playerPublishDir = null;
+  let viewerPublishDir = null;
   let statsPublishDir = null;
 
   try {
     run("npm", ["--prefix", jsDir, "run", "build"], packageDir);
     run("npm", ["run", "build"], path.resolve(jsDir, "player"));
+    run("npm", ["run", "build:dist"], path.resolve(jsDir, "viewer"));
     run("npm", ["run", "build"], packageDir);
 
     const packDir = path.join(scratchDir, "pack");
@@ -55,6 +60,12 @@ async function main() {
       encoding: "utf8",
     }).trim();
     const playerTarballPath = await packTarball(playerPublishDir, packDir);
+
+    viewerPublishDir = execFileSync("npm", ["run", "--silent", "prepare:package"], {
+      cwd: path.resolve(jsDir, "viewer"),
+      encoding: "utf8",
+    }).trim();
+    const viewerTarballPath = await packTarball(viewerPublishDir, packDir);
 
     statsPublishDir = execFileSync("npm", ["run", "--silent", "prepare:package"], {
       cwd: packageDir,
@@ -76,6 +87,7 @@ async function main() {
           dependencies: {
             "@rlrml/subtr-actor": `file:${path.relative(consumerDir, bindingsTarballPath)}`,
             [playerPackage.name]: `file:${path.relative(consumerDir, playerTarballPath)}`,
+            [viewerPackage.name]: `file:${path.relative(consumerDir, viewerTarballPath)}`,
             [sourcePackage.name]: `file:${path.relative(consumerDir, statsTarballPath)}`,
             three: "^0.180.0",
           },
@@ -219,6 +231,9 @@ async function main() {
   } finally {
     if (playerPublishDir) {
       await rm(playerPublishDir, { force: true, recursive: true });
+    }
+    if (viewerPublishDir) {
+      await rm(viewerPublishDir, { force: true, recursive: true });
     }
     if (statsPublishDir) {
       await rm(statsPublishDir, { force: true, recursive: true });

--- a/js/viewer/package-lock.json
+++ b/js/viewer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rlrml/viewer",
-  "version": "0.12.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rlrml/viewer",
-      "version": "0.12.0",
+      "version": "1.0.2",
       "dependencies": {
         "@rlrml/player": "file:../player",
         "@rlrml/subtr-actor": "file:../pkg",

--- a/js/viewer/package.json
+++ b/js/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rlrml/viewer",
-  "version": "0.12.0",
+  "version": "1.0.2",
   "description": "High-fidelity 3D Rocket League replay viewer powered by subtr-actor (seeded from ballcam.tv with permission)",
   "type": "module",
   "main": "./dist/index.js",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0"
 
 [dependencies.subtr-actor]
 path = ".."
-version = "1.0.1"
+version = "1.0.2"
 
 [dependencies.pyo3]
 version = "0.27.2"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtr-actor-py"
-version = "1.0.1"
+version = "1.0.2"
 description = "Python bindings for the Rocket League replay processing library subtr-actor."
 authors = [{ name = "Ivan Malison", email = "ivanmalison@gmail.com" }]
 license = { text = "MIT" }

--- a/scripts/check_release_versions.py
+++ b/scripts/check_release_versions.py
@@ -13,6 +13,7 @@ CHANGELOG = ROOT / "CHANGELOG.md"
 JS_PACKAGE_PATHS = [
     "js/package.json",
     "js/player/package.json",
+    "js/viewer/package.json",
     "js/stat-evaluation-player/package.json",
     "js/pages/package.json",
 ]
@@ -20,6 +21,7 @@ JS_PACKAGE_PATHS = [
 JS_PACKAGE_LOCK_PATHS = [
     "js/package-lock.json",
     "js/player/package-lock.json",
+    "js/viewer/package-lock.json",
     "js/stat-evaluation-player/package-lock.json",
 ]
 

--- a/scripts/sync_release_versions.py
+++ b/scripts/sync_release_versions.py
@@ -14,6 +14,7 @@ ROOT = Path(__file__).resolve().parent.parent
 PACKAGE_JSON_PATHS = [
     "js/package.json",
     "js/player/package.json",
+    "js/viewer/package.json",
     "js/stat-evaluation-player/package.json",
     "js/pages/package.json",
 ]
@@ -21,6 +22,7 @@ PACKAGE_JSON_PATHS = [
 PACKAGE_LOCK_PATHS = [
     "js/package-lock.json",
     "js/player/package-lock.json",
+    "js/viewer/package-lock.json",
     "js/stat-evaluation-player/package-lock.json",
 ]
 


### PR DESCRIPTION
## Summary
- bump release metadata to v1.0.2 after the v1.0.1 JS workflow failed before npm publish
- include @rlrml/viewer in release version checks and the JS publish workflow
- package stats-player with an explicit @rlrml/viewer dependency and smoke-test it via a local viewer tarball

## Verification
- python3 scripts/check_release_versions.py
- cargo metadata --locked --format-version 1 > /dev/null
- npm --prefix js run check:style
- npm --prefix js/stat-evaluation-player ci
- npm --prefix js/stat-evaluation-player run smoke:install