### PR TITLE
fix(player): resolve car body/FBX model URLs against viewer asset base

### DIFF
--- a/js/player/src/viewer/managers/CarModelLoader.js
+++ b/js/player/src/viewer/managers/CarModelLoader.js
@@ -283,8 +283,11 @@ export class CarModelLoader {
     let wheelModel = null;
 
     if (config.format === "glb") {
-      // Load GLB file (textures are embedded)
-      const glbPath = `${basePath}/${config.file}`;
+      // Load GLB file (textures are embedded). Resolve against the viewer asset
+      // base so the body model honors subpath/embedded deployments the same way
+      // the wheel + draco loads do (otherwise a relative URL resolves against
+      // the host page's route and 404s).
+      const glbPath = resolveViewerAssetUrl(`${basePath}/${config.file}`, this.assetBase);
 
       // If model uses wheel sockets, load wheel model in parallel
       if (config.wheelSockets && config.wheelModel) {
@@ -298,10 +301,14 @@ export class CarModelLoader {
         console.log(`✓ Loaded GLB model: ${glbPath}`);
       }
     } else {
-      // Load FBX file with external texture
-      const fbxPath = `${basePath}/${config.file}.fbx`;
+      // Load FBX file with external texture (same asset-base resolution as the
+      // GLB path above, so subpath/embedded deployments resolve correctly).
+      const fbxPath = resolveViewerAssetUrl(`${basePath}/${config.file}.fbx`, this.assetBase);
       const modelName = config.file;
-      const texturePath = `${basePath}/${modelName}_engine.png`;
+      const texturePath = resolveViewerAssetUrl(
+        `${basePath}/${modelName}_engine.png`,
+        this.assetBase,
+      );
 
       // Load FBX and texture in parallel
       [model, chassisTexture] = await Promise.all([


### PR DESCRIPTION
## Problem

The Pages asset-path fix (e478e00d) routed model/draco/skybox loads through `resolveViewerAssetUrl(path, assetBase)` so they honor a configured asset base (subpath deploys, or hosts embedding the viewer at a nested route). But `CarModelLoader._loadModelInternal` was missed: the car **body** GLB — and the FBX/texture fallback — were still built as raw relative paths:

```js
const glbPath = `${basePath}/${config.file}`;   // e.g. "models/cars/octane/octane.glb"
model = await this._loadGLB(glbPath);
```

The wheel and draco loads in the same file already wrap with `resolveViewerAssetUrl`, so they resolve correctly — only the body/FBX paths slip through.

### Symptom

When the viewer is embedded in a host app at a nested route (e.g. `/replays/:id/goals`) with `assetBase` pointing at the origin root, arena, ball, wheels, and draco load fine, but the **car bodies 404**: the relative URL resolves against the page route, the host's SPA fallback returns `index.html`, and `GLTFLoader` throws `Unexpected token '<', "<!doctype "... is not valid JSON`. Cars fall back to hitbox-only placeholders.

## Fix

Wrap the body GLB, FBX, and texture paths in `resolveViewerAssetUrl(..., this.assetBase)`, exactly like the existing wheel load. No behavior change for the default (relative) base — `resolveViewerAssetUrl` resolves against `import.meta.env.BASE_URL` when no base is set, which is what the bare relative path did before.

Found while integrating the viewer into a host app (rocket-sense) that mounts the clip player at a nested route.