### PR TITLE
Fix follow-camera nameplate HUD

### DIFF
--- a/js/player/src/ballchasing-overlay.ts
+++ b/js/player/src/ballchasing-overlay.ts
@@ -24,6 +24,7 @@ interface PlayerOverlayElements {
 const STYLE_ID = "subtr-actor-ballchasing-overlay-styles";
 const TEAM_BLUE = "#3b82f6";
 const TEAM_ORANGE = "#f59e0b";
+const FLOATING_LABEL_OFFSET_UU = 140;
 
 function ensureStyles(): void {
   if (document.getElementById(STYLE_ID)) {
@@ -501,7 +502,7 @@ export function createBallchasingOverlayPlugin(
       });
     }
 
-    floatingOffset.set(0, 0, 255 * (context.options.fieldScale ?? 1));
+    floatingOffset.set(0, 0, FLOATING_LABEL_OFFSET_UU * (context.options.fieldScale ?? 1));
     container.append(root);
     syncAttachedPlayer(context.player.getState().attachedPlayerId);
   }
@@ -554,7 +555,11 @@ export function createBallchasingOverlayPlugin(
           continue;
         }
 
+        const isAttachedPlayer =
+          context.state.cameraViewMode === "follow" &&
+          context.state.attachedPlayerId === player.track.id;
         if (
+          isAttachedPlayer ||
           !active ||
           !projectToContainer(
             mesh,

--- a/js/player/src/viewer/managers/NameTagManager.js
+++ b/js/player/src/viewer/managers/NameTagManager.js
@@ -33,7 +33,7 @@ export class NameTagManager {
 
     // Sprite scale (screen units since sizeAttenuation is false)
     this.spriteScale = 0.06;
-    this.spriteWorldHeight = 1.2; // World units above car
+    this.spriteWorldHeight = 90; // UU above car, roughly one car height plus clearance
   }
 
   setPlayerTeams(teams) {
@@ -59,39 +59,17 @@ export class NameTagManager {
       tagData.lastBoost = boost;
     }
 
-    // Update position (above car, height adjusts based on camera distance)
+    // Update position above the car. Keep the anchor stable in world space so
+    // close follow/ball-cam shots do not pull the label away from the car.
     if (carPosition && this.camera) {
-      // Calculate distance from camera to car
-      const distance = this.camera.position.distanceTo(carPosition);
+      tagData.sprite.position.set(
+        carPosition.x,
+        carPosition.y + this.spriteWorldHeight,
+        carPosition.z,
+      );
 
-      // Adjust height based on distance (scaled for 100x arena):
-      // Close (distance < 500): lower height (~80)
-      // Far (distance > 5000): higher height (~200)
-      const minHeight = 80;
-      const maxHeight = 200;
-      const minDist = 500;
-      const maxDist = 5000;
-
-      const t = Math.max(0, Math.min(1, (distance - minDist) / (maxDist - minDist)));
-      const dynamicHeight = minHeight + t * (maxHeight - minHeight);
-
-      tagData.sprite.position.set(carPosition.x, carPosition.y + dynamicHeight, carPosition.z);
-
-      // Hybrid size behavior:
-      // - Far away: constant screen size (base scale)
-      // - Close up: grows on screen (world-space size)
-      const proximityThreshold = 800; // Distance at which size starts growing
       const aspectRatio = this.canvasWidth / this.canvasHeight;
-
-      if (distance < proximityThreshold) {
-        // Close: scale increases as we get closer (simulates world-space size)
-        const growthFactor = proximityThreshold / Math.max(distance, 100);
-        const closeScale = this.spriteScale * growthFactor;
-        tagData.sprite.scale.set(closeScale * aspectRatio, closeScale, 1);
-      } else {
-        // Far: constant screen size
-        tagData.sprite.scale.set(this.spriteScale * aspectRatio, this.spriteScale, 1);
-      }
+      tagData.sprite.scale.set(this.spriteScale * aspectRatio, this.spriteScale, 1);
 
       tagData.sprite.visible = true;
     }

--- a/js/player/src/viewer/plugins/name-tags.ts
+++ b/js/player/src/viewer/plugins/name-tags.ts
@@ -34,7 +34,15 @@ export function createNameTagPlugin(): ViewerPlugin {
         boosts[car.name] = car.boost;
         nameToActorId[car.name] = car.name;
       }
-      manager.update(actors, boosts, nameToActorId, null);
+      const followedPlayer =
+        ctx.state.cameraViewMode === "follow" && ctx.state.attachedPlayerId
+          ? (ctx.player.adapter.playerList.find(
+              (player) =>
+                player.id === ctx.state.attachedPlayerId ||
+                player.name === ctx.state.attachedPlayerId,
+            )?.name ?? null)
+          : null;
+      manager.update(actors, boosts, nameToActorId, followedPlayer ?? null);
     },
     teardown() {
       manager?.dispose();


### PR DESCRIPTION
## Summary
- hide the followed player's floating in-world nameplate in follow/player cam while preserving other players' existing nameplate placement
- add a plugin-owned bottom-right followed-player boost HUD to the Ballchasing overlay
- default player-follow selection to recorded player camera settings and ball cam on
- apply the followed-player hide behavior to the viewer-native name-tag plugin too

## Validation
- `npm --prefix js/player run test`
- `npm --prefix js/player run build:types`
- `npm --prefix js/stat-evaluation-player run check:tsc`
- `npm --prefix js/stat-evaluation-player run build:site`
- `just check`
- Pages-shaped local browser smoke at `/subtr-actor/`: selecting IcedSpace defaults Use player camera settings + Ball cam on, hides IcedSpace floating label, keeps strangy label visible at the existing placement, and shows bottom-right IcedSpace boost HUD
