### PR TITLE
feat(stat-evaluation-player): dock floating windows as a bottom split on mobile

### DIFF
--- a/js/stat-evaluation-player/src/styles/responsive.css
+++ b/js/stat-evaluation-player/src/styles/responsive.css
@@ -42,3 +42,36 @@
     width: auto;
   }
 }
+
+/*
+ * Small screens: an open floating window splits the screen with the viewport
+ * (docked bottom sheet) instead of floating PiP over it. The 3D viewport shrinks
+ * to the top (its canvas auto-resizes via ResizeObserver) and the open window(s)
+ * dock to the bottom as a scrollable sheet. Scoped to `.floating-window`, so the
+ * top scoreboard pill and the launcher menu are unaffected.
+ */
+@media (max-width: 720px) {
+  /* Reserve the bottom for the sheet only while a floating window is open. */
+  .viewport-panel:has(.floating-window:not([hidden])) .viewport {
+    inset: 0 0 52dvh 0;
+  }
+
+  .floating-window {
+    position: fixed;
+    inset: auto 0 0 0;
+    width: 100%;
+    max-width: none;
+    height: 52dvh;
+    max-height: 52dvh;
+    overflow: auto;
+    border-width: 1px 0 0 0;
+    border-radius: 1rem 1rem 0 0;
+    transform: none;
+    z-index: 30;
+  }
+
+  /* Dragging is meaningless once the sheet is docked. */
+  .floating-window .floating-window-header {
+    cursor: default;
+  }
+}


### PR DESCRIPTION
## Summary

On small screens an open floating window (Camera, Playback, etc.) floated as a PiP over the whole viewport, and its tall content overflowed off-screen. Now, at ≤720px, an open window **docks to the bottom half as a scrollable sheet and the 3D viewport shrinks to the top half** — a clean split instead of an overlay.

## How

A `@media (max-width: 720px)` block in the stats player's `responsive.css`:
- `.viewport-panel:has(.floating-window:not([hidden])) .viewport { inset: 0 0 52dvh 0 }` — reserves the bottom only while a window is open; the viewport's WebGL canvas auto-resizes via its existing `ResizeObserver`.
- `.floating-window` → `position: fixed; inset: auto 0 0 0; height: 52dvh; overflow: auto` — docks open windows as a bottom sheet.

Scoped to `.floating-window`, so the top scoreboard pill and launcher menu are untouched. The drag controller writes CSS variables (not inline `left/top`), so the override wins without `!important`. Closing the window restores the full-height viewport.

## Verification

Headless Chrome at 390×844: viewport top 405px (canvas resized to 390×405) + camera sheet bottom 439px, full width; closing restores the viewport to full height. `prettier --check` passes (CSS-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
