### PR TITLE
Add adjustable name plate height to the camera window

### DIFF
--- a/js/player/src/ballchasing-overlay.ts
+++ b/js/player/src/ballchasing-overlay.ts
@@ -8,11 +8,25 @@ import type {
 import { boostAmountToPercent } from "./boost-units";
 import { findFrameIndexAtTime } from "./replay-data";
 
+/**
+ * Default world-space lift (Unreal units) applied to each car before
+ * projecting its floating name/boost label, so the pill sits above the car
+ * instead of on it. Exposed so consumers can seed UI controls with the same
+ * default the plugin uses.
+ */
+export const DEFAULT_FLOATING_NAMEPLATE_LIFT_UU = 250;
+
 export interface BallchasingOverlayPluginOptions {
   showFloatingNames?: boolean;
   showFloatingBoostBars?: boolean;
   showTeamBoostHud?: boolean;
   showFollowedPlayerHud?: boolean;
+  /**
+   * How far (Unreal units) to lift the floating name/boost pills above each
+   * car. A function is read every frame, so callers can wire it to a live UI
+   * control. Defaults to {@link DEFAULT_FLOATING_NAMEPLATE_LIFT_UU}.
+   */
+  floatingLiftUu?: number | (() => number | null | undefined);
 }
 
 interface PlayerOverlayElements {
@@ -568,14 +582,22 @@ export function createBallchasingOverlayPlugin(
   let changedContainerPosition = false;
   let originalContainerPosition = "";
   const playerElements = new Map<string, PlayerOverlayElements>();
+  const floatingLiftSource = options.floatingLiftUu;
   const projected = new THREE.Vector3();
   // World-space lift applied to each car before projecting the floating label,
-  // so the name/boost pill sits above the car instead of on it. Resolved along
-  // the scene's up axis in buildHud — the viewer renders Y-up while
-  // @rlrml/player's own scene is Z-up, so we read it from the camera rather
-  // than hardcoding an axis.
-  const FLOATING_LIFT_UU = 250;
-  const floatingOffset = new THREE.Vector3(0, FLOATING_LIFT_UU, 0);
+  // so the name/boost pill sits above the car instead of on it. Recomputed each
+  // frame in beforeRender along the scene's up axis (read from the camera) — the
+  // viewer renders Y-up while @rlrml/player's own scene is Z-up, so we never
+  // hardcode an axis — and scaled by the (optionally live) configured lift.
+  const floatingOffset = new THREE.Vector3();
+
+  function resolveFloatingLiftUu(): number {
+    const raw =
+      typeof floatingLiftSource === "function" ? floatingLiftSource() : floatingLiftSource;
+    return typeof raw === "number" && Number.isFinite(raw)
+      ? raw
+      : DEFAULT_FLOATING_NAMEPLATE_LIFT_UU;
+  }
 
   function syncAttachedPlayer(attachedPlayerId: string | null): void {
     for (const [playerId, elements] of playerElements.entries()) {
@@ -736,10 +758,6 @@ export function createBallchasingOverlayPlugin(
       });
     }
 
-    floatingOffset
-      .copy(context.scene.camera.up)
-      .normalize()
-      .multiplyScalar(FLOATING_LIFT_UU * (context.options.fieldScale ?? 1));
     container.append(root);
     syncAttachedPlayer(context.player.getState().attachedPlayerId);
     syncFollowedHud({ ...context, state: context.player.getState() });
@@ -771,6 +789,13 @@ export function createBallchasingOverlayPlugin(
       if (!root) {
         return;
       }
+
+      // Recompute the lift each frame so a live UI control takes effect
+      // immediately, and so the up axis tracks whichever scene we render in.
+      floatingOffset
+        .copy(context.scene.camera.up)
+        .normalize()
+        .multiplyScalar(resolveFloatingLiftUu() * (context.options.fieldScale ?? 1));
 
       let followedHudUpdated = false;
       for (const [playerIndex, player] of context.players.entries()) {

--- a/js/player/src/lib.ts
+++ b/js/player/src/lib.ts
@@ -49,7 +49,10 @@ export {
   normalizeBallchasingReplayId,
 } from "./ballchasing";
 export type { BallchasingReplayDownloadOptions } from "./ballchasing";
-export { createBallchasingOverlayPlugin } from "./ballchasing-overlay";
+export {
+  createBallchasingOverlayPlugin,
+  DEFAULT_FLOATING_NAMEPLATE_LIFT_UU,
+} from "./ballchasing-overlay";
 export type { BallchasingOverlayPluginOptions } from "./ballchasing-overlay";
 export { BOOST_RAW_MAX, boostAmountToPercent, boostPercentToAmount } from "./boost-units";
 export { createBoostPadOverlayPlugin } from "./boost-pad-overlay";

--- a/js/stat-evaluation-player/src/appTemplate.ts
+++ b/js/stat-evaluation-player/src/appTemplate.ts
@@ -192,6 +192,20 @@ export function getAppTemplate(): string {
               <input id="ball-cam" type="checkbox" disabled />
               <span>Ball cam</span>
             </label>
+            <label>
+              <span class="camera-setting-label">
+                <span>Name plate height</span>
+                <strong id="custom-nameplate-lift-readout">250</strong>
+              </span>
+              <input
+                id="custom-nameplate-lift"
+                type="range"
+                min="0"
+                max="700"
+                step="10"
+                value="250"
+              />
+            </label>
             <dl class="detail-grid">
               <div>
                 <dt>Profile</dt>

--- a/js/stat-evaluation-player/src/cameraControls.ts
+++ b/js/stat-evaluation-player/src/cameraControls.ts
@@ -1,9 +1,10 @@
-import type {
-  CameraSettings,
-  ReplayCameraViewMode,
-  ReplayFreeCameraPreset,
-  ReplayPlayerState,
-  ReplayPlayerTrack,
+import {
+  DEFAULT_FLOATING_NAMEPLATE_LIFT_UU,
+  type CameraSettings,
+  type ReplayCameraViewMode,
+  type ReplayFreeCameraPreset,
+  type ReplayPlayerState,
+  type ReplayPlayerTrack,
 } from "@rlrml/player";
 import type { StatsReplayPlayer } from "./statsReplayPlayer.ts";
 
@@ -42,6 +43,8 @@ export interface CameraControlsElements {
   readonly customCameraSwivelSpeedReadout: HTMLElement;
   readonly customCameraTransitionSpeedReadout: HTMLElement;
   readonly ballCam: HTMLInputElement;
+  readonly nameplateLift: HTMLInputElement;
+  readonly nameplateLiftReadout: HTMLElement;
   readonly cameraProfileReadout: HTMLElement;
   readonly cameraFovReadout: HTMLElement;
   readonly cameraHeightReadout: HTMLElement;
@@ -71,6 +74,20 @@ export class CameraControlsController {
 
   get ballCamChecked(): boolean {
     return this.options.elements.ballCam.checked;
+  }
+
+  /** Current floating name-plate lift (Unreal units) from the slider. */
+  get nameplateLiftUu(): number {
+    const value = Number(this.options.elements.nameplateLift.value);
+    return Number.isFinite(value) ? value : DEFAULT_FLOATING_NAMEPLATE_LIFT_UU;
+  }
+
+  /** Apply a persisted name-plate lift to the slider + readout (config load). */
+  applyNameplateLiftUu(value: number | undefined): void {
+    const { nameplateLift, nameplateLiftReadout } = this.options.elements;
+    const lift = value ?? DEFAULT_FLOATING_NAMEPLATE_LIFT_UU;
+    nameplateLift.value = `${lift}`;
+    nameplateLiftReadout.textContent = formatSetting(lift, "", 0);
   }
 
   installEventListeners(signal: AbortSignal): void {
@@ -176,6 +193,18 @@ export class CameraControlsController {
       "change",
       () => {
         this.options.getReplayPlayer()?.setBallCamEnabled(elements.ballCam.checked);
+        this.options.requestConfigSync();
+      },
+      { signal },
+    );
+
+    // The ballchasing overlay reads nameplateLiftUu live each frame, so changing
+    // the slider takes effect without touching the player — just refresh the
+    // readout and persist.
+    elements.nameplateLift.addEventListener(
+      "input",
+      () => {
+        elements.nameplateLiftReadout.textContent = formatSetting(this.nameplateLiftUu, "", 0);
         this.options.requestConfigSync();
       },
       { signal },

--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -758,6 +758,8 @@ export function mountStatEvaluationPlayer(
         "#custom-camera-transition-speed-readout",
       ),
       ballCam: mustElement<HTMLInputElement>(root, "#ball-cam"),
+      nameplateLift: mustElement<HTMLInputElement>(root, "#custom-nameplate-lift"),
+      nameplateLiftReadout: mustElement<HTMLElement>(root, "#custom-nameplate-lift-readout"),
       cameraProfileReadout: mustElement<HTMLElement>(root, "#camera-profile-readout"),
       cameraFovReadout: mustElement<HTMLElement>(root, "#camera-fov-readout"),
       cameraHeightReadout: mustElement<HTMLElement>(root, "#camera-height-readout"),

--- a/js/stat-evaluation-player/src/playerConfig.ts
+++ b/js/stat-evaluation-player/src/playerConfig.ts
@@ -74,6 +74,7 @@ export interface PlayerCameraConfig {
   readonly ballCam?: boolean;
   readonly usePlayerCameraSettings?: boolean;
   readonly customSettings?: CameraSettings | null;
+  readonly nameplateLiftUu?: number;
 }
 
 export interface PlayerOverlayConfig {
@@ -301,6 +302,7 @@ function normalizeCameraConfig(value: unknown): PlayerCameraConfig {
   const ballCam = booleanValue(value.ballCam);
   const usePlayerCameraSettings = booleanValue(value.usePlayerCameraSettings);
   const customSettings = normalizeCameraSettings(value.customSettings);
+  const nameplateLiftUu = finiteNumber(value.nameplateLiftUu);
   if (mode !== undefined) config.mode = mode;
   if (freePreset !== undefined) config.freePreset = freePreset;
   if (attachedPlayerId !== undefined) config.attachedPlayerId = attachedPlayerId;
@@ -309,6 +311,7 @@ function normalizeCameraConfig(value: unknown): PlayerCameraConfig {
     config.usePlayerCameraSettings = usePlayerCameraSettings;
   }
   if (customSettings !== undefined) config.customSettings = customSettings;
+  if (nameplateLiftUu !== undefined) config.nameplateLiftUu = nameplateLiftUu;
   return config;
 }
 

--- a/js/stat-evaluation-player/src/playerConfigBindings.ts
+++ b/js/stat-evaluation-player/src/playerConfigBindings.ts
@@ -127,6 +127,7 @@ export function createPlayerConfigBindings(
       options.skipKickoffs.checked = config.playback.skipKickoffs ?? options.skipKickoffs.checked;
       options.hitboxWireframes.checked = config.overlays.hitboxWireframes;
       options.hitboxOnlyMode.checked = config.overlays.hitboxOnlyMode;
+      options.getCameraControlsController()?.applyNameplateLiftUu(config.camera.nameplateLiftUu);
       if (config.playback.rate !== undefined) {
         options.playbackRate.value = `${config.playback.rate}`;
       }

--- a/js/stat-evaluation-player/src/playerConfigRuntime.ts
+++ b/js/stat-evaluation-player/src/playerConfigRuntime.ts
@@ -118,6 +118,7 @@ export function getCameraConfigSnapshot({
     ballCam: state?.ballCamEnabled ?? cameraControlsController?.ballCamChecked,
     usePlayerCameraSettings: state?.customCameraSettings === null,
     customSettings: state?.customCameraSettings,
+    nameplateLiftUu: cameraControlsController?.nameplateLiftUu,
   };
 }
 

--- a/js/stat-evaluation-player/src/replayDisplayRuntime.ts
+++ b/js/stat-evaluation-player/src/replayDisplayRuntime.ts
@@ -167,7 +167,11 @@ export async function loadReplayBundleForDisplay(
             if (replay) replay.textContent = `${replayFps.toFixed(0)} fps`;
           },
         }),
-        fromReplayPlayerPlugin(createBallchasingOverlayPlugin()),
+        fromReplayPlayerPlugin(
+          createBallchasingOverlayPlugin({
+            floatingLiftUu: () => options.getCameraControlsController()?.nameplateLiftUu,
+          }),
+        ),
         fromReplayPlayerPlugin(
           createBoostPickupAnimationPlugin({
             includePickup: options.includeBoostPickupAnimationPickup,


### PR DESCRIPTION
Follow-up to #180. Makes the floating name/boost pill lift adjustable at runtime instead of a fixed constant.

## What

A **Name plate height** slider in the stat-evaluation-player **Camera** window (0–700uu, default 250). Dragging it lifts/lowers the floating player name + boost pills above the cars in real time, and the value persists in the shareable `#cfg` URL hash.

The slider lives *outside* the mode-gated custom-camera controls, so it's always available regardless of camera mode (free / follow / ball-cam).

## How

- **`ballchasing-overlay.ts`**: `BallchasingOverlayPluginOptions.floatingLiftUu` now accepts a `number` or a `() => number` getter. The getter is read **every frame**, so a live UI control takes effect immediately. The world offset is recomputed each frame along the scene's up axis (camera-derived — Y-up viewer / Z-up `@rlrml/player`). Exported `DEFAULT_FLOATING_NAMEPLATE_LIFT_UU` (250) so consumers seed controls with the same default.
- **stat-evaluation-player**: added the slider markup, exposed `nameplateLiftUu` on the camera-controls controller, wired it into the bridged ballchasing overlay via a live getter (`replayDisplayRuntime`), and persisted it in the camera section of the config (`playerConfig` type + normalize, `playerConfigRuntime` snapshot, `playerConfigBindings` apply-on-load).

## Verification

- Verified live in the dev build against a real replay: slider updates the pill height in real time (follow + ball-cam), and reloading the resulting `#cfg` URL restores the value to both the slider and the overlay.
- `just check-style` (prettier + eslint) clean; `tsc --noEmit` clean; `playerConfig` round-trip tests pass (11/11); pre-commit clippy clean.

> Note: based on the #180 branch (the up-axis fix). Retarget to `master` once #180 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)