### PR TITLE
fix(stats): tighten one-timer definition (exclude backboard passes, require on-net)

### DIFF
--- a/src/stats/calculators/one_timer.rs
+++ b/src/stats/calculators/one_timer.rs
@@ -3,6 +3,12 @@ use super::*;
 const ONE_TIMER_MIN_BALL_SPEED: f32 = 1000.0;
 const ONE_TIMER_MIN_GOAL_ALIGNMENT_COSINE: f32 = 0.65;
 const GOAL_CENTER_Y: f32 = 5120.0;
+const GOAL_MOUTH_HEIGHT_Z: f32 = 642.775;
+const GOAL_MOUTH_TRAJECTORY_MARGIN: f32 = BALL_RADIUS_Z * 1.5;
+/// The post-touch trajectory must cross the opponent goal mouth within this many
+/// seconds for the touch to read as a one-timer (i.e. it must actually be on
+/// net, not merely aimed in the goal's general direction).
+const ONE_TIMER_MAX_TIME_TO_GOAL_SECONDS: f32 = 4.0;
 
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
@@ -47,6 +53,17 @@ impl OneTimerCalculator {
     }
 
     fn one_timer_event_for_pass(pass: &PassEvent, ball: &BallFrameState) -> Option<OneTimerEvent> {
+        // A one-timer is a direct first-touch redirect of a pass. If the ball
+        // bounced off the backboard between the passer's touch and the
+        // receiver's finish, that is a double tap / backboard play, not a
+        // one-timer, so exclude the backboard pass kinds here.
+        if matches!(
+            pass.pass_kind,
+            PassKind::Backboard | PassKind::FiftyFiftyBackboard
+        ) {
+            return None;
+        }
+
         let ball = ball.sample()?;
         let ball_position = ball.position();
         let ball_velocity = ball.velocity();
@@ -68,6 +85,10 @@ impl OneTimerCalculator {
             return None;
         }
 
+        if !Self::trajectory_on_net(ball_position, ball_velocity, target_y) {
+            return None;
+        }
+
         Some(OneTimerEvent {
             time: pass.time,
             frame: pass.frame,
@@ -84,6 +105,26 @@ impl OneTimerCalculator {
             ball_speed,
             goal_alignment,
         })
+    }
+
+    /// Whether the post-touch ball trajectory, extended in a straight line to
+    /// the opponent goal plane, actually crosses the goal mouth (the shot is "on
+    /// net"). This is stricter than the goal-direction alignment check, which
+    /// only requires the ball to be heading toward the goal's general area.
+    fn trajectory_on_net(position: glam::Vec3, velocity: glam::Vec3, target_goal_y: f32) -> bool {
+        if velocity.y.abs() <= f32::EPSILON {
+            return false;
+        }
+        let time_to_goal_line = (target_goal_y - position.y) / velocity.y;
+        if !time_to_goal_line.is_finite()
+            || !(0.0..=ONE_TIMER_MAX_TIME_TO_GOAL_SECONDS).contains(&time_to_goal_line)
+        {
+            return false;
+        }
+        let projected = position + velocity * time_to_goal_line;
+        projected.x.abs() <= BACK_WALL_GOAL_MOUTH_HALF_WIDTH_X + GOAL_MOUTH_TRAJECTORY_MARGIN
+            && projected.z >= BALL_RADIUS_Z - GOAL_MOUTH_TRAJECTORY_MARGIN
+            && projected.z <= GOAL_MOUTH_HEIGHT_Z + GOAL_MOUTH_TRAJECTORY_MARGIN
     }
 
     fn record_one_timer(&mut self, _frame: &FrameInfo, event: OneTimerEvent) {

--- a/src/stats/calculators/one_timer_tests.rs
+++ b/src/stats/calculators/one_timer_tests.rs
@@ -64,6 +64,28 @@ fn update_pass(
         .unwrap();
 }
 
+fn update_pass_with_backboard(
+    calculator: &mut PassCalculator,
+    frame: FrameInfo,
+    ball: BallFrameState,
+    touch_events: Vec<TouchEvent>,
+    backboard_bounce_state: &BackboardBounceState,
+) {
+    calculator
+        .update(
+            &frame,
+            &ball,
+            &TouchState {
+                touch_events,
+                ..TouchState::default()
+            },
+            backboard_bounce_state,
+            &FiftyFiftyState::default(),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+}
+
 fn update_one_timer(
     calculator: &mut OneTimerCalculator,
     pass_calculator: &PassCalculator,
@@ -143,6 +165,94 @@ fn rejects_slow_receiver_touch_even_after_completed_pass() {
         &pass_calculator,
         frame(20, 2.0),
         ball(800.0, glam::Vec3::new(0.0, 400.0, 0.0)),
+    );
+
+    assert!(one_timer.player_stats().get(&receiver).is_none());
+    assert!(one_timer.events().is_empty());
+}
+
+#[test]
+fn rejects_backboard_pass_double_tap() {
+    let passer = PlayerId::Steam(1);
+    let receiver = PlayerId::Steam(2);
+    let mut pass_calculator = PassCalculator::new();
+    let mut one_timer = OneTimerCalculator::new();
+
+    update_pass(
+        &mut pass_calculator,
+        frame(10, 1.0),
+        ball(0.0, glam::Vec3::ZERO),
+        vec![touch(10, 1.0, passer.clone(), true)],
+    );
+    update_one_timer(
+        &mut one_timer,
+        &pass_calculator,
+        frame(10, 1.0),
+        ball(0.0, glam::Vec3::ZERO),
+    );
+
+    // The passer knocks the ball off the backboard before the teammate finishes
+    // it: this is a double tap / backboard play, not a one-timer.
+    let backboard_bounce_state = BackboardBounceState {
+        last_bounce_event: Some(BackboardBounceEvent {
+            time: 1.5,
+            frame: 15,
+            player: passer,
+            player_position: None,
+            is_team_0: true,
+        }),
+        ..BackboardBounceState::default()
+    };
+    update_pass_with_backboard(
+        &mut pass_calculator,
+        frame(20, 2.0),
+        ball(800.0, glam::Vec3::new(0.0, 1600.0, 0.0)),
+        vec![touch(20, 2.0, receiver.clone(), true)],
+        &backboard_bounce_state,
+    );
+    update_one_timer(
+        &mut one_timer,
+        &pass_calculator,
+        frame(20, 2.0),
+        ball(800.0, glam::Vec3::new(0.0, 1600.0, 0.0)),
+    );
+
+    // The underlying pass is detected, but classified as a backboard pass...
+    assert_eq!(pass_calculator.events().len(), 1);
+    assert_eq!(pass_calculator.events()[0].pass_kind, PassKind::Backboard);
+    // ...so it must not be counted as a one-timer.
+    assert!(one_timer.player_stats().get(&receiver).is_none());
+    assert!(one_timer.events().is_empty());
+}
+
+#[test]
+fn rejects_fast_goal_aligned_touch_that_sails_wide_of_net() {
+    let passer = PlayerId::Steam(1);
+    let receiver = PlayerId::Steam(2);
+    let mut pass_calculator = PassCalculator::new();
+    let mut one_timer = OneTimerCalculator::new();
+
+    update_pass(
+        &mut pass_calculator,
+        frame(10, 1.0),
+        ball(0.0, glam::Vec3::ZERO),
+        vec![touch(10, 1.0, passer, true)],
+    );
+    // Fast and pointed at the goal's general direction (passes the alignment
+    // cosine), but the sideways component carries it well wide of the posts:
+    // off net, so it is not a one-timer.
+    let velocity = glam::Vec3::new(600.0, 1500.0, 0.0);
+    update_pass(
+        &mut pass_calculator,
+        frame(20, 2.0),
+        ball(800.0, velocity),
+        vec![touch(20, 2.0, receiver.clone(), true)],
+    );
+    update_one_timer(
+        &mut one_timer,
+        &pass_calculator,
+        frame(20, 2.0),
+        ball(800.0, velocity),
     );
 
     assert!(one_timer.player_stats().get(&receiver).is_none());


### PR DESCRIPTION
## Problem

The one-timer classifier was over-counting. Reported via a replay where goal 7 was tagged a one-timer despite being a double tap ([example](https://rocket-sense.duckdns.org/replays/019ebb65-b209-7031-98e8-26946ab43efc/stats/goals)).

Two root causes:

1. **Backboard passes counted as one-timers.** One-timer detection keys off `PassEvent`s but ignored `PassKind`. A `PassKind::Backboard` / `FiftyFiftyBackboard` pass is one where the *passer knocks the ball off the backboard* before a teammate finishes it — i.e. a double tap / backboard play, not a first-touch redirect.

2. **No on-net requirement.** The only goal-direction gate was an alignment cosine toward goal *center* (`> 0.65`), which a shot can satisfy while still sailing wide of the posts.

## Changes

In `src/stats/calculators/one_timer.rs`:

- Reject `PassKind::Backboard` and `PassKind::FiftyFiftyBackboard` up front. A one-timer now requires a `Direct` or (non-backboard) `FiftyFifty` pass.
- Add `trajectory_on_net`: project the post-touch ball trajectory to the opponent goal plane and require the crossing point to land within the goal mouth (within a positive, bounded time-to-goal). Reuses the shared `BACK_WALL_GOAL_MOUTH_HALF_WIDTH_X` constant and the same mouth-height/margin pattern already used by `touch_intention` and `double_tap` detection.

Both gates apply on top of the existing speed (≥1000) and alignment checks.

## Tests

Added in `src/stats/calculators/one_timer_tests.rs`:
- `rejects_backboard_pass_double_tap` — passer bounces the ball off the backboard before a fast, goal-aligned teammate finish; the pass is detected as `PassKind::Backboard` but no one-timer is recorded.
- `rejects_fast_goal_aligned_touch_that_sails_wide_of_net` — fast and within the alignment cosine, but the sideways component carries it wide of the posts.

All one-timer and goal-tag lib tests pass; `just check-rust` (fmt, clippy `--all-targets --all-features -D warnings`, metadata, rdme) is clean. No `ts-rs`-exported types changed.

## Note

Logic verified against the code and the reported behavior, but goal 7's actual pass/trajectory data in production was not queried directly. To take effect in rocket-sense this needs `sync-subtr-actor` + a schema bump/reprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)