### PR TITLE
[codex] Tighten kickoff support boost classification

### DIFF
--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -32,6 +32,7 @@ const KICKOFF_PRESSURE_MIN_ESTABLISH_SECONDS: f32 = 2.0;
 const KICKOFF_PRESSURE_MIN_ESTABLISH_THIRD_SECONDS: f32 = 0.75;
 const KICKOFF_SUPPORT_GO_FOR_BOOST_MIN_LATERAL_MOVE: f32 = 600.0;
 const KICKOFF_SUPPORT_GO_FOR_BOOST_MIN_BOOST_GAIN: f32 = 10.0;
+const KICKOFF_SUPPORT_BACK_BIG_MAX_SECONDS_AFTER_GO: f32 = 3.0;
 
 #[derive(Debug, Clone, PartialEq)]
 struct KickoffPlayerSnapshot {
@@ -65,6 +66,7 @@ struct KickoffApproachTrace {
     /// reported boost balances reconcile, so summing positive deltas
     /// double-counts and can push `boost_used` past a full tank.
     pickup_boost_collected: f32,
+    picked_up_immediate_own_back_big_boost: bool,
     last_position: Option<[f32; 3]>,
     previous_velocity: Option<glam::Vec3>,
     previous_dodge_active: bool,
@@ -859,7 +861,43 @@ impl KickoffCalculator {
                 continue;
             }
             snapshot.approach_trace.pickup_boost_collected += pickup.collected_amount;
+            if Self::is_immediate_own_back_big_pickup(snapshot, pickup, lower_bound) {
+                snapshot
+                    .approach_trace
+                    .picked_up_immediate_own_back_big_boost = true;
+            }
         }
+    }
+
+    fn is_immediate_own_back_big_pickup(
+        player: &KickoffPlayerSnapshot,
+        pickup: &BoostPickupEvent,
+        movement_start_time: f32,
+    ) -> bool {
+        if pickup.pad_type != BoostPickupPadType::Big {
+            return false;
+        }
+        if pickup.time < movement_start_time {
+            return false;
+        }
+        if pickup.time - movement_start_time > KICKOFF_SUPPORT_BACK_BIG_MAX_SECONDS_AFTER_GO {
+            return false;
+        }
+        let Some(position) = pickup.player_position else {
+            return false;
+        };
+        let pickup_position = glam::Vec2::new(position[0], position[1]);
+        let own_back_y = if player.is_team_0 {
+            -BOOST_PAD_BACK_CORNER_Y
+        } else {
+            BOOST_PAD_BACK_CORNER_Y
+        };
+        [-BOOST_PAD_BACK_CORNER_X, BOOST_PAD_BACK_CORNER_X]
+            .iter()
+            .any(|x| {
+                pickup_position.distance(glam::Vec2::new(*x, own_back_y))
+                    <= STANDARD_PAD_MATCH_RADIUS_BIG
+            })
     }
 
     fn apply_speed_flip_events(
@@ -1128,7 +1166,6 @@ impl KickoffCalculator {
     fn classify_support_behavior(
         player: &KickoffPlayerSnapshot,
         is_taker: bool,
-        boost_after: Option<f32>,
     ) -> Option<KickoffSupportBehavior> {
         if is_taker {
             return None;
@@ -1138,9 +1175,7 @@ impl KickoffCalculator {
         {
             return Some(KickoffSupportBehavior::Cheat);
         }
-        if Self::boost_gain(player, boost_after) >= KICKOFF_SUPPORT_GO_FOR_BOOST_MIN_BOOST_GAIN
-            || Self::lateral_movement(player) >= KICKOFF_SUPPORT_GO_FOR_BOOST_MIN_LATERAL_MOVE
-        {
+        if player.approach_trace.picked_up_immediate_own_back_big_boost {
             return Some(KickoffSupportBehavior::GoForBoost);
         }
         Some(KickoffSupportBehavior::Other)
@@ -1634,7 +1669,7 @@ impl KickoffCalculator {
                     boost_after,
                     first_touch_time: player.first_touch_time,
                     first_touch_frame: player.first_touch_frame,
-                    support_behavior: Self::classify_support_behavior(player, false, boost_after)
+                    support_behavior: Self::classify_support_behavior(player, false)
                         .unwrap_or_default(),
                 };
                 if player_event.is_team_0 {

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -41,13 +41,33 @@ fn boost_pickup(
     time: f32,
     collected_amount: f32,
 ) -> BoostPickupEvent {
+    boost_pickup_at(
+        player_id,
+        is_team_0,
+        frame,
+        time,
+        collected_amount,
+        BoostPickupPadType::Big,
+        None,
+    )
+}
+
+fn boost_pickup_at(
+    player_id: PlayerId,
+    is_team_0: bool,
+    frame: usize,
+    time: f32,
+    collected_amount: f32,
+    pad_type: BoostPickupPadType,
+    player_position: Option<[f32; 3]>,
+) -> BoostPickupEvent {
     BoostPickupEvent {
         frame,
         time,
         player_id,
-        player_position: None,
+        player_position,
         is_team_0,
-        pad_type: BoostPickupPadType::Big,
+        pad_type,
         field_half: BoostPickupFieldHalf::Own,
         activity: BoostPickupActivity::Active,
         detection: BoostPickupDetection::Both,
@@ -677,14 +697,14 @@ fn kickoff_classifies_support_players_as_cheating_or_going_for_boost() {
         .unwrap();
 
     calculator
-        .update(
-            &frame(5, 0.5),
-            &GameplayState {
+        .update_with_speed_flips(KickoffUpdateContext {
+            frame: &frame(5, 0.5),
+            gameplay: &GameplayState {
                 ball_has_been_hit: Some(false),
                 ..GameplayState::default()
             },
-            &ball(0.0),
-            &PlayerFrameState {
+            ball: &ball(0.0),
+            players: &PlayerFrameState {
                 players: vec![
                     player(
                         blue_cheat.clone(),
@@ -695,14 +715,24 @@ fn kickoff_classifies_support_players_as_cheating_or_going_for_boost() {
                     player(
                         orange_boost.clone(),
                         false,
-                        glam::Vec3::new(900.0, 4300.0, 17.0),
+                        glam::Vec3::new(3072.0, 4096.0, 17.0),
                         100.0,
                     ),
                 ],
             },
-            &TouchState::default(),
-            &FrameEventsState::default(),
-        )
+            touch_state: &TouchState::default(),
+            events: &FrameEventsState::default(),
+            speed_flip_events: &[],
+            boost_pickups: &[boost_pickup_at(
+                orange_boost.clone(),
+                false,
+                5,
+                0.5,
+                67.0,
+                BoostPickupPadType::Big,
+                Some([3072.0, 4096.0, 73.0]),
+            )],
+        })
         .unwrap();
 
     calculator
@@ -743,7 +773,7 @@ fn kickoff_classifies_support_players_as_cheating_or_going_for_boost() {
                     player(
                         orange_boost.clone(),
                         false,
-                        glam::Vec3::new(1200.0, 4300.0, 17.0),
+                        glam::Vec3::new(3072.0, 4096.0, 17.0),
                         100.0,
                     ),
                 ],
@@ -796,6 +826,108 @@ fn kickoff_classifies_support_players_as_cheating_or_going_for_boost() {
             .support_go_for_boosts,
         1
     );
+}
+
+#[test]
+fn kickoff_support_boost_gain_without_boost_route_is_other() {
+    let support = KickoffPlayerSnapshot {
+        player: PlayerId::Epic("calemacar".to_owned()),
+        is_team_0: false,
+        start_position: [2048.0, 2560.0, 17.0],
+        spawn_position: KickoffSpawnPosition::DiagonalLeft,
+        start_boost: Some(85.0),
+        first_touch_boost: None,
+        first_touch_time: None,
+        first_touch_frame: None,
+        approach_trace: KickoffApproachTrace {
+            min_boost: Some(85.0),
+            last_position: Some([2100.0, 2200.0, 17.0]),
+            previous_boost: Some(145.0),
+            ..KickoffApproachTrace::default()
+        },
+    };
+
+    assert_eq!(
+        KickoffCalculator::classify_support_behavior(&support, false),
+        Some(KickoffSupportBehavior::Other)
+    );
+}
+
+#[test]
+fn kickoff_support_go_for_boost_requires_immediate_own_back_big() {
+    let support_id = PlayerId::Epic("support".to_owned());
+    let support = KickoffPlayerSnapshot {
+        player: support_id.clone(),
+        is_team_0: false,
+        start_position: [2048.0, 2560.0, 17.0],
+        spawn_position: KickoffSpawnPosition::DiagonalLeft,
+        start_boost: Some(85.0),
+        first_touch_boost: None,
+        first_touch_time: None,
+        first_touch_frame: None,
+        approach_trace: KickoffApproachTrace::default(),
+    };
+    let movement_start_time = 10.0;
+
+    let own_back_big = boost_pickup_at(
+        support_id.clone(),
+        false,
+        20,
+        12.0,
+        170.0,
+        BoostPickupPadType::Big,
+        Some([3072.0, 4096.0, 73.0]),
+    );
+    assert!(KickoffCalculator::is_immediate_own_back_big_pickup(
+        &support,
+        &own_back_big,
+        movement_start_time,
+    ));
+
+    let small_pad = boost_pickup_at(
+        support_id.clone(),
+        false,
+        20,
+        12.0,
+        30.6,
+        BoostPickupPadType::Small,
+        Some([3072.0, 4096.0, 73.0]),
+    );
+    assert!(!KickoffCalculator::is_immediate_own_back_big_pickup(
+        &support,
+        &small_pad,
+        movement_start_time,
+    ));
+
+    let midfield_big = boost_pickup_at(
+        support_id.clone(),
+        false,
+        20,
+        12.0,
+        170.0,
+        BoostPickupPadType::Big,
+        Some([3584.0, 0.0, 73.0]),
+    );
+    assert!(!KickoffCalculator::is_immediate_own_back_big_pickup(
+        &support,
+        &midfield_big,
+        movement_start_time,
+    ));
+
+    let late_back_big = boost_pickup_at(
+        support_id,
+        false,
+        20,
+        movement_start_time + KICKOFF_SUPPORT_BACK_BIG_MAX_SECONDS_AFTER_GO + 0.1,
+        170.0,
+        BoostPickupPadType::Big,
+        Some([3072.0, 4096.0, 73.0]),
+    );
+    assert!(!KickoffCalculator::is_immediate_own_back_big_pickup(
+        &support,
+        &late_back_big,
+        movement_start_time,
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Tightens kickoff support `go_for_boost` classification so it is no longer inferred from generic boost gain or lateral movement.

Support players now only receive `go_for_boost` when the kickoff approach includes an immediate pickup of one of their own back-corner big boosts. Small-pad chains, midfield big pickups, delayed corner boost pickups, and ordinary boost gain fall through to `other` unless the player qualifies as a cheat.

## Root Cause

The previous classifier treated final boost gain or sufficient lateral movement as enough to label support behavior as `go_for_boost`. In the reported CaleMaCar kickoff, the player appeared to collect small pads and gained boost, which triggered the label even though they did not clearly take the back big boost kickoff role.

## Validation

- `cargo test stats::calculators::kickoff::tests`
- Commit hook: `cargo clippy --all-targets --all-features -- -D warnings`
