### PR TITLE
Loosen whiff detector into a high-recall candidate generator

### DIFF
--- a/src/stats/calculators/whiff.rs
+++ b/src/stats/calculators/whiff.rs
@@ -1,16 +1,26 @@
 use super::*;
 
-const WHIFF_ENTER_DISTANCE: f32 = 150.0;
-const WHIFF_EXIT_DISTANCE: f32 = 285.0;
-const WHIFF_MAX_CANDIDATE_SECONDS: f32 = 0.65;
-const WHIFF_MIN_APPROACH_SPEED: f32 = 700.0;
-const WHIFF_MIN_CLOSING_SPEED: f32 = 450.0;
-const WHIFF_MIN_FORWARD_ALIGNMENT: f32 = 0.55;
-const WHIFF_MIN_VELOCITY_ALIGNMENT: f32 = 0.7;
+// These thresholds are intentionally permissive. The whiff detector feeds a
+// human confirm/reject review loop (rocket-sense `event_reviews`) whose purpose
+// is to build a labeled dataset, so it is tuned for recall rather than
+// precision: it flags essentially any committed move at a nearby ball that did
+// not produce a touch as a *candidate*, and leaves reviewers to prune the false
+// positives. Precision is recovered downstream from the labels, not here.
+//
+// The non-dodge approach path and the shared distance/time gates carry the
+// loosening; the dodge-specific gates below are left at their stricter values so
+// a clear side-dodge past the ball is still not treated as an attempt.
+const WHIFF_ENTER_DISTANCE: f32 = 220.0;
+const WHIFF_EXIT_DISTANCE: f32 = 360.0;
+const WHIFF_MAX_CANDIDATE_SECONDS: f32 = 1.0;
+const WHIFF_MIN_APPROACH_SPEED: f32 = 350.0;
+const WHIFF_MIN_CLOSING_SPEED: f32 = 250.0;
+const WHIFF_MIN_FORWARD_ALIGNMENT: f32 = 0.3;
+const WHIFF_MIN_VELOCITY_ALIGNMENT: f32 = 0.45;
 const WHIFF_MIN_DODGE_APPROACH_SPEED: f32 = 450.0;
 const WHIFF_MIN_DODGE_CLOSING_SPEED: f32 = 300.0;
 const WHIFF_MIN_DODGE_FORWARD_ALIGNMENT: f32 = 0.25;
-const WHIFF_MAX_LATERAL_OFFSET: f32 = 120.0;
+const WHIFF_MAX_LATERAL_OFFSET: f32 = 200.0;
 const WHIFF_MAX_DODGE_LATERAL_OFFSET: f32 = 150.0;
 const WHIFF_MIN_LOCAL_FORWARD_OFFSET: f32 = 0.0;
 const WHIFF_MIN_DODGE_LOCAL_FORWARD_OFFSET: f32 = -20.0;

--- a/src/stats/calculators/whiff_tests.rs
+++ b/src/stats/calculators/whiff_tests.rs
@@ -92,7 +92,7 @@ fn counts_near_miss_after_player_exits_ball_area() {
             &frame(2, 0.2),
             &ball,
             &PlayerFrameState {
-                players: vec![player(1, 460.0, false)],
+                players: vec![player(1, 560.0, false)],
             },
             &touch_state,
             &LivePlayState::active_play(),
@@ -103,6 +103,55 @@ fn counts_near_miss_after_player_exits_ball_area() {
     assert_eq!(stats.whiff_count, 1);
     assert_eq!(stats.grounded_whiff_count, 1);
     assert_eq!(calculator.events().len(), 1);
+}
+
+#[test]
+fn loosened_detector_counts_moderate_speed_approach_as_candidate() {
+    // A ~500 uu/s committed approach that gets close to the ball and then leaves
+    // without a touch sits below the old 700 uu/s arming gate, but now registers
+    // as a whiff candidate for review.
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = WhiffCalculator::new();
+    let ball = ball();
+    let touch_state = TouchState::default();
+
+    calculator
+        .update(
+            &frame(1, 0.1),
+            &ball,
+            &PlayerFrameState {
+                players: vec![player_at(
+                    1,
+                    glam::Vec3::new(-200.0, 0.0, 17.0),
+                    glam::Vec3::new(500.0, 0.0, 0.0),
+                    false,
+                )],
+            },
+            &touch_state,
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(2, 0.2),
+            &ball,
+            &PlayerFrameState {
+                players: vec![player_at(
+                    1,
+                    glam::Vec3::new(560.0, 0.0, 17.0),
+                    glam::Vec3::new(500.0, 0.0, 0.0),
+                    false,
+                )],
+            },
+            &touch_state,
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    let stats = calculator.player_stats().get(&player_id).unwrap();
+    assert_eq!(stats.whiff_count, 1);
+    assert_eq!(calculator.events().len(), 1);
+    assert_eq!(calculator.events()[0].kind, WhiffEventKind::Whiff);
 }
 
 #[test]


### PR DESCRIPTION
## Why

The whiff / beaten-to-ball detector (`src/stats/calculators/whiff.rs`) was precision-tuned with strict arming gates, so it misses many genuine attempts at the ball. We're repurposing it as the front end of a human **confirm/reject review loop** in rocket-sense (`event_reviews`) whose goal is to build a *labeled dataset* of whiffs / beaten-to-ball / attempts. For that job the detector should err toward **recall**: flag essentially any committed move at a nearby ball that did not produce a touch as a *candidate*, and let reviewers prune the false positives. Precision is recovered downstream from the labels, not in the detector.

## What

Loosen the **non-dodge approach path** and the **shared distance/time gates**:

| constant | before | after |
|---|---|---|
| `WHIFF_ENTER_DISTANCE` | 150 | 220 |
| `WHIFF_EXIT_DISTANCE` | 285 | 360 |
| `WHIFF_MAX_CANDIDATE_SECONDS` | 0.65 | 1.0 |
| `WHIFF_MIN_APPROACH_SPEED` | 700 | 350 |
| `WHIFF_MIN_CLOSING_SPEED` | 450 | 250 |
| `WHIFF_MIN_FORWARD_ALIGNMENT` | 0.55 | 0.3 |
| `WHIFF_MIN_VELOCITY_ALIGNMENT` | 0.7 | 0.45 |
| `WHIFF_MAX_LATERAL_OFFSET` | 120 | 200 |

The **dodge-specific gates are left stricter** so a clear side-dodge past the ball is still not treated as an attempt (keeps an anchor negative).

No `WhiffEvent` / `WhiffEventKind` schema change, so **TS bindings are unaffected** and propagation to rocket-sense stays a pure `sync-subtr-actor`.

## Tests

- All existing whiff tests pass, including the "not an attempt" negatives (lateral drive-by, velocity-matched pacing, side dodge) kept as anchors.
- Added `loosened_detector_counts_moderate_speed_approach_as_candidate` covering a ~500 uu/s approach that was below the old 700 gate and now registers as a candidate.

## Follow-up (not in this PR)

This is phase 1. Next: `sync-subtr-actor` into rocket-sense so these candidates flow into the existing `event_reviews` confirm/reject system, then deploy. The collected labels become regression test cases for the detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
