### PR TITLE
Fix viewer asset paths on Pages

### DIFF
--- a/js/pages/package-lock.json
+++ b/js/pages/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subtr-actor-pages",
-  "version": "0.11.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subtr-actor-pages",
-      "version": "0.11.0",
+      "version": "1.0.2",
       "dependencies": {
         "fflate": "^0.8.2"
       },

--- a/js/pages/vite.config.ts
+++ b/js/pages/vite.config.ts
@@ -50,10 +50,15 @@ function ensureWasmBindingsPlugin() {
 export default defineConfig({
   base: "./",
   plugins: [ensureWasmBindingsPlugin()],
+  publicDir: path.resolve(import.meta.dirname, "../player/public"),
   resolve: {
     alias: {
       "@rlrml/subtr-actor": path.resolve(import.meta.dirname, "../pkg/rl_replay_subtr_actor.js"),
       "@rlrml/player": path.resolve(import.meta.dirname, "../player/src/lib.ts"),
+      "camera-controls": path.resolve(
+        import.meta.dirname,
+        "../stat-evaluation-player/node_modules/camera-controls",
+      ),
       three: path.resolve(import.meta.dirname, "../stat-evaluation-player/node_modules/three"),
     },
   },

--- a/js/player/src/lib.ts
+++ b/js/player/src/lib.ts
@@ -14,6 +14,7 @@ export {
   ViewerPlayer,
   ViewerPlayer as ReplayPlayer,
 } from "./viewer/lib";
+export { getViewerAssetBase, resolveViewerAssetUrl, setViewerAssetBase } from "./viewer/asset-url";
 export type {
   CameraPlugin,
   CameraPluginMode,

--- a/js/player/src/viewer/ViewerPlayer.ts
+++ b/js/player/src/viewer/ViewerPlayer.ts
@@ -306,17 +306,19 @@ export class ViewerPlayer extends EventTarget {
       options.initialSkipPostGoalTransitionsEnabled ?? true;
     this.skipKickoffsEnabledValue = options.initialSkipKickoffsEnabled ?? false;
 
-    this.sceneManager = new SceneManager(container);
+    this.sceneManager = new SceneManager(container, { assetBase: options.assetBase });
     // Neutral IBL renders instantly so playback starts immediately; the HDR
     // environment (default "space") loads lazily and swaps in once decoded.
     this.sceneManager.initDefaultEnvironment();
     this.applyEnvironmentSpec(options.environment ?? DEFAULT_ENVIRONMENT_ID);
-    this.arenaManager = new ArenaManager(this.scene);
+    this.arenaManager = new ArenaManager(this.scene, { assetBase: options.assetBase });
     // Trails (boost / supersonic / ball). Explosions stay dormant until the
     // adapter exposes goal/demo events (its event getters are still stubs).
     this.effectsEnabled = options.effects ?? true;
     this.effectsManager = this.effectsEnabled ? new EffectsManager(this.scene) : effectsStub;
-    this.actorManager = new ActorManager(this.scene, this.effectsManager);
+    this.actorManager = new ActorManager(this.scene, this.effectsManager, {
+      assetBase: options.assetBase,
+    });
     if (options.motionInterpolation) {
       this.setMotionInterpolation(options.motionInterpolation);
     }

--- a/js/player/src/viewer/asset-url.js
+++ b/js/player/src/viewer/asset-url.js
@@ -1,0 +1,36 @@
+let configuredAssetBase = null;
+
+function documentBaseUrl() {
+  if (typeof document !== "undefined" && document.baseURI) {
+    return document.baseURI;
+  }
+  if (typeof window !== "undefined" && window.location?.href) {
+    return window.location.href;
+  }
+  return import.meta.url;
+}
+
+function viteBaseUrl() {
+  return import.meta.env?.BASE_URL ?? "/";
+}
+
+function isAbsoluteUrl(path) {
+  return /^[a-z][a-z\d+\-.]*:/i.test(path) || path.startsWith("//");
+}
+
+export function setViewerAssetBase(assetBase) {
+  configuredAssetBase = assetBase == null ? null : String(assetBase);
+}
+
+export function getViewerAssetBase(assetBase = configuredAssetBase) {
+  const base = assetBase == null || assetBase === "" ? viteBaseUrl() : String(assetBase);
+  return new URL(base, documentBaseUrl()).href;
+}
+
+export function resolveViewerAssetUrl(path, assetBase = configuredAssetBase) {
+  const rawPath = String(path);
+  if (isAbsoluteUrl(rawPath)) {
+    return rawPath;
+  }
+  return new URL(rawPath.replace(/^\/+/, ""), getViewerAssetBase(assetBase)).href;
+}

--- a/js/player/src/viewer/environments.ts
+++ b/js/player/src/viewer/environments.ts
@@ -16,8 +16,9 @@ export interface ViewerEnvironment {
   /** Stable id (also the key used to look it up). */
   id: string;
   /**
-   * URL of the equirectangular HDR skybox, resolved against the web root.
-   * Bundled assets live under `public/skyboxes/` and ship with the package.
+   * URL of the equirectangular HDR skybox, resolved against the viewer asset
+   * base unless absolute. Bundled assets live under `public/skyboxes/` and ship
+   * with the package.
    */
   skyboxUrl: string;
   /** `renderer.toneMappingExposure` while this environment is active (default 1.0). */

--- a/js/player/src/viewer/lib.ts
+++ b/js/player/src/viewer/lib.ts
@@ -68,6 +68,7 @@ export function createViewerFromParsed(
 
 export { ViewerPlayer } from "./ViewerPlayer.js";
 export { SubtrActorPlayer } from "./adapter/SubtrActorPlayer.js";
+export { getViewerAssetBase, resolveViewerAssetUrl, setViewerAssetBase } from "./asset-url.js";
 export type {
   RecordedCameraSettings,
   SubtrActorPlayerOptions,

--- a/js/player/src/viewer/managers/ActorManager.js
+++ b/js/player/src/viewer/managers/ActorManager.js
@@ -1,12 +1,14 @@
 import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { getCarHitboxInfo } from "../data/hitboxes.js";
+import { resolveViewerAssetUrl } from "../asset-url.js";
 import { CarModelLoader } from "./CarModelLoader.js";
 
 export class ActorManager {
-  constructor(scene, effectsManager) {
+  constructor(scene, effectsManager, options = {}) {
     this.scene = scene;
     this.effectsManager = effectsManager;
+    this.assetBase = options.assetBase;
     this.actors = {}; // actorId -> Mesh
     this.ballActorId = null;
     this.ballIndicator = null;
@@ -25,7 +27,7 @@ export class ActorManager {
     this.carBodyIds = {}; // actorId -> bodyId
 
     // Car model loader for FBX models
-    this.carModelLoader = new CarModelLoader();
+    this.carModelLoader = new CarModelLoader({ assetBase: this.assetBase });
     this.pendingCarReplacements = new Map(); // actorId -> hitboxType (cars waiting for model)
 
     // Reusable vectors for interpolation
@@ -96,7 +98,7 @@ export class ActorManager {
     const gltfLoader = new GLTFLoader();
     this.ballModelReady = new Promise((resolve) => {
       gltfLoader.load(
-        "/models/ball/scene.gltf",
+        resolveViewerAssetUrl("models/ball/scene.gltf", this.assetBase),
         (gltf) => {
           this.ballModel = gltf.scene;
           console.log("✓ Ball model loaded");

--- a/js/player/src/viewer/managers/ArenaManager.js
+++ b/js/player/src/viewer/managers/ArenaManager.js
@@ -2,10 +2,12 @@ import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader.js";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js";
+import { resolveViewerAssetUrl } from "../asset-url.js";
 
 export class ArenaManager {
-  constructor(scene) {
+  constructor(scene, options = {}) {
     this.scene = scene;
+    this.assetBase = options.assetBase;
     this.arenaMeshes = []; // Store references to arena meshes for raycasting
     this.drawingCollider = null; // Simplified mesh for drawing raycasting
     this.drawingColliderMeshes = []; // Individual meshes from the collider
@@ -14,7 +16,7 @@ export class ArenaManager {
 
     // Setup DRACO loader for compressed meshes
     this.dracoLoader = new DRACOLoader();
-    this.dracoLoader.setDecoderPath("https://www.gstatic.com/draco/versioned/decoders/1.5.6/");
+    this.dracoLoader.setDecoderPath(resolveViewerAssetUrl("draco/", this.assetBase));
 
     // Setup GLTF loader with DRACO support
     this.gltfLoader = new GLTFLoader();
@@ -25,7 +27,9 @@ export class ArenaManager {
     try {
       console.log("Loading arena mesh...");
 
-      const gltf = await this.gltfLoader.loadAsync("/models/stadium/stadium.glb");
+      const gltf = await this.gltfLoader.loadAsync(
+        resolveViewerAssetUrl("models/stadium/stadium.glb", this.assetBase),
+      );
       const arena = gltf.scene;
 
       // Rotate arena 180 degrees around Y axis to match replay coordinate system
@@ -180,7 +184,9 @@ export class ArenaManager {
     try {
       console.log("[ArenaManager] Loading drawing collider...");
       const objLoader = new OBJLoader();
-      const collider = await objLoader.loadAsync("/models/stadium/DrawingArena.obj");
+      const collider = await objLoader.loadAsync(
+        resolveViewerAssetUrl("models/stadium/DrawingArena.obj", this.assetBase),
+      );
 
       // Apply rotations to match arena orientation
       // X rotation: +90 degrees to lay the collider flat (it's modeled vertically)
@@ -257,7 +263,9 @@ export class ArenaManager {
     try {
       console.log("[ArenaManager] Loading arena decoration mesh...");
 
-      const gltf = await this.gltfLoader.loadAsync("/models/stadium/arene.glb");
+      const gltf = await this.gltfLoader.loadAsync(
+        resolveViewerAssetUrl("models/stadium/arene.glb", this.assetBase),
+      );
       this.arenaDecorMesh = gltf.scene;
       this.showArenaDecor = show;
 

--- a/js/player/src/viewer/managers/CarModelLoader.js
+++ b/js/player/src/viewer/managers/CarModelLoader.js
@@ -3,6 +3,7 @@ import { FBXLoader } from "three/examples/jsm/loaders/FBXLoader.js";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader.js";
 import { clone as skeletonClone } from "three/examples/jsm/utils/SkeletonUtils.js";
+import { resolveViewerAssetUrl } from "../asset-url.js";
 
 /**
  * CarModelLoader - Loads and manages car models (GLB format) with team-colored materials
@@ -19,14 +20,15 @@ import { clone as skeletonClone } from "three/examples/jsm/utils/SkeletonUtils.j
  * - Merc hitbox -> merc
  */
 export class CarModelLoader {
-  constructor() {
+  constructor(options = {}) {
+    this.assetBase = options.assetBase;
     this.fbxLoader = new FBXLoader();
     this.gltfLoader = new GLTFLoader();
     this.textureLoader = new THREE.TextureLoader();
 
     // Setup DRACO loader for compressed GLB files (local copy for better caching)
     const dracoLoader = new DRACOLoader();
-    dracoLoader.setDecoderPath("/draco/");
+    dracoLoader.setDecoderPath(resolveViewerAssetUrl("draco/", this.assetBase));
     this.gltfLoader.setDRACOLoader(dracoLoader);
 
     // Cache for loaded models (we clone them for each car)
@@ -267,7 +269,7 @@ export class CarModelLoader {
   }
 
   async _loadModelInternal(modelType) {
-    const basePath = `/models/cars/${modelType}`;
+    const basePath = `models/cars/${modelType}`;
     const config = this.modelConfig[modelType] || {
       format: "glb",
       file: `${modelType}.glb`,
@@ -464,7 +466,9 @@ export class CarModelLoader {
     }
 
     // Start loading
-    const loadPromise = this._loadGLB(`/models/wheels/${wheelModelName}`);
+    const loadPromise = this._loadGLB(
+      resolveViewerAssetUrl(`models/wheels/${wheelModelName}`, this.assetBase),
+    );
     this.wheelLoadingPromises.set(wheelModelName, loadPromise);
 
     try {

--- a/js/player/src/viewer/managers/SceneManager.js
+++ b/js/player/src/viewer/managers/SceneManager.js
@@ -1,10 +1,12 @@
 import * as THREE from "three";
-import { RGBELoader } from "three/examples/jsm/loaders/RGBELoader.js";
+import { HDRLoader } from "three/examples/jsm/loaders/HDRLoader.js";
 import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
+import { resolveViewerAssetUrl } from "../asset-url.js";
 
 export class SceneManager {
-  constructor(container) {
+  constructor(container, options = {}) {
     this.container = typeof container === "string" ? document.getElementById(container) : container;
+    this.assetBase = options.assetBase;
     if (!this.container) {
       console.error("Invalid container passed to SceneManager");
       return;
@@ -80,9 +82,11 @@ export class SceneManager {
    */
   applyEnvironment(env) {
     return new Promise((resolve) => {
-      const rgbeLoader = new RGBELoader();
-      rgbeLoader.load(
-        env.skyboxUrl,
+      const hdrLoader = new HDRLoader();
+      const path = resolveViewerAssetUrl(env.skyboxUrl, this.assetBase);
+
+      hdrLoader.load(
+        path,
         (texture) => {
           // Dispose of previous HDR skybox texture if one is mounted.
           if (this.scene.background && this.scene.background.dispose) {

--- a/js/player/src/viewer/managers/ViewerCameraManager.js
+++ b/js/player/src/viewer/managers/ViewerCameraManager.js
@@ -12,15 +12,17 @@ import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader.js";
 import { clone as skeletonClone } from "three/examples/jsm/utils/SkeletonUtils.js";
+import { resolveViewerAssetUrl } from "../asset-url.js";
 
 export class ViewerCameraManager {
   /**
    * @param {THREE.Scene} scene - The scene to add camera meshes to
    * @param {THREE.Camera} camera - The main camera (for label orientation)
    */
-  constructor(scene, camera) {
+  constructor(scene, camera, options = {}) {
     this.scene = scene;
     this.camera = camera;
+    this.assetBase = options.assetBase;
 
     // Map of participantId -> { mesh, label, color, nickname }
     this.viewerCameras = new Map();
@@ -31,7 +33,7 @@ export class ViewerCameraManager {
     // Model loading
     this.gltfLoader = new GLTFLoader();
     const dracoLoader = new DRACOLoader();
-    dracoLoader.setDecoderPath("https://www.gstatic.com/draco/versioned/decoders/1.5.6/");
+    dracoLoader.setDecoderPath(resolveViewerAssetUrl("draco/", this.assetBase));
     this.gltfLoader.setDRACOLoader(dracoLoader);
 
     // Cached model template
@@ -72,7 +74,7 @@ export class ViewerCameraManager {
     this.modelLoading = new Promise((resolve, reject) => {
       console.log("[ViewerCameraManager] Loading camera drone model...");
       this.gltfLoader.load(
-        "/models/camera/camera_drone.glb",
+        resolveViewerAssetUrl("models/camera/camera_drone.glb", this.assetBase),
         (gltf) => {
           console.log("[ViewerCameraManager] Loaded camera drone model successfully");
           this.modelTemplate = gltf.scene;

--- a/js/player/src/viewer/types.ts
+++ b/js/player/src/viewer/types.ts
@@ -194,6 +194,12 @@ export type ViewerPluginDefinition = ViewerPlugin | ViewerPluginFactory;
 export interface ViewerOptions {
   plugins?: ViewerPluginDefinition[];
   autoplay?: boolean;
+  /**
+   * Base URL for bundled viewer assets (`models/`, `draco/`, optional
+   * `skyboxes/`). Defaults to Vite's `BASE_URL`, which keeps GitHub Pages
+   * subpath deployments working when assets are copied beside the app bundle.
+   */
+  assetBase?: string | URL;
   /** Initial playback rate (default 1). Viewer-native alias of initialPlaybackRate. */
   speed?: number;
   /** Wrap to t=0 at the end instead of pausing (default false). */

--- a/js/stat-evaluation-player/vite.config.ts
+++ b/js/stat-evaluation-player/vite.config.ts
@@ -55,9 +55,9 @@ export default defineConfig(({ command, mode }) => {
   return {
     base: "./",
     plugins: [wasm(), ensureWasmBindingsPlugin()],
-    // The 3D viewer loads its models/draco assets from absolute web-root paths
-    // (/models/..., /draco/...); serve js/player/public at the root in dev and
-    // copy it into site builds. The library build ships no assets.
+    // Site/dev builds serve the bundled 3D viewer assets beside the app. The
+    // viewer resolves them through Vite's BASE_URL so subpath deployments such
+    // as GitHub Pages do not depend on web-root /models or /draco paths.
     publicDir: useLocalAliases ? path.resolve(import.meta.dirname, "../player/public") : false,
     resolve: {
       alias: useLocalAliases
@@ -67,6 +67,7 @@ export default defineConfig(({ command, mode }) => {
               "../pkg/rl_replay_subtr_actor.js",
             ),
             "@rlrml/player": path.resolve(import.meta.dirname, "../player/src/lib.ts"),
+            "camera-controls": path.resolve(import.meta.dirname, "node_modules/camera-controls"),
             three: path.resolve(import.meta.dirname, "node_modules/three"),
           }
         : undefined,


### PR DESCRIPTION
## Summary
- resolve bundled viewer assets through a shared asset-base helper instead of web-root /models, /draco, and /skyboxes paths
- thread the asset base through the viewer managers and the default space environment so GitHub Pages subpath deployments load models, Draco, and the HDR skybox
- align local Pages builds with the bundled player assets and source-aliased camera-controls dependency

## Root cause
The stats player was deployed under /subtr-actor/, but the viewer still requested assets from the domain root. That made GitHub Pages request URLs like https://rlrml.github.io/models/... and https://rlrml.github.io/skyboxes/... instead of paths under the repository site.

## Validation
- just check
- npm --prefix js/stat-evaluation-player run check:tsc
- npm --prefix js/pages run check
- npm --prefix js/stat-evaluation-player run build:site
- npm --prefix js/pages run build
- Chrome smoke check against a local /subtr-actor/ preview confirmed no failed model/draco/skybox/replay requests and loaded /subtr-actor/skyboxes/PlanetaryEarth4k.hdr