### PR TITLE
fix(player): keep team boost HUD on-screen on small viewports

### DIFF
--- a/js/player/src/ballchasing-overlay.ts
+++ b/js/player/src/ballchasing-overlay.ts
@@ -259,6 +259,43 @@ function ensureStyles(): void {
         font-size: 0.64rem;
         padding-inline: 0.58rem;
       }
+
+      /*
+       * Team HUDs (a row of per-player boost bars on each side of center) are
+       * too wide for a phone: with fixed-width bars a 3v3 roster runs off both
+       * edges. Cap each HUD to its half of the viewport, anchor it tight to
+       * center, and let the bars flex-shrink to share the space.
+       */
+      .sap-bc-team-hud {
+        max-width: calc(50vw - 0.6rem);
+        gap: 0.2rem;
+        padding: 0.28rem 0.3rem;
+      }
+
+      .sap-bc-team-hud-blue {
+        right: calc(50% + 0.3rem);
+      }
+
+      .sap-bc-team-hud-orange {
+        left: calc(50% + 0.3rem);
+      }
+
+      .sap-bc-team-hud .sap-bc-hud-player {
+        flex: 1 1 0;
+        min-width: 0;
+      }
+
+      .sap-bc-hud-boost-bar {
+        min-width: 0;
+        max-width: none;
+        width: 100%;
+      }
+
+      .sap-bc-hud-boost-text {
+        gap: 0.2rem;
+        padding-inline: 0.32rem;
+        font-size: 0.58rem;
+      }
     }
   `;
   document.head.append(style);


### PR DESCRIPTION
## Summary

The ballchasing overlay's two team boost HUDs are anchored on either side of center with fixed-width per-player boost bars (`min-width: 5.9rem` each). On phone-width screens a 3v3 roster is wider than each half of the viewport, so **both HUDs ran off the left and right edges** (measured: a HUD's left edge at ~−30px, right edge at ~+417px on a 390px screen).

## Fix

A `@media (max-width: 640px)` rule that:
- caps each team HUD to its half of the viewport — `max-width: calc(50vw - 0.6rem)`
- anchors them tight to center (offset `2.7rem` → `0.3rem`)
- lets the per-player bars flex-shrink to share the space — `.sap-bc-hud-player { flex: 1 1 0; min-width: 0 }`, `.sap-bc-hud-boost-bar { min-width: 0; width: 100% }`
- tightens padding/font slightly so the compact bars stay legible

Desktop and tablet (>640px) are unchanged.

## Verification

- Headless Chrome at a 390×844 (DPR 2) phone viewport: both HUDs now fit (blue 49–191px, orange 199–349px) with **zero horizontal overflow** in `.sap-bc-overlay-root`.
- `npm run check:style` (prettier + eslint) and the player package `tsc --noEmit` pass.

Found while making the stat-evaluation-player usable on mobile; this is the shared upstream piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
