### PR TITLE
fix(player): snap across demos and kickoff repositioning instead of interpolating

### DIFF
--- a/js/player/src/player-internals/spatial.ts
+++ b/js/player/src/player-internals/spatial.ts
@@ -9,6 +9,12 @@ import type {
   Vec3,
 } from "../types";
 
+// Player cars cannot plausibly travel faster than supersonic (~2300 uu/s) under
+// their own power; we double it for headroom against sparse keyframes and bump
+// knockback. A jump larger than this between two samples is a teleport
+// (demolition respawn or kickoff repositioning), not motion.
+const MAX_INTERPOLATION_SPEED_UU_PER_S = 2300 * 2;
+
 const CHASE_CAMERA_HEIGHT_MULTIPLIER = 1.4;
 const CAMERA_SMOOTHING = 0.18;
 const FREE_CAMERA_TRANSITION_SMOOTHING = 0.14;
@@ -42,6 +48,28 @@ export interface AttachedCameraBlendState {
   currentBlend: number;
   targetBlend: number;
   lastIsBallCam: boolean | null;
+}
+
+// Detect a teleport-scale jump between two consecutive samples. Demolition
+// respawns and kickoff repositioning relocate a car instantly; interpolating
+// across that gap slides the car (and any attached camera) across the field,
+// which reads as a glitch. Callers should hold the current sample so the jump
+// lands cleanly on the frame boundary instead of being smeared through space.
+export function isPositionDiscontinuity(
+  current: Vec3 | null,
+  next: Vec3 | null,
+  dt: number,
+): boolean {
+  if (!current || !next || dt <= 0) {
+    return false;
+  }
+
+  const dx = next.x - current.x;
+  const dy = next.y - current.y;
+  const dz = next.z - current.z;
+  const distanceSq = dx * dx + dy * dy + dz * dz;
+  const maxDistance = MAX_INTERPOLATION_SPEED_UU_PER_S * dt;
+  return distanceSq > maxDistance * maxDistance;
 }
 
 export function interpolatePosition(
@@ -84,6 +112,13 @@ export function interpolatePositionHermite(
   alpha: number,
 ): Vec3 | null {
   const linear = interpolatePosition(current, next, alpha);
+
+  // Hold the current sample across teleport-scale gaps (demolition respawns,
+  // kickoff repositioning) rather than sliding toward the relocated sample.
+  if (isPositionDiscontinuity(current, next, dt)) {
+    return current;
+  }
+
   if (
     !current ||
     !next ||
@@ -305,7 +340,15 @@ function interpolateCameraFrame(
   dt: number,
   alpha: number,
 ): PlayerFrame {
-  if (!nextFrame || alpha <= 0 || nextFrame.isPresent === false || !nextFrame.position) {
+  if (
+    !nextFrame ||
+    alpha <= 0 ||
+    nextFrame.isPresent === false ||
+    !nextFrame.position ||
+    // Don't let the camera chase a relocated target across a teleport (demo
+    // respawn / kickoff reposition); hold the current frame so it snaps cleanly.
+    isPositionDiscontinuity(frame.position ?? null, nextFrame.position, dt)
+  ) {
     return frame;
   }
 

--- a/js/player/src/player.ts
+++ b/js/player/src/player.ts
@@ -34,6 +34,7 @@ import {
   getFreeCameraPreset,
   interpolateQuaternion,
   interpolatePositionHermite,
+  isPositionDiscontinuity,
   rootPosition,
   updateFreeCameraTransition,
   updateAttachedCamera,
@@ -784,9 +785,17 @@ export class ReplayPlayer extends EventTarget {
       }
       renderPosition = interpolatedPosition;
       mesh.position.copy(rootPosition(interpolatedPosition));
+      // When the position snaps across a teleport (demo respawn / kickoff
+      // reposition), snap the orientation too instead of slerping through the
+      // relocation, which otherwise spins the car between frames.
+      const positionTeleport = isPositionDiscontinuity(
+        frame?.position ?? null,
+        nextFrame?.position ?? null,
+        frameWindow.dt,
+      );
       const rotation = interpolateQuaternion(
         frame?.rotation ?? null,
-        nextFrame?.rotation ?? null,
+        positionTeleport ? null : (nextFrame?.rotation ?? null),
         frameWindow.alpha,
       );
       if (rotation) {

--- a/js/player/test/spatial.test.ts
+++ b/js/player/test/spatial.test.ts
@@ -7,6 +7,7 @@ import {
   getFreeCameraPreset,
   interpolatePositionHermite,
   interpolateQuaternion,
+  isPositionDiscontinuity,
   updateAttachedCamera,
 } from "../src/player-internals/spatial";
 import type { ReplayModel } from "../src/types";
@@ -200,6 +201,40 @@ test("interpolatePositionHermite rejects implausible tangents and falls back to 
     Math.abs(result.x - 5) < 1e-9,
     "expected the pathological tangent to fall back to lerp",
   );
+});
+
+test("isPositionDiscontinuity flags teleport-scale jumps but not fast motion", () => {
+  // Supersonic travel over a ~30Hz frame (~77uu) is real motion, not a teleport.
+  assert.equal(
+    isPositionDiscontinuity({ x: 0, y: 0, z: 17 }, { x: -77, y: 0, z: 17 }, 1 / 30),
+    false,
+  );
+  // A kickoff reposition / demo respawn jumps thousands of units in one frame.
+  assert.equal(
+    isPositionDiscontinuity({ x: 0, y: 0, z: 17 }, { x: -2048, y: -2560, z: 17 }, 1 / 30),
+    true,
+  );
+  // Without a valid gap there is nothing to interpolate across.
+  assert.equal(isPositionDiscontinuity({ x: 0, y: 0, z: 0 }, { x: 5000, y: 0, z: 0 }, 0), false);
+  assert.equal(isPositionDiscontinuity(null, { x: 5000, y: 0, z: 0 }, 1 / 30), false);
+});
+
+test("interpolatePositionHermite holds the current sample across a teleport", () => {
+  // A kickoff reposition: the car is relocated thousands of units in one frame.
+  // Interpolating would slide it across the field, so we hold the current sample
+  // until the frame boundary instead.
+  const result = interpolatePositionHermite(
+    { x: 0, y: 0, z: 17 },
+    { x: -2048, y: -2560, z: 17 },
+    { x: 0, y: 0, z: 0 },
+    { x: 0, y: 0, z: 0 },
+    1 / 30,
+    0.5,
+  );
+  assert.ok(result);
+  assert.equal(result.x, 0);
+  assert.equal(result.y, 0);
+  assert.equal(result.z, 17);
 });
 
 test("hitbox overlay transform uses Rocket League local axes", () => {


### PR DESCRIPTION
## Problem

Demolition respawns and kickoff repositioning relocate a car **instantly**, but the player interpolated *through* those teleport-scale gaps:

- `interpolatePositionHermite` (used for both car meshes and the attached-camera target) and `interpolateCameraFrame` slid toward the relocated sample, smearing the car and chase camera across the field instead of cutting cleanly.
- Demo *events* were already handled (mesh hidden, camera frozen via `attachedPlayerUnavailable`), but a **present-through-teleport respawn** or a **kickoff reset** (cars present the whole time, just teleported) was not — those produced a glide across the field.

## Fix

- Add `isPositionDiscontinuity(current, next, dt)` — flags a jump faster than 2× supersonic (`2300 * 2` uu/s, with headroom for sparse keyframes/bumps) as a teleport rather than motion.
- `interpolatePositionHermite` now **holds the current sample** across a discontinuity, so the jump lands cleanly on the frame boundary.
- `interpolateCameraFrame` holds the current frame across a discontinuity, so the attached camera cuts to the new position instead of chasing a relocated target across the field.
- In the mesh path, rotation **snaps** to the current frame across a teleport instead of slerping through the relocation (which would spin the car between frames).

Net effect: a disembodied player is represented without dragging the camera through empty space.

## Tests

- `isPositionDiscontinuity` distinguishes supersonic motion (~77 uu/frame) from a kickoff-scale jump, and handles the no-gap / null cases.
- `interpolatePositionHermite` holds the current sample across a teleport.
- Existing `spatial` tests still pass; `just check` (fmt + clippy + prettier + eslint) is clean.

No Rust or `ts-rs`-exported types were touched, so no binding regeneration is needed.

> Note: the speed threshold is `2300 * 2` uu/s — the knob to loosen if a legitimately fast moment over an unusually sparse keyframe span ever gets snapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)