### PR TITLE
[codex] Improve boost pad visuals

### DIFF
--- a/js/player/src/boost-pad-overlay.ts
+++ b/js/player/src/boost-pad-overlay.ts
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
 import type {
   ReplayBoostPad,
   ReplayPlayerPlugin,
@@ -12,11 +13,23 @@ export interface BoostPadOverlayPluginOptions {
 
 interface BoostPadMeshes {
   group: THREE.Group;
+  base: THREE.Group;
   ring: THREE.Mesh<THREE.RingGeometry, THREE.MeshBasicMaterial>;
   core: THREE.Mesh<THREE.CircleGeometry, THREE.MeshBasicMaterial>;
   cooldown: THREE.Mesh<THREE.CircleGeometry, THREE.MeshBasicMaterial>;
-  orb: THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial | THREE.MeshPhongMaterial>;
+  orb: THREE.Mesh<
+    THREE.BufferGeometry,
+    THREE.MeshBasicMaterial | THREE.MeshPhongMaterial | THREE.MeshPhysicalMaterial
+  >;
+  lensColumn: THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>;
+  lensRim: THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>;
+  sheen: THREE.Mesh<THREE.CircleGeometry, THREE.MeshBasicMaterial>;
   glow: THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>;
+}
+
+interface BoostPadVisualEnvironment {
+  reflectionMap: THREE.Texture | null;
+  dispose(): void;
 }
 
 function configureOverlayMaterial(material: THREE.MeshBasicMaterial): void {
@@ -41,7 +54,7 @@ function padRadius(pad: ReplayBoostPad): number {
 }
 
 function padOrbRadius(pad: ReplayBoostPad): number {
-  return scaledPadDimension(pad.size === "big" ? 155 : 46);
+  return scaledPadDimension(pad.size === "big" ? 104 : 46);
 }
 
 function padOrbBottomClearance(pad: ReplayBoostPad): number {
@@ -67,10 +80,124 @@ function padGlowCenterZ(pad: ReplayBoostPad): number {
 }
 
 function padColor(pad: ReplayBoostPad): number {
-  return pad.size === "big" ? 0xf59e0b : 0xfacc15;
+  return pad.size === "big" ? 0xc98500 : 0xffd119;
 }
 
-function createPadMeshes(pad: ReplayBoostPad): BoostPadMeshes {
+function setMeshBasicOpacity(group: THREE.Group, opacityScale: number): void {
+  group.traverse((child) => {
+    const mesh = child as THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>;
+    if (!mesh.isMesh || !(mesh.material instanceof THREE.MeshBasicMaterial)) {
+      return;
+    }
+    const baseOpacity = mesh.userData.baseOpacity as number | undefined;
+    mesh.material.opacity = (baseOpacity ?? mesh.material.opacity) * opacityScale;
+  });
+}
+
+function createBigBoostBase(radius: number): THREE.Group {
+  const group = new THREE.Group();
+  group.renderOrder = 18;
+  group.frustumCulled = false;
+
+  const darkMaterial = new THREE.MeshBasicMaterial({
+    color: 0x11110d,
+    transparent: true,
+    opacity: 0.86,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+  });
+  configureOverlayMaterial(darkMaterial);
+
+  const panelMaterial = new THREE.MeshBasicMaterial({
+    color: 0xffa000,
+    transparent: true,
+    opacity: 0.86,
+    side: THREE.DoubleSide,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+  });
+  configureOverlayMaterial(panelMaterial);
+
+  const center = new THREE.Mesh(new THREE.CircleGeometry(radius * 0.55, 48), darkMaterial.clone());
+  center.userData.baseOpacity = darkMaterial.opacity;
+  center.position.z = PAD_SURFACE_Z_OFFSET - 2.2;
+  center.renderOrder = 18;
+  center.frustumCulled = false;
+  group.add(center);
+
+  const centerRing = new THREE.Mesh(
+    new THREE.RingGeometry(radius * 0.45, radius * 0.62, 48),
+    new THREE.MeshBasicMaterial({
+      color: 0xffd13a,
+      transparent: true,
+      opacity: 0.78,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    }),
+  );
+  configureOverlayMaterial(centerRing.material);
+  centerRing.userData.baseOpacity = centerRing.material.opacity;
+  centerRing.position.z = PAD_SURFACE_Z_OFFSET - 1.1;
+  centerRing.renderOrder = 20;
+  centerRing.frustumCulled = false;
+  group.add(centerRing);
+
+  function createArmShape(
+    innerRadius: number,
+    outerRadius: number,
+    halfAngle: number,
+  ): THREE.Shape {
+    const shape = new THREE.Shape();
+    const points: Array<[number, number]> = [
+      [innerRadius * Math.cos(-halfAngle * 0.72), innerRadius * Math.sin(-halfAngle * 0.72)],
+      [outerRadius * Math.cos(-halfAngle), outerRadius * Math.sin(-halfAngle)],
+      [outerRadius * Math.cos(halfAngle), outerRadius * Math.sin(halfAngle)],
+      [innerRadius * Math.cos(halfAngle * 0.72), innerRadius * Math.sin(halfAngle * 0.72)],
+    ];
+    points.forEach(([x, y], index) => {
+      if (index === 0) {
+        shape.moveTo(x, y);
+      } else {
+        shape.lineTo(x, y);
+      }
+    });
+    shape.closePath();
+    return shape;
+  }
+
+  for (let index = 0; index < 3; index += 1) {
+    const rotation = (index * (Math.PI * 2)) / 3 + Math.PI / 2;
+    const arm = new THREE.Mesh(
+      new THREE.ShapeGeometry(createArmShape(radius * 0.52, radius * 1.42, 0.33)),
+      darkMaterial.clone(),
+    );
+    arm.userData.baseOpacity = darkMaterial.opacity;
+    arm.position.z = PAD_SURFACE_Z_OFFSET - 2;
+    arm.rotation.z = rotation;
+    arm.renderOrder = 18;
+    arm.frustumCulled = false;
+    group.add(arm);
+
+    const panel = new THREE.Mesh(
+      new THREE.ShapeGeometry(createArmShape(radius * 0.66, radius * 1.2, 0.21)),
+      panelMaterial.clone(),
+    );
+    panel.userData.baseOpacity = panelMaterial.opacity;
+    panel.position.z = PAD_SURFACE_Z_OFFSET - 0.8;
+    panel.rotation.z = rotation;
+    panel.renderOrder = 19;
+    panel.frustumCulled = false;
+    group.add(panel);
+  }
+
+  return group;
+}
+
+function createPadMeshes(
+  pad: ReplayBoostPad,
+  visualEnvironment: BoostPadVisualEnvironment,
+): BoostPadMeshes {
   const radius = padRadius(pad);
   const color = padColor(pad);
   const orbRadius = padOrbRadius(pad);
@@ -80,13 +207,19 @@ function createPadMeshes(pad: ReplayBoostPad): BoostPadMeshes {
   group.renderOrder = 20;
   group.frustumCulled = false;
 
+  const base = isBigPad ? createBigBoostBase(radius) : new THREE.Group();
+  if (isBigPad) {
+    group.add(base);
+  }
+
   const ring = new THREE.Mesh(
-    new THREE.RingGeometry(radius * 0.72, radius, 24),
+    new THREE.RingGeometry(radius * (isBigPad ? 0.62 : 0.72), radius * (isBigPad ? 0.82 : 1), 32),
     new THREE.MeshBasicMaterial({
-      color,
+      color: isBigPad ? 0xffd137 : color,
       transparent: true,
-      opacity: 0.92,
+      opacity: isBigPad ? 0.82 : 0.92,
       side: THREE.DoubleSide,
+      blending: isBigPad ? THREE.AdditiveBlending : THREE.NormalBlending,
       depthWrite: false,
     }),
   );
@@ -97,12 +230,13 @@ function createPadMeshes(pad: ReplayBoostPad): BoostPadMeshes {
   group.add(ring);
 
   const core = new THREE.Mesh(
-    new THREE.CircleGeometry(radius * 0.58, 24),
+    new THREE.CircleGeometry(radius * (isBigPad ? 0.54 : 0.58), 32),
     new THREE.MeshBasicMaterial({
-      color,
+      color: isBigPad ? 0xffa600 : color,
       transparent: true,
-      opacity: 0.3,
+      opacity: isBigPad ? 0.46 : 0.3,
       side: THREE.DoubleSide,
+      blending: isBigPad ? THREE.AdditiveBlending : THREE.NormalBlending,
       depthWrite: false,
     }),
   );
@@ -131,40 +265,126 @@ function createPadMeshes(pad: ReplayBoostPad): BoostPadMeshes {
   const orb = new THREE.Mesh(
     isBigPad
       ? new THREE.SphereGeometry(orbRadius, 32, 18)
-      : new THREE.CircleGeometry(orbRadius * 0.9, 24),
+      : new THREE.SphereGeometry(orbRadius * 1.22, 32, 12),
     isBigPad
-      ? new THREE.MeshPhongMaterial({
-          color,
-          emissive: new THREE.Color(color),
-          emissiveIntensity: 0.6,
-          shininess: 88,
-          specular: new THREE.Color(0xfff2c2),
+      ? new THREE.MeshPhysicalMaterial({
+          color: 0xffb21a,
+          emissive: new THREE.Color(0xff8a00),
+          emissiveIntensity: 0.42,
+          metalness: 0.04,
+          roughness: 0.08,
+          clearcoat: 1,
+          clearcoatRoughness: 0.025,
+          transmission: 0.18,
+          thickness: scaledPadDimension(48),
+          ior: 1.42,
+          envMap: visualEnvironment.reflectionMap,
+          envMapIntensity: 1.9,
           transparent: true,
-          opacity: 0.92,
+          opacity: 0.68,
           depthWrite: false,
-        })
-      : new THREE.MeshBasicMaterial({
-          color,
-          transparent: true,
-          opacity: 0.88,
-          side: THREE.DoubleSide,
           blending: THREE.AdditiveBlending,
+        })
+      : new THREE.MeshPhysicalMaterial({
+          color,
+          emissive: new THREE.Color(0xff9d00),
+          emissiveIntensity: 0.72,
+          metalness: 0.88,
+          roughness: 0.14,
+          clearcoat: 1,
+          clearcoatRoughness: 0.05,
+          envMap: visualEnvironment.reflectionMap,
+          envMapIntensity: 2.0,
+          transparent: true,
+          opacity: 0.96,
           depthWrite: false,
         }),
   );
   orb.position.z = padLightCenterZ(pad);
+  if (!isBigPad) {
+    orb.scale.z = 0.18;
+  }
   orb.renderOrder = 23;
   orb.frustumCulled = false;
   group.add(orb);
 
+  const lensColumn = new THREE.Mesh(
+    isBigPad
+      ? new THREE.CylinderGeometry(radius * 0.07, radius * 0.11, orbRadius * 2.04, 24, 1, true)
+      : new THREE.CylinderGeometry(
+          orbRadius * 0.72,
+          orbRadius * 1.12,
+          orbRadius * 0.42,
+          24,
+          1,
+          true,
+        ),
+    new THREE.MeshBasicMaterial({
+      color: isBigPad ? 0xffc340 : 0xffd64a,
+      transparent: true,
+      opacity: isBigPad ? 0.28 : 0.12,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    }),
+  );
+  lensColumn.rotation.x = Math.PI / 2;
+  lensColumn.position.z = isBigPad
+    ? PAD_SURFACE_Z_OFFSET + scaledPadDimension(58)
+    : PAD_SURFACE_Z_OFFSET + scaledPadDimension(7);
+  lensColumn.renderOrder = 23;
+  lensColumn.frustumCulled = false;
+  group.add(lensColumn);
+
+  const lensRim = new THREE.Mesh(
+    new THREE.SphereGeometry(isBigPad ? orbRadius * 1.01 : orbRadius * 1.24, 32, 14),
+    new THREE.MeshBasicMaterial({
+      color: isBigPad ? 0xffdf7a : color,
+      transparent: true,
+      opacity: isBigPad ? 0.32 : 0.12,
+      side: THREE.BackSide,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    }),
+  );
+  lensRim.position.z = padLightCenterZ(pad);
+  if (!isBigPad) {
+    lensRim.scale.z = 0.18;
+  }
+  lensRim.renderOrder = 24;
+  lensRim.frustumCulled = false;
+  group.add(lensRim);
+
+  const sheen = new THREE.Mesh(
+    new THREE.CircleGeometry(isBigPad ? orbRadius * 0.72 : orbRadius * 0.82, 24),
+    new THREE.MeshBasicMaterial({
+      color: isBigPad ? 0xffdf82 : 0xfff7cf,
+      transparent: true,
+      opacity: isBigPad ? 0.52 : 0.34,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    }),
+  );
+  configureOverlayMaterial(sheen.material);
+  sheen.scale.y = isBigPad ? 0.36 : 0.44;
+  sheen.position.set(
+    isBigPad ? -orbRadius * 0.16 : -orbRadius * 0.22,
+    isBigPad ? orbRadius * 0.1 : orbRadius * 0.12,
+    padLightCenterZ(pad) + (isBigPad ? orbRadius * 0.5 : orbRadius * 0.16),
+  );
+  sheen.renderOrder = 25;
+  sheen.frustumCulled = false;
+  group.add(sheen);
+
   const glow = new THREE.Mesh(
     isBigPad
-      ? new THREE.SphereGeometry(orbRadius * 1.36, 32, 14)
-      : new THREE.CircleGeometry(orbRadius * 1.35, 28),
+      ? new THREE.SphereGeometry(orbRadius * 1.28, 32, 14)
+      : new THREE.CircleGeometry(orbRadius * 1.82, 32),
     new THREE.MeshBasicMaterial({
       color,
       transparent: true,
-      opacity: isBigPad ? 0.2 : 0.16,
+      opacity: isBigPad ? 0.16 : 0.28,
       side: THREE.DoubleSide,
       blending: THREE.AdditiveBlending,
       depthWrite: false,
@@ -175,7 +395,27 @@ function createPadMeshes(pad: ReplayBoostPad): BoostPadMeshes {
   glow.frustumCulled = false;
   group.add(glow);
 
-  return { group, ring, core, cooldown, orb, glow };
+  return { group, base, ring, core, cooldown, orb, lensColumn, lensRim, sheen, glow };
+}
+
+function createVisualEnvironment(context: ReplayPlayerPluginContext): BoostPadVisualEnvironment {
+  const sceneEnvironment = context.scene.scene.environment;
+  if (sceneEnvironment instanceof THREE.Texture) {
+    return {
+      reflectionMap: sceneEnvironment,
+      dispose() {},
+    };
+  }
+
+  const pmrem = new THREE.PMREMGenerator(context.scene.renderer);
+  const reflectionMap = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+  pmrem.dispose();
+  return {
+    reflectionMap,
+    dispose() {
+      reflectionMap.dispose();
+    },
+  };
 }
 
 function boostPadAvailableState(
@@ -226,38 +466,71 @@ function updatePadMeshes(
   const { available, progress } = boostPadAvailableState(pad, currentTime);
   const isBigPad = pad.size === "big";
   const pulse = 0.92 + 0.08 * Math.sin(currentTime * 6 + pad.index * 0.45);
-  const orbPulse = 0.96 + 0.04 * Math.sin(currentTime * (isBigPad ? 4.8 : 7.2) + pad.index * 0.37);
-  const hover = isBigPad ? Math.sin(currentTime * 2.2 + pad.index * 0.61) * 18 : 0;
+  const orbPulse =
+    (isBigPad ? 0.98 : 0.96) +
+    (isBigPad ? 0.025 : 0.04) * Math.sin(currentTime * (isBigPad ? 4.8 : 7.2) + pad.index * 0.37);
+  const hover = isBigPad ? Math.sin(currentTime * 2.2 + pad.index * 0.61) * 10 : 0;
   const lightZ = padLightCenterZ(pad) + hover;
   const glowZ = padGlowCenterZ(pad) + hover;
+  const orbRadius = padOrbRadius(pad);
 
   meshes.orb.position.z = lightZ;
+  meshes.lensRim.position.z = lightZ;
+  meshes.sheen.position.z = lightZ + (isBigPad ? orbRadius * 0.5 : orbRadius * 0.16);
   meshes.glow.position.z = glowZ;
   meshes.orb.rotation.z = currentTime * (isBigPad ? 0.9 : 1.25);
+  meshes.lensRim.rotation.z = -currentTime * (isBigPad ? 0.7 : 1.1);
+  meshes.lensColumn.rotation.z = currentTime * 0.18;
+  meshes.sheen.rotation.z = currentTime * (isBigPad ? -0.35 : -0.8);
   meshes.glow.rotation.z = -currentTime * 0.45;
 
   if (available) {
     meshes.group.visible = true;
-    meshes.ring.material.opacity = 0.95;
-    meshes.core.material.opacity = isBigPad ? 0.56 : 0.5;
+    setMeshBasicOpacity(meshes.base, 1);
+    meshes.ring.material.opacity = isBigPad ? 0.82 : 0.95;
+    meshes.core.material.opacity = isBigPad ? 0.48 : 0.5;
     meshes.cooldown.visible = false;
-    meshes.ring.scale.setScalar(pulse);
+    meshes.base.visible = isBigPad;
+    meshes.base.scale.setScalar(1 + (pulse - 0.92) * 0.18);
+    meshes.ring.scale.setScalar(isBigPad ? 1 + (pulse - 0.92) * 0.32 : pulse);
     meshes.core.scale.setScalar(1);
     meshes.orb.visible = true;
+    meshes.lensColumn.visible = true;
+    meshes.lensRim.visible = true;
+    meshes.sheen.visible = true;
     meshes.glow.visible = true;
-    meshes.orb.material.opacity = isBigPad ? 0.96 : 0.9;
-    meshes.glow.material.opacity = (isBigPad ? 0.2 : 0.16) + (orbPulse - 0.96);
+    meshes.orb.material.opacity = isBigPad ? 0.68 : 0.98;
+    meshes.lensColumn.material.opacity =
+      (isBigPad ? 0.28 : 0.12) + (orbPulse - (isBigPad ? 0.98 : 0.96)) * 0.34;
+    meshes.lensRim.material.opacity =
+      (isBigPad ? 0.32 : 0.12) + (orbPulse - (isBigPad ? 0.98 : 0.96)) * 0.55;
+    meshes.sheen.material.opacity =
+      (isBigPad ? 0.52 : 0.34) + (orbPulse - (isBigPad ? 0.98 : 0.96)) * 0.7;
+    meshes.glow.material.opacity = (isBigPad ? 0.16 : 0.28) + (orbPulse - (isBigPad ? 0.98 : 0.96));
     meshes.orb.scale.setScalar(orbPulse);
+    meshes.lensRim.scale.setScalar(1.01 + (orbPulse - (isBigPad ? 0.98 : 0.96)) * 1.7);
+    meshes.lensColumn.scale.setScalar(1 + (orbPulse - (isBigPad ? 0.98 : 0.96)) * 1.2);
+    if (!isBigPad) {
+      meshes.orb.scale.z = 0.18 * orbPulse;
+      meshes.lensRim.scale.z = 0.18 * orbPulse;
+    }
+    meshes.sheen.scale.setScalar(isBigPad ? 1.02 + (orbPulse - 0.96) : 1.06 + (orbPulse - 0.96));
+    meshes.sheen.scale.y *= isBigPad ? 0.36 : 0.44;
     meshes.glow.scale.setScalar(isBigPad ? 1.02 + (orbPulse - 0.96) * 2 : 1);
     return;
   }
 
   meshes.group.visible = true;
+  setMeshBasicOpacity(meshes.base, 0.26);
   meshes.ring.material.opacity = 0.18;
   meshes.core.material.opacity = 0.07;
+  meshes.base.scale.setScalar(1);
   meshes.ring.scale.setScalar(1);
   meshes.core.scale.setScalar(1);
   meshes.orb.visible = false;
+  meshes.lensColumn.visible = false;
+  meshes.lensRim.visible = false;
+  meshes.sheen.visible = false;
   meshes.glow.visible = false;
 
   meshes.cooldown.visible = showCooldownProgress;
@@ -274,6 +547,7 @@ export function createBoostPadOverlayPlugin(
   const showCooldownProgress = options.showCooldownProgress ?? true;
 
   let padRoot: THREE.Group | null = null;
+  let visualEnvironment: BoostPadVisualEnvironment | null = null;
   const padMeshes = new Map<number, BoostPadMeshes>();
 
   function buildPads(context: ReplayPlayerPluginContext): void {
@@ -281,9 +555,10 @@ export function createBoostPadOverlayPlugin(
     padRoot.name = "boost-pad-overlay";
     padRoot.renderOrder = 20;
     padRoot.frustumCulled = false;
+    visualEnvironment = createVisualEnvironment(context);
 
     for (const pad of context.replay.boostPads) {
-      const meshes = createPadMeshes(pad);
+      const meshes = createPadMeshes(pad, visualEnvironment);
       padRoot.add(meshes.group);
       padMeshes.set(pad.index, meshes);
     }
@@ -315,6 +590,8 @@ export function createBoostPadOverlayPlugin(
     },
     teardown(): void {
       padRoot?.removeFromParent();
+      visualEnvironment?.dispose();
+      visualEnvironment = null;
       padRoot = null;
       padMeshes.clear();
     },

--- a/js/player/src/player.ts
+++ b/js/player/src/player.ts
@@ -7,6 +7,7 @@ import {
   updateBoostMeter,
   type ReplayScene,
 } from "./scene";
+import { createBoostPadOverlayPlugin } from "./boost-pad-overlay";
 import { findFrameIndexAtTime } from "./replay-data";
 import {
   DEFAULT_CAMERA_VIEW_MODE,
@@ -197,6 +198,9 @@ export class ReplayPlayer extends EventTarget {
     this.installResizeHandling();
     for (const plugin of options.plugins ?? []) {
       this.installPlugin(plugin, false);
+    }
+    if (!this.plugins.some((entry) => entry.plugin.id === "boost-pad-overlay")) {
+      this.installPlugin(createBoostPadOverlayPlugin(), false);
     }
     this.render();
     this.scheduleAnimationFrame();

--- a/js/player/src/viewer/ViewerPlayer.ts
+++ b/js/player/src/viewer/ViewerPlayer.ts
@@ -18,6 +18,7 @@ import { ActorManager } from "./managers/ActorManager.js";
 import { EffectsManager } from "./managers/EffectsManager.js";
 import { HitboxManager } from "./managers/HitboxManager.js";
 import type { SubtrActorPlayer } from "./adapter/SubtrActorPlayer.js";
+import { createBoostPadsPlugin } from "./plugins/boost-pads.js";
 // Timeline projection / skip-window semantics are @rlrml/player's own
 // ReplayModel utilities, so both players agree on what gets skipped and how
 // replay time maps onto the (skip-aware) timeline.
@@ -380,6 +381,9 @@ export class ViewerPlayer extends EventTarget {
     this.installResizeHandling();
     for (const definition of options.plugins ?? []) {
       this.installPlugin(definition, false);
+    }
+    if (!this.plugins.some((entry) => entry.plugin.id === "boost-pads")) {
+      this.installPlugin(createBoostPadsPlugin(), false);
     }
     this.applyInitialCameraOptions();
     // @rlrml/player semantics: don't start inside a skipped window (t=0 is a

--- a/js/player/src/viewer/plugins/boost-pads.ts
+++ b/js/player/src/viewer/plugins/boost-pads.ts
@@ -12,6 +12,153 @@ import type { ViewerPlugin, ViewerPluginContext, ViewerRenderContext } from "../
 
 type PadMesh = THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
 
+const BOOST_PAD_CHILD_MESH_KEYS = [
+  "baseGroup",
+  "glowMesh",
+  "innerGlowMesh",
+  "lensColumnMesh",
+  "lensRimMesh",
+  "topGlowMesh",
+  "coreGlowMesh",
+  "highlightMesh",
+] as const;
+
+function createHorizontalGlowDisk(
+  radius: number,
+  color: number,
+  opacity: number,
+  renderOrder: number,
+): THREE.Mesh<THREE.CircleGeometry, THREE.MeshBasicMaterial> {
+  const mesh = new THREE.Mesh(
+    new THREE.CircleGeometry(radius, 32),
+    new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    }),
+  );
+  mesh.rotation.x = -Math.PI / 2;
+  mesh.renderOrder = renderOrder;
+  return mesh;
+}
+
+function setBasicGroupOpacity(group: THREE.Object3D | undefined, opacityScale: number): void {
+  if (!group) {
+    return;
+  }
+  group.traverse((child) => {
+    const mesh = child as THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>;
+    if (!mesh.isMesh || !(mesh.material instanceof THREE.MeshBasicMaterial)) {
+      return;
+    }
+    const baseOpacity = mesh.userData.baseOpacity as number | undefined;
+    mesh.material.opacity = (baseOpacity ?? mesh.material.opacity) * opacityScale;
+  });
+}
+
+function configureBigBaseMesh(
+  mesh: THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>,
+  opacity: number,
+  renderOrder: number,
+): void {
+  mesh.rotation.x = -Math.PI / 2;
+  mesh.renderOrder = renderOrder;
+  mesh.frustumCulled = false;
+  mesh.userData.baseOpacity = opacity;
+  mesh.material.transparent = true;
+  mesh.material.opacity = opacity;
+  mesh.material.side = THREE.DoubleSide;
+  mesh.material.depthWrite = false;
+}
+
+function createBigBoostBase(radius: number): THREE.Group {
+  const group = new THREE.Group();
+  group.renderOrder = 98;
+  group.frustumCulled = false;
+
+  const darkMaterial = new THREE.MeshBasicMaterial({ color: 0x11110d });
+  const panelMaterial = new THREE.MeshBasicMaterial({
+    color: 0xffa000,
+    blending: THREE.AdditiveBlending,
+  });
+
+  const center = new THREE.Mesh(new THREE.CircleGeometry(radius * 0.55, 48), darkMaterial.clone());
+  configureBigBaseMesh(center, 0.86, 98);
+  group.add(center);
+
+  const centerRing = new THREE.Mesh(
+    new THREE.RingGeometry(radius * 0.45, radius * 0.62, 48),
+    new THREE.MeshBasicMaterial({
+      color: 0xffd13a,
+      blending: THREE.AdditiveBlending,
+    }),
+  );
+  configureBigBaseMesh(centerRing, 0.78, 100);
+  centerRing.position.y = 1.4;
+  group.add(centerRing);
+
+  function createArmShape(
+    innerRadius: number,
+    outerRadius: number,
+    halfAngle: number,
+  ): THREE.Shape {
+    const shape = new THREE.Shape();
+    const points: Array<[number, number]> = [
+      [innerRadius * Math.cos(-halfAngle * 0.72), innerRadius * Math.sin(-halfAngle * 0.72)],
+      [outerRadius * Math.cos(-halfAngle), outerRadius * Math.sin(-halfAngle)],
+      [outerRadius * Math.cos(halfAngle), outerRadius * Math.sin(halfAngle)],
+      [innerRadius * Math.cos(halfAngle * 0.72), innerRadius * Math.sin(halfAngle * 0.72)],
+    ];
+    points.forEach(([x, z], index) => {
+      if (index === 0) {
+        shape.moveTo(x, z);
+      } else {
+        shape.lineTo(x, z);
+      }
+    });
+    shape.closePath();
+    return shape;
+  }
+
+  for (let index = 0; index < 3; index += 1) {
+    const rotation = (index * (Math.PI * 2)) / 3 + Math.PI / 2;
+    const arm = new THREE.Mesh(
+      new THREE.ShapeGeometry(createArmShape(radius * 0.52, radius * 1.42, 0.33)),
+      darkMaterial.clone(),
+    );
+    configureBigBaseMesh(arm, 0.86, 98);
+    arm.rotation.z = rotation;
+    group.add(arm);
+
+    const panel = new THREE.Mesh(
+      new THREE.ShapeGeometry(createArmShape(radius * 0.66, radius * 1.2, 0.21)),
+      panelMaterial.clone(),
+    );
+    configureBigBaseMesh(panel, 0.86, 99);
+    panel.position.y = 1.1;
+    panel.rotation.z = rotation;
+    group.add(panel);
+  }
+
+  return group;
+}
+
+function setChildMeshAvailability(mesh: PadMesh, available: boolean): void {
+  for (const key of BOOST_PAD_CHILD_MESH_KEYS) {
+    const child = mesh.userData[key] as
+      | THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>
+      | THREE.Group
+      | undefined;
+    if (!child) {
+      continue;
+    }
+    child.visible = available;
+  }
+}
+
 export function createBoostPadsPlugin(): ViewerPlugin {
   let boostPadMeshes = new Map<number, PadMesh>();
 
@@ -31,29 +178,71 @@ export function createBoostPadsPlugin(): ViewerPlugin {
       let mesh: PadMesh;
 
       if (isBig) {
-        // Big pads: Glowing sphere (dimensions in Unreal Units)
-        // Big boost pads in RL are ~144 UU diameter, we use a smaller visual sphere
-        const radius = 50; // Visual sphere radius in UU
-        geometry = new THREE.SphereGeometry(radius, 16, 16);
-        material = new THREE.MeshStandardMaterial({
-          color: 0xffdd44, // Bright yellow/orange core
-          emissive: 0xffaa00,
-          emissiveIntensity: 1.0,
-          metalness: 0.3,
-          roughness: 0.2,
+        // Big pads: translucent golden lens over a dark/gold base.
+        const radius = 37; // Visual sphere radius in UU
+        geometry = new THREE.SphereGeometry(radius, 24, 18);
+        material = new THREE.MeshPhysicalMaterial({
+          color: 0xffb21a,
+          emissive: 0xff8a00,
+          emissiveIntensity: 0.42,
+          metalness: 0.04,
+          roughness: 0.08,
+          clearcoat: 1.0,
+          clearcoatRoughness: 0.025,
+          transmission: 0.18,
+          thickness: 30,
+          ior: 1.42,
+          envMapIntensity: 1.9,
+          blending: THREE.AdditiveBlending,
           transparent: true, // CRITICAL: Required for opacity changes
-          opacity: 1.0,
+          opacity: 0.68,
           depthWrite: false, // Fix transparency sorting with arena walls
         });
         mesh = new THREE.Mesh(geometry, material);
         mesh.renderOrder = 100; // Render after arena walls
 
+        const baseGroup = createBigBoostBase(radius * 2.05);
+        baseGroup.position.y = -140;
+        mesh.add(baseGroup);
+        mesh.userData.baseGroup = baseGroup;
+
+        const lensColumnMesh = new THREE.Mesh(
+          new THREE.CylinderGeometry(radius * 0.12, radius * 0.18, 112, 24, 1, true),
+          new THREE.MeshBasicMaterial({
+            color: 0xffc340,
+            transparent: true,
+            opacity: 0.28,
+            blending: THREE.AdditiveBlending,
+            side: THREE.DoubleSide,
+            depthWrite: false,
+          }),
+        );
+        lensColumnMesh.position.y = -62;
+        lensColumnMesh.renderOrder = 99;
+        mesh.add(lensColumnMesh);
+        mesh.userData.lensColumnMesh = lensColumnMesh;
+
+        const lensRimMesh = new THREE.Mesh(
+          new THREE.SphereGeometry(radius * 1.03, 24, 14),
+          new THREE.MeshBasicMaterial({
+            color: 0xffdf7a,
+            transparent: true,
+            opacity: 0.32,
+            blending: THREE.AdditiveBlending,
+            side: THREE.BackSide,
+            depthWrite: false,
+          }),
+        );
+        lensRimMesh.renderOrder = 101;
+        mesh.add(lensRimMesh);
+        mesh.userData.lensRimMesh = lensRimMesh;
+
         // Add glow effect - larger transparent sphere with additive blending
-        const glowGeometry = new THREE.SphereGeometry(radius * 2.0, 16, 16);
+        const glowGeometry = new THREE.SphereGeometry(radius * 1.3, 20, 14);
         const glowMaterial = new THREE.MeshBasicMaterial({
-          color: 0xffaa00,
+          color: 0xffb62b,
           transparent: true,
-          opacity: 0.3,
+          opacity: 0.16,
           blending: THREE.AdditiveBlending,
           side: THREE.BackSide, // Render inside of sphere for halo effect
           depthWrite: false,
@@ -64,11 +253,11 @@ export function createBoostPadsPlugin(): ViewerPlugin {
         mesh.userData.glowMesh = glowMesh;
 
         // Add second smaller glow layer for more intensity
-        const innerGlowGeometry = new THREE.SphereGeometry(radius * 1.4, 16, 16);
+        const innerGlowGeometry = new THREE.SphereGeometry(radius * 1.12, 20, 14);
         const innerGlowMaterial = new THREE.MeshBasicMaterial({
-          color: 0xffcc00,
+          color: 0xffc12a,
           transparent: true,
-          opacity: 0.4,
+          opacity: 0.22,
           blending: THREE.AdditiveBlending,
           side: THREE.BackSide,
           depthWrite: false,
@@ -82,21 +271,40 @@ export function createBoostPadsPlugin(): ViewerPlugin {
       } else {
         // Small pads: Flat cylinder at ground level (dimensions in Unreal Units)
         // Small boost pads in RL are ~64 UU diameter
-        const radius = 40; // Visual radius in UU
-        const height = 5; // Flat disk height in UU
-        geometry = new THREE.CylinderGeometry(radius, radius, height, 16);
-        material = new THREE.MeshStandardMaterial({
-          color: 0xffcc00, // Yellow/orange
-          emissive: 0xff9900,
-          emissiveIntensity: 0.4,
-          metalness: 0.2,
-          roughness: 0.8,
+        const radius = 45; // Visual radius in UU
+        const height = 8; // Low reflective puck height in UU
+        geometry = new THREE.CylinderGeometry(radius, radius * 0.92, height, 32);
+        material = new THREE.MeshPhysicalMaterial({
+          color: 0xffc21a,
+          emissive: 0xff9700,
+          emissiveIntensity: 0.72,
+          metalness: 0.88,
+          roughness: 0.14,
+          clearcoat: 1.0,
+          clearcoatRoughness: 0.05,
+          envMapIntensity: 2.0,
           transparent: true, // CRITICAL: Required for opacity changes
           opacity: 1.0,
           depthWrite: false, // Fix transparency sorting with arena walls
         });
         mesh = new THREE.Mesh(geometry, material);
         mesh.renderOrder = 100; // Render after arena walls
+
+        const topGlowMesh = createHorizontalGlowDisk(radius * 1.42, 0xffb000, 0.34, 101);
+        topGlowMesh.position.y = height / 2 + 0.15;
+        mesh.add(topGlowMesh);
+        mesh.userData.topGlowMesh = topGlowMesh;
+
+        const coreGlowMesh = createHorizontalGlowDisk(radius * 0.74, 0xffff9a, 0.42, 102);
+        coreGlowMesh.position.y = height / 2 + 0.35;
+        mesh.add(coreGlowMesh);
+        mesh.userData.coreGlowMesh = coreGlowMesh;
+
+        const highlightMesh = createHorizontalGlowDisk(radius * 0.42, 0xfff8d0, 0.46, 103);
+        highlightMesh.position.set(-radius * 0.18, height / 2 + 0.55, -radius * 0.12);
+        highlightMesh.scale.y = 0.34;
+        mesh.add(highlightMesh);
+        mesh.userData.highlightMesh = highlightMesh;
       }
 
       // Position the boost pad (adapter provides positions in UU)
@@ -122,7 +330,7 @@ export function createBoostPadsPlugin(): ViewerPlugin {
 
       // Add point light for big pads directly to scene
       if (mesh.userData.needsLight) {
-        const light = new THREE.PointLight(0xffaa00, 1.0, 600);
+        const light = new THREE.PointLight(0xff9d00, 0.7, 480);
         light.decay = 0; // No decay, but limited by distance
         light.position.set(pad.position.x, floatHeight - 50, pad.position.y);
         ctx.scene.add(light);
@@ -147,14 +355,16 @@ export function createBoostPadsPlugin(): ViewerPlugin {
 
       if (isAvailable) {
         // Available - orange/yellow (normal color)
-        mesh.material.color.setHex(pad.isBig ? 0xffdd44 : 0xffcc00);
-        mesh.material.emissive.setHex(pad.isBig ? 0xffaa00 : 0xff9900);
-        mesh.material.emissiveIntensity = pad.isBig ? 1.0 : 0.4;
-        mesh.material.opacity = 1.0;
+        mesh.material.color.setHex(pad.isBig ? 0xffb21a : 0xffc21a);
+        mesh.material.emissive.setHex(pad.isBig ? 0xff8a00 : 0xff9700);
+        mesh.material.emissiveIntensity = pad.isBig ? 0.42 : 0.72;
+        mesh.material.opacity = pad.isBig ? 0.68 : 1.0;
         mesh.visible = true;
+        setChildMeshAvailability(mesh, true);
+        setBasicGroupOpacity(mesh.userData.baseGroup as THREE.Group | undefined, 1);
         // Turn on light and glow for big pads
         if (mesh.userData.light) {
-          mesh.userData.light.intensity = 1.0;
+          mesh.userData.light.intensity = 0.85;
         }
         if (mesh.userData.glowMesh) {
           mesh.userData.glowMesh.visible = true;
@@ -164,11 +374,16 @@ export function createBoostPadsPlugin(): ViewerPlugin {
         }
       } else {
         // Picked up - transparent (faded out)
-        mesh.material.color.setHex(pad.isBig ? 0xffaa00 : 0xffcc00);
+        mesh.material.color.setHex(pad.isBig ? 0x8a4c00 : 0x8a5400);
         mesh.material.emissive.setHex(0x000000); // No emission when inactive
         mesh.material.emissiveIntensity = 0.0;
         mesh.material.opacity = 0.2; // Very transparent
         mesh.visible = true; // Still visible but faded
+        setChildMeshAvailability(mesh, false);
+        if (mesh.userData.baseGroup) {
+          mesh.userData.baseGroup.visible = true;
+          setBasicGroupOpacity(mesh.userData.baseGroup as THREE.Group, 0.26);
+        }
         // Turn off light and glow for big pads
         if (mesh.userData.light) {
           mesh.userData.light.intensity = 0;
@@ -201,13 +416,20 @@ export function createBoostPadsPlugin(): ViewerPlugin {
         ctx.scene.remove(mesh);
         mesh.geometry.dispose();
         mesh.material.dispose();
-        for (const key of ["glowMesh", "innerGlowMesh"] as const) {
+        for (const key of BOOST_PAD_CHILD_MESH_KEYS) {
           const glow = mesh.userData[key] as
             | THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>
+            | THREE.Group
             | undefined;
           if (glow) {
-            glow.geometry.dispose();
-            glow.material.dispose();
+            glow.traverse((child) => {
+              const childMesh = child as THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>;
+              if (!childMesh.isMesh) {
+                return;
+              }
+              childMesh.geometry.dispose();
+              childMesh.material.dispose();
+            });
           }
         }
         const light = mesh.userData.light as THREE.PointLight | undefined;

--- a/js/stat-evaluation-player/src/activeModulesRuntime.ts
+++ b/js/stat-evaluation-player/src/activeModulesRuntime.ts
@@ -1,9 +1,4 @@
-import {
-  createBoostPadOverlayPlugin,
-  type ReplayTimelineEvent,
-  type TimelineOverlayPlugin,
-} from "@rlrml/player";
-import { fromReplayPlayerPlugin } from "@rlrml/player";
+import type { ReplayTimelineEvent, TimelineOverlayPlugin } from "@rlrml/player";
 import type { StatsReplayPlayer } from "./statsReplayPlayer.ts";
 import type { BoostPickupFilterController } from "./boostPickupFilters.ts";
 import type { EventTimelineSource } from "./eventTimelineSources.ts";
@@ -35,8 +30,6 @@ export class ActiveModulesRuntime {
   private removeRenderHook: (() => void) | null = null;
   private readonly timelineSourceRemovers = new Map<string, () => void>();
   private readonly timelineRangeSourceRemovers = new Map<string, () => void>();
-  private readonly standalonePluginRemovers = new Map<string, () => void>();
-  private boostPadOverlayEnabled = true;
 
   constructor(private readonly options: ActiveModulesRuntimeOptions) {}
 
@@ -69,7 +62,7 @@ export class ActiveModulesRuntime {
   }
 
   getBoostPadOverlayEnabled(): boolean {
-    return this.boostPadOverlayEnabled;
+    return true;
   }
 
   getTimelineEventSourceIds(): string[] {
@@ -106,7 +99,7 @@ export class ActiveModulesRuntime {
     this.activeMechanicTimelineKinds = new Set(mechanics);
     this.migrateMechanicBackedTimelineEventSelections();
     this.activeRenderEffectModuleIds = new Set(renderEffects);
-    this.boostPadOverlayEnabled = boostPads;
+    void boostPads;
   }
 
   reset(): void {
@@ -117,7 +110,6 @@ export class ActiveModulesRuntime {
     this.activeTimelineRangeModuleIds = new Set<string>();
     this.activeMechanicTimelineKinds = new Set<string>();
     this.activeRenderEffectModuleIds = new Set<string>();
-    this.boostPadOverlayEnabled = true;
     this.removeRenderHook = null;
   }
 
@@ -217,30 +209,16 @@ export class ActiveModulesRuntime {
   }
 
   clearStandalonePlugins(): void {
-    for (const removePlugin of this.standalonePluginRemovers.values()) {
-      removePlugin();
-    }
-    this.standalonePluginRemovers.clear();
+    // Boost pad rendering is baseline player scene content now; no standalone
+    // render plugins are managed by the stats module runtime.
   }
 
   syncBoostPadOverlayPlugin(): void {
-    this.standalonePluginRemovers.get("boost-pad-overlay")?.();
-    this.standalonePluginRemovers.delete("boost-pad-overlay");
-
-    const replayPlayer = this.options.getReplayPlayer();
-    if (!replayPlayer || !this.boostPadOverlayEnabled) {
-      return;
-    }
-
-    this.standalonePluginRemovers.set(
-      "boost-pad-overlay",
-      replayPlayer.addPlugin(fromReplayPlayerPlugin(createBoostPadOverlayPlugin())),
-    );
+    // Kept as a compatibility no-op for existing wiring.
   }
 
   toggleBoostPadOverlay(): void {
-    this.boostPadOverlayEnabled = !this.boostPadOverlayEnabled;
-    this.syncBoostPadOverlayPlugin();
+    // Boost pad locations are always rendered by the player.
     this.options.renderModuleSummary();
     this.options.requestConfigSync();
   }

--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -290,10 +290,6 @@ function syncBoostPadOverlayPlugin(): void {
   activeModulesRuntime.syncBoostPadOverlayPlugin();
 }
 
-function toggleBoostPadOverlay(): void {
-  activeModulesRuntime.toggleBoostPadOverlay();
-}
-
 function syncTimelineEvents(): void {
   activeModulesRuntime.syncTimelineEvents();
 }
@@ -785,7 +781,6 @@ export function mountStatEvaluationPlayer(
     getActiveCapabilityIds,
     getBoostPickupAnimationEnabled: () =>
       replayPlayer?.getState().boostPickupAnimationEnabled ?? false,
-    getBoostPadOverlayEnabled: () => activeModulesRuntime.getBoostPadOverlayEnabled(),
     toggleCapability,
     toggleBoostPickupAnimation() {
       const next = !(replayPlayer?.getState().boostPickupAnimationEnabled ?? false);
@@ -795,7 +790,6 @@ export function mountStatEvaluationPlayer(
       renderModuleSettings();
       scheduleConfigUrlUpdate();
     },
-    toggleBoostPadOverlay,
     syncTimelineEvents,
     syncTimelineRanges,
     renderTimelineEventCount,

--- a/js/stat-evaluation-player/src/moduleControls.ts
+++ b/js/stat-evaluation-player/src/moduleControls.ts
@@ -36,10 +36,8 @@ export interface ModuleControlsOptions {
   getActiveModules(): readonly StatModule[];
   getActiveCapabilityIds(kind: ModuleCapabilityKind): ReadonlySet<string>;
   getBoostPickupAnimationEnabled(): boolean;
-  getBoostPadOverlayEnabled(): boolean;
   toggleCapability(id: string, kind: ModuleCapabilityKind, enabled: boolean): void;
   toggleBoostPickupAnimation(): void;
-  toggleBoostPadOverlay(): void;
   syncTimelineEvents(): void;
   syncTimelineRanges(): void;
   renderTimelineEventCount(): void;
@@ -88,7 +86,6 @@ export class ModuleControlsController {
     }
 
     inGameVisualizationToggles.push(this.renderBoostPickupAnimationToggle());
-    inGameVisualizationToggles.push(this.renderBoostPadOverlayToggle());
 
     summary.append(
       renderModuleSummaryGroup("Timeline markers", markerToggles),
@@ -132,25 +129,6 @@ export class ModuleControlsController {
 
     const name = document.createElement("span");
     name.textContent = "Boost pickup animation";
-
-    const state = document.createElement("strong");
-    state.textContent = active ? "On" : "Off";
-
-    item.append(name, state);
-    return item;
-  }
-
-  private renderBoostPadOverlayToggle(): HTMLButtonElement {
-    const active = this.options.getBoostPadOverlayEnabled();
-    const item = document.createElement("button");
-    item.type = "button";
-    item.className = "module-summary-item";
-    item.dataset.active = active ? "true" : "false";
-    item.setAttribute("aria-pressed", active ? "true" : "false");
-    item.addEventListener("click", this.options.toggleBoostPadOverlay);
-
-    const name = document.createElement("span");
-    name.textContent = "Boost pad locations";
 
     const state = document.createElement("strong");
     state.textContent = active ? "On" : "Off";


### PR DESCRIPTION
## Summary
- make boost pad rendering baseline player scene content instead of a stat-evaluation toggle
- rebuild big boost pads with a three-prong base, denser golden translucent lens, stronger rim highlight, and thinner vertical halo
- keep the standard ReplayPlayer and ViewerPlayer boost pad render paths visually aligned

## Validation
- `just check`
- `just check-types`

## Notes
- Stat evaluation player uses `ViewerPlayer`, which now installs the boost pad plugin by default, so it gets this boost style automatically.