### PR TITLE
[codex] Tighten delayed-dodge flick candidates

### DIFF
--- a/src/stats/calculators/flick.rs
+++ b/src/stats/calculators/flick.rs
@@ -4,6 +4,7 @@ const FLICK_MAX_DODGE_TO_TOUCH_SECONDS: f32 = 0.32;
 const FLICK_MAX_CONTROL_TO_DODGE_SECONDS: f32 = 0.08;
 const FLICK_MAX_SETUP_STALE_SECONDS: f32 = 0.35;
 const FLICK_DODGE_LAG_TOLERANCE_SECONDS: f32 = 0.12;
+const FLICK_MIN_PENDING_DODGE_SETUP_SECONDS: f32 = 0.10;
 const FLICK_MIN_SETUP_SECONDS: f32 = 0.20;
 const FLICK_MIN_BALL_SPEED_CHANGE: f32 = 325.0;
 const FLICK_MIN_CONFIDENCE: f32 = 0.55;
@@ -653,6 +654,9 @@ impl FlickCalculator {
         touch_event: &TouchEvent,
     ) -> Option<RecentDodgeStart> {
         let setup = self.recent_setup_for_player(&player.player_id, touch_event.time)?;
+        if setup.duration < FLICK_MIN_PENDING_DODGE_SETUP_SECONDS {
+            return None;
+        }
         Some(RecentDodgeStart {
             time: touch_event.time,
             frame: touch_event.frame,

--- a/src/stats/calculators/flick_tests.rs
+++ b/src/stats/calculators/flick_tests.rs
@@ -250,6 +250,98 @@ fn counts_dodge_contact_touch_when_dodge_transition_is_late() {
 }
 
 #[test]
+fn rejects_late_dodge_touch_with_only_single_frame_setup() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = FlickCalculator::new();
+    let live_play = live_play();
+
+    calculator
+        .update(
+            &FrameInfo {
+                frame_number: 1,
+                time: 0.046,
+                dt: 0.046,
+                seconds_remaining: None,
+            },
+            &ball(glam::Vec3::new(60.0, 0.0, 112.0), glam::Vec3::ZERO),
+            &players(false),
+            &touch_state(Vec::new()),
+            &TouchCalculator::new(),
+            &live_play,
+        )
+        .unwrap();
+
+    calculator
+        .update_with_touch_classification_events(
+            &FrameInfo {
+                frame_number: 2,
+                time: 0.092,
+                dt: 0.046,
+                seconds_remaining: None,
+            },
+            &ball(
+                glam::Vec3::new(180.0, 0.0, 160.0),
+                glam::Vec3::new(1800.0, 0.0, 750.0),
+            ),
+            &players(false),
+            &touch_state(vec![TouchEvent {
+                touch_id: None,
+                time: 0.092,
+                frame: 2,
+                team_is_team_0: true,
+                player: Some(player_id.clone()),
+                player_position: None,
+                closest_approach_distance: Some(0.0),
+                dodge_contact: false,
+            }]),
+            &[],
+            &live_play,
+        )
+        .unwrap();
+
+    calculator
+        .update_with_touch_classification_events(
+            &FrameInfo {
+                frame_number: 3,
+                time: 0.138,
+                dt: 0.046,
+                seconds_remaining: None,
+            },
+            &ball(
+                glam::Vec3::new(180.0, 0.0, 160.0),
+                glam::Vec3::new(1800.0, 0.0, 750.0),
+            ),
+            &players(true),
+            &touch_state(Vec::new()),
+            &[TouchClassificationEvent {
+                touch_id: None,
+                time: 0.092,
+                frame: 2,
+                sample_time: 0.092,
+                sample_frame: 2,
+                player: player_id,
+                player_position: None,
+                is_team_0: true,
+                kind: "hard_hit".to_owned(),
+                height_band: "ground".to_owned(),
+                surface: "ground".to_owned(),
+                dodge_state: "dodge".to_owned(),
+                intention: "shot".to_owned(),
+                first_touch: false,
+                contested: false,
+                role: RoleState::Unknown,
+                play_depth: PlayDepthState::Unknown,
+                ball_speed_change: 1800.0,
+                ball_movement: None,
+            }],
+            &live_play,
+        )
+        .unwrap();
+
+    assert!(calculator.events().is_empty());
+}
+
+#[test]
 fn labels_reverse_flicks_with_backflip_pitch_forward_impulse_and_rotation_under_ball() {
     let player_id = boxcars::RemoteId::Steam(1);
     let mut calculator = FlickCalculator::new();


### PR DESCRIPTION
## Summary

- add a minimum close-control duration for delayed-dodge flick candidates
- reject one-frame close-contact blips that the touch classifier later upgrades to dodge
- keep fast real flicks eligible when they have more than a single frame of close-control setup

## Context

PR #160 landed the delayed-dodge flick recognition path. Follow-up replay review showed that path was too permissive for single-frame control blips on goals 3 and 6 of replay 019ebf5c-0640-7a22-8f0a-8a590b5515c1. This adds a narrower guard only for the delayed-dodge pending path.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test stats::calculators::flick::tests
- cargo test flick_goal
- replay diagnostic confirmed the original replay still labels the first three orange flick goals
- replay diagnostic confirmed replay 019ebf5c-0640-7a22-8f0a-8a590b5515c1 no longer adds FlickGoal on the reported false-positive goals
