### PR TITLE
[codex] Classify movement events as other

### DIFF
--- a/docs/event-definitions.md
+++ b/docs/event-definitions.md
@@ -706,7 +706,7 @@ _None documented._
 
 ### Movement (`movement`)
 
-- Category: `movement`
+- Category: `other`
 - Confidence:
   - Approach: `unknown`
   - True positive evidence: `not_evaluated`

--- a/js/stat-evaluation-player/src/generated/EventCategory.ts
+++ b/js/stat-evaluation-player/src/generated/EventCategory.ts
@@ -3,4 +3,4 @@
 /**
  * Coarse product/domain grouping for an event definition.
  */
-export type EventCategory = "core" | "mechanic" | "positioning" | "movement" | "annotation" | "other" | "context";
+export type EventCategory = "core" | "mechanic" | "positioning" | "annotation" | "other" | "context";

--- a/js/stat-evaluation-player/src/generated/eventDefinitionCatalog.generated.ts
+++ b/js/stat-evaluation-player/src/generated/eventDefinitionCatalog.generated.ts
@@ -235,7 +235,7 @@ export const EVENT_DEFINITION_CATALOG: EventDefinitionCatalogEntry[] = [
   {
     "key": "movement",
     "label": "Movement",
-    "category": "movement",
+    "category": "other",
     "hidden_from_review": false,
     "variants": []
   },

--- a/src/stats/calculators/event_definition.rs
+++ b/src/stats/calculators/event_definition.rs
@@ -88,7 +88,6 @@ pub enum EventCategory {
     Core,
     Mechanic,
     Positioning,
-    Movement,
     Annotation,
     Other,
     /// Label-like metadata rows (e.g. goal context). These are hidden from the
@@ -899,7 +898,7 @@ define_stats_event!(
     MOVEMENT_EVENT_DEFINITION,
     "movement",
     "Movement",
-    EventCategory::Movement
+    EventCategory::Other
 );
 define_stats_event!(
     PlayerActivityEvent,

--- a/src/stats/calculators/event_definition_tests.rs
+++ b/src/stats/calculators/event_definition_tests.rs
@@ -79,10 +79,11 @@ fn mechanic_event_definitions_have_documented_approaches() {
 }
 
 #[test]
-fn low_level_ball_interaction_events_are_other() {
+fn low_level_interaction_events_are_other() {
     for definition in [
         TOUCH_CLASSIFICATION_EVENT_DEFINITION,
         WHIFF_EVENT_DEFINITION,
+        MOVEMENT_EVENT_DEFINITION,
     ] {
         assert_eq!(
             definition.category,


### PR DESCRIPTION
## Summary

- Reclassifies the low-level `movement` event definition under `other` instead of a dedicated `movement` category.
- Removes `movement` from the generated TypeScript `EventCategory` union.
- Regenerates the event catalog and Markdown event definitions.

## Why

`MovementEvent` is a per-player motion/stat accumulation span, not a replay-review category. Grouping it with other low-level events keeps the review/event taxonomy simpler.

## Validation

- `cargo test stats::calculators::event_definition`
- `npm run check` in `js/stat-evaluation-player`
- pre-commit hook: `cargo clippy --all-targets --all-features -- -D warnings`
