### PR TITLE
refactor(stats): make analysis nodes own their emitted events

### DIFF
--- a/crates/subtr-actor-tools/src/bin/generate_event_docs.rs
+++ b/crates/subtr-actor-tools/src/bin/generate_event_docs.rs
@@ -3,9 +3,10 @@ use std::path::PathBuf;
 
 use anyhow::{Context, bail};
 use clap::Parser;
+use subtr_actor::analysis_graph::all_analysis_nodes;
 use subtr_actor::{
     ALL_GOAL_TAG_DEFINITIONS, DetectionConfidence, EmittedEvent, EventDefinition,
-    EventProducerDefinition, GoalTagDefinition, KnownIssueRef, ProducerDefinition, event_producers,
+    GoalTagDefinition, KnownIssueRef, ProducerDefinition,
 };
 
 #[derive(Debug, Parser)]
@@ -28,7 +29,15 @@ struct EventDoc {
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    let markdown = render_docs(event_producers(), ALL_GOAL_TAG_DEFINITIONS)?;
+    // Walk the actual analysis nodes so docs are sourced from the same place
+    // the runtime is: each node reports the events it emits. There is no
+    // separate name-keyed producer registry to keep in sync.
+    let nodes = all_analysis_nodes();
+    let emitted_events: Vec<EmittedEvent> = nodes
+        .iter()
+        .flat_map(|node| node.emitted_events().iter().copied())
+        .collect();
+    let markdown = render_docs(&emitted_events, ALL_GOAL_TAG_DEFINITIONS)?;
 
     match (args.output, args.check) {
         (Some(output), true) => {
@@ -58,34 +67,29 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn render_docs(
-    producers: &[EventProducerDefinition],
+    emitted_events: &[EmittedEvent],
     goal_tags: &[GoalTagDefinition],
 ) -> anyhow::Result<String> {
     let mut markdown = String::new();
     markdown.push_str("# Stat Definitions\n\n");
     markdown.push_str("Generated from static Rust metadata. Do not edit by hand.\n\n");
-    render_event_docs(&mut markdown, producers)?;
+    render_event_docs(&mut markdown, emitted_events)?;
     render_goal_tag_docs(&mut markdown, goal_tags);
     Ok(markdown)
 }
 
-fn render_event_docs(
-    markdown: &mut String,
-    producers: &[EventProducerDefinition],
-) -> anyhow::Result<()> {
+fn render_event_docs(markdown: &mut String, emitted_events: &[EmittedEvent]) -> anyhow::Result<()> {
     let mut events = BTreeMap::<&'static str, EventDoc>::new();
 
-    for producer in producers {
-        for emitted in producer.emitted_events {
-            let entry = events.entry(emitted.event.id).or_insert_with(|| EventDoc {
-                definition: emitted.event,
-                producers: Vec::new(),
-            });
-            if entry.definition != emitted.event {
-                bail!("conflicting event definitions for {}", emitted.event.id);
-            }
-            entry.producers.push(emitted.producer);
+    for emitted in emitted_events {
+        let entry = events.entry(emitted.event.id).or_insert_with(|| EventDoc {
+            definition: emitted.event,
+            producers: Vec::new(),
+        });
+        if entry.definition != emitted.event {
+            bail!("conflicting event definitions for {}", emitted.event.id);
         }
+        entry.producers.push(emitted.producer);
     }
 
     markdown.push_str("## Events\n\n");

--- a/src/stats/analysis_graph/graph.rs
+++ b/src/stats/analysis_graph/graph.rs
@@ -1,7 +1,7 @@
 use std::any::{Any, TypeId, type_name};
 use std::collections::{HashMap, HashSet};
 
-use crate::stats::calculators::{EmittedEvent, event_producers};
+use crate::stats::calculators::EmittedEvent;
 use crate::*;
 
 #[derive(Clone, Copy)]
@@ -130,6 +130,16 @@ pub trait AnalysisNode: 'static {
 
     fn name(&self) -> &'static str;
 
+    /// Static catalog of the events this node emits, if any.
+    ///
+    /// The node is the source of truth for what it produces: a graph's emitted
+    /// events come from walking its actual nodes (see
+    /// [`AnalysisGraph::emitted_events`]), so there is no name-keyed side
+    /// registry that can drift out of sync with the nodes themselves.
+    fn emitted_events(&self) -> &'static [EmittedEvent] {
+        &[]
+    }
+
     fn on_replay_meta(&mut self, _meta: &ReplayMeta) -> SubtrActorResult<()> {
         Ok(())
     }
@@ -149,6 +159,8 @@ pub trait AnalysisNode: 'static {
 
 pub trait AnalysisNodeDyn: 'static {
     fn name(&self) -> &'static str;
+
+    fn emitted_events(&self) -> &'static [EmittedEvent];
 
     fn provides_state_type_id(&self) -> TypeId;
 
@@ -171,6 +183,10 @@ where
 {
     fn name(&self) -> &'static str {
         AnalysisNode::name(self)
+    }
+
+    fn emitted_events(&self) -> &'static [EmittedEvent] {
+        AnalysisNode::emitted_events(self)
     }
 
     fn provides_state_type_id(&self) -> TypeId {
@@ -474,21 +490,11 @@ impl AnalysisGraph {
 
     pub fn emitted_events(&mut self) -> SubtrActorResult<Vec<EmittedEvent>> {
         self.resolve()?;
-        let node_names = self
+        Ok(self
             .nodes
             .iter()
-            .map(|node| node.name())
-            .collect::<HashSet<_>>();
-        Ok(self
-            .event_producers()
-            .iter()
-            .filter(|producer| node_names.contains(producer.node_name))
-            .flat_map(|producer| producer.emitted_events.iter().copied())
+            .flat_map(|node| node.emitted_events().iter().copied())
             .collect())
-    }
-
-    fn event_producers(&self) -> &'static [crate::stats::calculators::EventProducerDefinition] {
-        event_producers()
     }
 
     fn provider_index_by_type(&self) -> SubtrActorResult<HashMap<TypeId, usize>> {

--- a/src/stats/analysis_graph/module_tests.rs
+++ b/src/stats/analysis_graph/module_tests.rs
@@ -28,6 +28,28 @@ fn parse_replay(path: &str) -> boxcars::Replay {
         .unwrap_or_else(|_| panic!("Failed to parse replay: {}", replay_path.display()))
 }
 
+/// Every event a node emits must have a corresponding registered
+/// [`EventDefinition`]. Sourced by walking the actual analysis nodes — the
+/// nodes are the authoritative producers of their events, so this can't drift
+/// the way a separate name-keyed producer registry could.
+#[test]
+fn every_emitted_event_has_a_registered_definition() {
+    let registered: HashSet<&str> = crate::all_event_definitions()
+        .iter()
+        .map(|definition| definition.id)
+        .collect();
+    for node in all_analysis_nodes() {
+        for emitted in node.emitted_events() {
+            assert!(
+                registered.contains(emitted.event.id),
+                "event {:?} is emitted by node {:?} but is missing from the definition registry",
+                emitted.event.id,
+                node.name(),
+            );
+        }
+    }
+}
+
 fn canonical_builtin_analysis_node_name_set() -> HashSet<&'static str> {
     builtin_analysis_node_names()
         .iter()

--- a/src/stats/analysis_graph/node_macros.rs
+++ b/src/stats/analysis_graph/node_macros.rs
@@ -3,6 +3,7 @@ macro_rules! impl_analysis_node {
         node = $node:ident,
         state = $state:ty,
         name = $name:literal,
+        $(emitted_events = $emitted:expr_2021,)?
         dependencies = [$($dependency:expr_2021 => $dependency_ty:ty),* $(,)?],
         $(on_replay_meta = |$meta_self:ident, $meta:ident| $on_replay_meta:block,)?
         call = $field:ident.$method:ident
@@ -21,6 +22,14 @@ macro_rules! impl_analysis_node {
             fn name(&self) -> &'static str {
                 $name
             }
+
+            $(
+                fn emitted_events(
+                    &self,
+                ) -> &'static [$crate::stats::calculators::EmittedEvent] {
+                    $emitted
+                }
+            )?
 
             fn dependencies(&self) -> Vec<AnalysisDependency> {
                 vec![$($dependency),*]
@@ -61,6 +70,7 @@ macro_rules! impl_analysis_node {
         node = $node:ident,
         state = $state:ty,
         name = $name:literal,
+        $(emitted_events = $emitted:expr_2021,)?
         dependencies = [$($dependency:expr_2021 => $dependency_ty:ty),* $(,)?],
         $(on_replay_meta = |$meta_self:ident, $meta:ident| $on_replay_meta:block,)?
         update_state = $field:ident.$method:ident
@@ -79,6 +89,14 @@ macro_rules! impl_analysis_node {
             fn name(&self) -> &'static str {
                 $name
             }
+
+            $(
+                fn emitted_events(
+                    &self,
+                ) -> &'static [$crate::stats::calculators::EmittedEvent] {
+                    $emitted
+                }
+            )?
 
             fn dependencies(&self) -> Vec<AnalysisDependency> {
                 vec![$($dependency),*]
@@ -120,6 +138,7 @@ macro_rules! impl_analysis_node {
         node = $node:ident,
         state = $state:ty,
         name = $name:literal,
+        $(emitted_events = $emitted:expr_2021,)?
         dependencies = [$($dependency:expr_2021),* $(,)?],
         inputs = {$($binding:ident : $binding_ty:ty),* $(,)?},
         $(on_replay_meta = |$meta_self:ident, $meta:ident| $on_replay_meta:block,)?
@@ -139,6 +158,14 @@ macro_rules! impl_analysis_node {
             fn name(&self) -> &'static str {
                 $name
             }
+
+            $(
+                fn emitted_events(
+                    &self,
+                ) -> &'static [$crate::stats::calculators::EmittedEvent] {
+                    $emitted
+                }
+            )?
 
             fn dependencies(&self) -> Vec<AnalysisDependency> {
                 vec![$($dependency),*]

--- a/src/stats/analysis_graph/nodes/backboard_bounce.rs
+++ b/src/stats/analysis_graph/nodes/backboard_bounce.rs
@@ -20,6 +20,7 @@ impl_analysis_node! {
     node = BackboardBounceStateNode,
     state = BackboardBounceState,
     name = "backboard_bounce_state",
+    emitted_events = crate::stats::calculators::BACKBOARD_BOUNCE_STATE_EMITTED_EVENTS,
     dependencies = [
         frame_info_dependency() => FrameInfo,
         ball_frame_state_dependency() => BallFrameState,

--- a/src/stats/analysis_graph/nodes/ball_carry.rs
+++ b/src/stats/analysis_graph/nodes/ball_carry.rs
@@ -35,6 +35,10 @@ impl AnalysisNode for BallCarryNode {
         "ball_carry"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::BALL_CARRY_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> Vec<AnalysisDependency> {
         vec![continuous_ball_control_dependency()]
     }

--- a/src/stats/analysis_graph/nodes/ball_half.rs
+++ b/src/stats/analysis_graph/nodes/ball_half.rs
@@ -31,6 +31,10 @@ impl AnalysisNode for BallHalfNode {
         "ball_half"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::BALL_HALF_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/boost.rs
+++ b/src/stats/analysis_graph/nodes/boost.rs
@@ -22,6 +22,7 @@ impl_analysis_node! {
     node = BoostNode,
     state = BoostCalculator,
     name = "boost",
+    emitted_events = crate::stats::calculators::BOOST_EMITTED_EVENTS,
     dependencies = [
         frame_info_dependency(),
         gameplay_state_dependency(),

--- a/src/stats/analysis_graph/nodes/bump.rs
+++ b/src/stats/analysis_graph/nodes/bump.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for BumpNode {
         "bump"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::BUMP_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/ceiling_shot.rs
+++ b/src/stats/analysis_graph/nodes/ceiling_shot.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for CeilingShotNode {
         "ceiling_shot"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::CEILING_SHOT_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/center.rs
+++ b/src/stats/analysis_graph/nodes/center.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for CenterNode {
         "center"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::CENTER_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/controlled_play.rs
+++ b/src/stats/analysis_graph/nodes/controlled_play.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for ControlledPlayNode {
         "controlled_play"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::CONTROLLED_PLAY_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> Vec<AnalysisDependency> {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/demo.rs
+++ b/src/stats/analysis_graph/nodes/demo.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for DemoNode {
         "demo"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::DEMO_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/dodge_reset.rs
+++ b/src/stats/analysis_graph/nodes/dodge_reset.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for DodgeResetNode {
         "dodge_reset"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::DODGE_RESET_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/double_tap.rs
+++ b/src/stats/analysis_graph/nodes/double_tap.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for DoubleTapNode {
         "double_tap"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::DOUBLE_TAP_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/fifty_fifty.rs
+++ b/src/stats/analysis_graph/nodes/fifty_fifty.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for FiftyFiftyNode {
         "fifty_fifty"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::FIFTY_FIFTY_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![fifty_fifty_state_dependency()]
     }

--- a/src/stats/analysis_graph/nodes/flick.rs
+++ b/src/stats/analysis_graph/nodes/flick.rs
@@ -18,6 +18,7 @@ impl_analysis_node! {
     node = FlickNode,
     state = FlickCalculator,
     name = "flick",
+    emitted_events = crate::stats::calculators::FLICK_EMITTED_EVENTS,
     dependencies = [
         frame_info_dependency() => FrameInfo,
         ball_frame_state_dependency() => BallFrameState,

--- a/src/stats/analysis_graph/nodes/flip_impulse.rs
+++ b/src/stats/analysis_graph/nodes/flip_impulse.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for FlipImpulseNode {
         "dodge"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::DODGE_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/half_flip.rs
+++ b/src/stats/analysis_graph/nodes/half_flip.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for HalfFlipNode {
         "half_flip"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::HALF_FLIP_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/half_volley.rs
+++ b/src/stats/analysis_graph/nodes/half_volley.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for HalfVolleyNode {
         "half_volley"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::HALF_VOLLEY_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/match_stats.rs
+++ b/src/stats/analysis_graph/nodes/match_stats.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for MatchStatsNode {
         "match_stats"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::MATCH_STATS_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> Vec<AnalysisDependency> {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/movement.rs
+++ b/src/stats/analysis_graph/nodes/movement.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for MovementNode {
         "movement"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::MOVEMENT_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/musty_flick.rs
+++ b/src/stats/analysis_graph/nodes/musty_flick.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for MustyFlickNode {
         "musty_flick"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::MUSTY_FLICK_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/one_timer.rs
+++ b/src/stats/analysis_graph/nodes/one_timer.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for OneTimerNode {
         "one_timer"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::ONE_TIMER_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/pass.rs
+++ b/src/stats/analysis_graph/nodes/pass.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for PassNode {
         "pass"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::PASS_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/player_possession.rs
+++ b/src/stats/analysis_graph/nodes/player_possession.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for PlayerPossessionNode {
         "player_possession"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::PLAYER_POSSESSION_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/positioning.rs
+++ b/src/stats/analysis_graph/nodes/positioning.rs
@@ -31,6 +31,10 @@ impl AnalysisNode for PositioningNode {
         "positioning"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::POSITIONING_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/possession.rs
+++ b/src/stats/analysis_graph/nodes/possession.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for PossessionNode {
         "possession"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::POSSESSION_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/powerslide.rs
+++ b/src/stats/analysis_graph/nodes/powerslide.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for PowerslideNode {
         "powerslide"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::POWERSLIDE_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/rotation.rs
+++ b/src/stats/analysis_graph/nodes/rotation.rs
@@ -31,6 +31,10 @@ impl AnalysisNode for RotationNode {
         "rotation"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::ROTATION_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/rush.rs
+++ b/src/stats/analysis_graph/nodes/rush.rs
@@ -22,6 +22,7 @@ impl_analysis_node! {
     node = RushNode,
     state = RushCalculator,
     name = "rush",
+    emitted_events = crate::stats::calculators::RUSH_EMITTED_EVENTS,
     dependencies = [
         frame_info_dependency() => FrameInfo,
         gameplay_state_dependency() => GameplayState,

--- a/src/stats/analysis_graph/nodes/speed_flip.rs
+++ b/src/stats/analysis_graph/nodes/speed_flip.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for SpeedFlipNode {
         "speed_flip"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::SPEED_FLIP_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/stats_timeline_events.rs
+++ b/src/stats/analysis_graph/nodes/stats_timeline_events.rs
@@ -257,6 +257,10 @@ impl AnalysisNode for StatsTimelineEventsNode {
         "stats_timeline_events"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::STATS_TIMELINE_EVENTS_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> Vec<AnalysisDependency> {
         Self::dependencies()
     }

--- a/src/stats/analysis_graph/nodes/territorial_pressure.rs
+++ b/src/stats/analysis_graph/nodes/territorial_pressure.rs
@@ -22,6 +22,7 @@ impl_analysis_node! {
     node = TerritorialPressureNode,
     state = TerritorialPressureCalculator,
     name = "territorial_pressure",
+    emitted_events = crate::stats::calculators::TERRITORIAL_BALL_HALF_EMITTED_EVENTS,
     dependencies = [
         frame_info_dependency() => FrameInfo,
         ball_frame_state_dependency() => BallFrameState,

--- a/src/stats/analysis_graph/nodes/touch.rs
+++ b/src/stats/analysis_graph/nodes/touch.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for TouchNode {
         "touch"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::TOUCH_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/wall_aerial.rs
+++ b/src/stats/analysis_graph/nodes/wall_aerial.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for WallAerialNode {
         "wall_aerial"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::WALL_AERIAL_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/wall_aerial_shot.rs
+++ b/src/stats/analysis_graph/nodes/wall_aerial_shot.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for WallAerialShotNode {
         "wall_aerial_shot"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::WALL_AERIAL_SHOT_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/wavedash.rs
+++ b/src/stats/analysis_graph/nodes/wavedash.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for WavedashNode {
         "wavedash"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::WAVEDASH_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/analysis_graph/nodes/whiff.rs
+++ b/src/stats/analysis_graph/nodes/whiff.rs
@@ -27,6 +27,10 @@ impl AnalysisNode for WhiffNode {
         "whiff"
     }
 
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::WHIFF_EMITTED_EVENTS
+    }
+
     fn dependencies(&self) -> NodeDependencies {
         vec![
             frame_info_dependency(),

--- a/src/stats/calculators/event_definition.rs
+++ b/src/stats/calculators/event_definition.rs
@@ -241,34 +241,6 @@ pub struct EmittedEvent {
     pub producer: ProducerDefinition,
 }
 
-/// Static registration for the events emitted by one analysis node.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-pub struct EventProducerDefinition {
-    pub node_name: &'static str,
-    pub emitted_events: &'static [EmittedEvent],
-}
-
-/// Distributed static catalog of event producers.
-///
-/// Each analysis node can register its own emitted events next to the node or
-/// calculator implementation. Documentation generation should walk this slice
-/// instead of maintaining a second central catalog.
-#[cfg(not(target_arch = "wasm32"))]
-#[distributed_slice]
-pub static EVENT_PRODUCERS: [EventProducerDefinition];
-
-#[cfg(not(target_arch = "wasm32"))]
-pub fn event_producers() -> &'static [EventProducerDefinition] {
-    &EVENT_PRODUCERS
-}
-
-/// `linkme` does not support `wasm32-unknown-unknown`, so the static
-/// documentation registry is available on host/tooling builds only for now.
-#[cfg(target_arch = "wasm32")]
-pub fn event_producers() -> &'static [EventProducerDefinition] {
-    &[]
-}
-
 /// Distributed catalog of every [`EventDefinition`].
 ///
 /// `define_stats_event!` (and `register_event_definition!` for payload-less
@@ -440,17 +412,6 @@ macro_rules! define_stats_event {
         }
 
         register_stats_event_definition!($definition);
-    };
-}
-
-macro_rules! register_event_producer {
-    ($static_name:ident, $node_name:literal, $emitted_events:expr_2021) => {
-        #[cfg(not(target_arch = "wasm32"))]
-        #[distributed_slice(EVENT_PRODUCERS)]
-        static $static_name: EventProducerDefinition = EventProducerDefinition {
-            node_name: $node_name,
-            emitted_events: $emitted_events,
-        };
     };
 }
 
@@ -988,7 +949,7 @@ define_stats_event!(
 // `all_event_definitions()`. Defining an event via `define_stats_event!` (or
 // `register_stats_event_definition!`) is now the only registration step.
 
-const MATCH_STATS_EMITTED_EVENTS: &[EmittedEvent] = &[
+pub(crate) const MATCH_STATS_EMITTED_EVENTS: &[EmittedEvent] = &[
     produced_event(
         &TIMELINE_EVENT_DEFINITION,
         "match_stats",
@@ -1003,175 +964,175 @@ const MATCH_STATS_EMITTED_EVENTS: &[EmittedEvent] = &[
     ),
 ];
 
-const DEMO_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const DEMO_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &TIMELINE_EVENT_DEFINITION,
     "demo",
     "DemoNode",
     "DemoCalculator",
 )];
 
-const BACKBOARD_BOUNCE_STATE_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const BACKBOARD_BOUNCE_STATE_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &BACKBOARD_BOUNCE_EVENT_DEFINITION,
     "backboard_bounce_state",
     "BackboardBounceStateNode",
     "BackboardBounceCalculator",
 )];
 
-const CEILING_SHOT_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const CEILING_SHOT_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &CEILING_SHOT_EVENT_DEFINITION,
     "ceiling_shot",
     "CeilingShotNode",
     "CeilingShotCalculator",
 )];
 
-const WALL_AERIAL_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const WALL_AERIAL_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &WALL_AERIAL_EVENT_DEFINITION,
     "wall_aerial",
     "WallAerialNode",
     "WallAerialCalculator",
 )];
 
-const WALL_AERIAL_SHOT_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const WALL_AERIAL_SHOT_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &WALL_AERIAL_SHOT_EVENT_DEFINITION,
     "wall_aerial_shot",
     "WallAerialShotNode",
     "WallAerialShotCalculator",
 )];
 
-const CENTER_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const CENTER_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &CENTER_EVENT_DEFINITION,
     "center",
     "CenterNode",
     "CenterCalculator",
 )];
 
-const FLICK_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const FLICK_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &FLICK_EVENT_DEFINITION,
     "flick",
     "FlickNode",
     "FlickCalculator",
 )];
 
-const MUSTY_FLICK_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const MUSTY_FLICK_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &MUSTY_FLICK_EVENT_DEFINITION,
     "musty_flick",
     "MustyFlickNode",
     "MustyFlickCalculator",
 )];
 
-const DODGE_RESET_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const DODGE_RESET_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &DODGE_RESET_EVENT_DEFINITION,
     "dodge_reset",
     "DodgeResetNode",
     "DodgeResetCalculator",
 )];
 
-const DOUBLE_TAP_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const DOUBLE_TAP_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &DOUBLE_TAP_EVENT_DEFINITION,
     "double_tap",
     "DoubleTapNode",
     "DoubleTapCalculator",
 )];
 
-const ONE_TIMER_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const ONE_TIMER_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &ONE_TIMER_EVENT_DEFINITION,
     "one_timer",
     "OneTimerNode",
     "OneTimerCalculator",
 )];
 
-const PASS_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const PASS_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &PASS_EVENT_DEFINITION,
     "pass",
     "PassNode",
     "PassCalculator",
 )];
 
-const BALL_CARRY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const BALL_CARRY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &BALL_CARRY_EVENT_DEFINITION,
     "ball_carry",
     "BallCarryNode",
     "BallCarryCalculator",
 )];
 
-const CONTROLLED_PLAY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const CONTROLLED_PLAY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &CONTROLLED_PLAY_EVENT_DEFINITION,
     "controlled_play",
     "ControlledPlayNode",
     "ControlledPlayCalculator",
 )];
 
-const FIFTY_FIFTY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const FIFTY_FIFTY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &FIFTY_FIFTY_EVENT_DEFINITION,
     "fifty_fifty",
     "FiftyFiftyNode",
     "FiftyFiftyCalculator",
 )];
 
-const RUSH_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const RUSH_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &RUSH_EVENT_DEFINITION,
     "rush",
     "RushNode",
     "RushCalculator",
 )];
 
-const DODGE_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const DODGE_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &DODGE_EVENT_DEFINITION,
     "dodge",
     "FlipImpulseNode",
     "FlipImpulseCalculator",
 )];
 
-const SPEED_FLIP_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const SPEED_FLIP_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &SPEED_FLIP_EVENT_DEFINITION,
     "speed_flip",
     "SpeedFlipNode",
     "SpeedFlipCalculator",
 )];
 
-const HALF_FLIP_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const HALF_FLIP_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &HALF_FLIP_EVENT_DEFINITION,
     "half_flip",
     "HalfFlipNode",
     "HalfFlipCalculator",
 )];
 
-const HALF_VOLLEY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const HALF_VOLLEY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &HALF_VOLLEY_EVENT_DEFINITION,
     "half_volley",
     "HalfVolleyNode",
     "HalfVolleyCalculator",
 )];
 
-const WAVEDASH_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const WAVEDASH_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &WAVEDASH_EVENT_DEFINITION,
     "wavedash",
     "WavedashNode",
     "WavedashCalculator",
 )];
 
-const WHIFF_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const WHIFF_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &WHIFF_EVENT_DEFINITION,
     "whiff",
     "WhiffNode",
     "WhiffCalculator",
 )];
 
-const POWERSLIDE_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const POWERSLIDE_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &POWERSLIDE_EVENT_DEFINITION,
     "powerslide",
     "PowerslideNode",
     "PowerslideCalculator",
 )];
 
-const TOUCH_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const TOUCH_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &TOUCH_CLASSIFICATION_EVENT_DEFINITION,
     "touch",
     "TouchNode",
     "TouchCalculator",
 )];
 
-const BOOST_EMITTED_EVENTS: &[EmittedEvent] = &[
+pub(crate) const BOOST_EMITTED_EVENTS: &[EmittedEvent] = &[
     produced_event(
         &BOOST_PICKUP_EVENT_DEFINITION,
         "boost",
@@ -1186,49 +1147,49 @@ const BOOST_EMITTED_EVENTS: &[EmittedEvent] = &[
     ),
 ];
 
-const BUMP_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const BUMP_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &BUMP_EVENT_DEFINITION,
     "bump",
     "BumpNode",
     "BumpCalculator",
 )];
 
-const POSSESSION_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const POSSESSION_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &POSSESSION_EVENT_DEFINITION,
     "possession",
     "PossessionNode",
     "PossessionCalculator",
 )];
 
-const PLAYER_POSSESSION_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const PLAYER_POSSESSION_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &PLAYER_POSSESSION_EVENT_DEFINITION,
     "player_possession",
     "PlayerPossessionNode",
     "PlayerPossessionCalculator",
 )];
 
-const BALL_HALF_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const BALL_HALF_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &PRESSURE_EVENT_DEFINITION,
     "ball_half",
     "BallHalfNode",
     "BallHalfCalculator",
 )];
 
-const TERRITORIAL_BALL_HALF_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const TERRITORIAL_BALL_HALF_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &TERRITORIAL_PRESSURE_EVENT_DEFINITION,
     "territorial_pressure",
     "TerritorialPressureNode",
     "TerritorialPressureCalculator",
 )];
 
-const MOVEMENT_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const MOVEMENT_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &MOVEMENT_EVENT_DEFINITION,
     "movement",
     "MovementNode",
     "MovementCalculator",
 )];
 
-const POSITIONING_EMITTED_EVENTS: &[EmittedEvent] = &[
+pub(crate) const POSITIONING_EMITTED_EVENTS: &[EmittedEvent] = &[
     produced_event(
         &PLAYER_ACTIVITY_EVENT_DEFINITION,
         "positioning",
@@ -1267,7 +1228,7 @@ const POSITIONING_EMITTED_EVENTS: &[EmittedEvent] = &[
     ),
 ];
 
-const ROTATION_EMITTED_EVENTS: &[EmittedEvent] = &[
+pub(crate) const ROTATION_EMITTED_EVENTS: &[EmittedEvent] = &[
     produced_event(
         &ROTATION_ROLE_EVENT_DEFINITION,
         "rotation",
@@ -1282,136 +1243,12 @@ const ROTATION_EMITTED_EVENTS: &[EmittedEvent] = &[
     ),
 ];
 
-const STATS_TIMELINE_EVENTS_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+pub(crate) const STATS_TIMELINE_EVENTS_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &TIMELINE_ENVELOPE_EVENT_DEFINITION,
     "stats_timeline_events",
     "StatsTimelineEventsNode",
     "StatsTimelineEventsState",
 )];
-
-register_event_producer!(
-    MATCH_STATS_EVENT_PRODUCER,
-    "match_stats",
-    MATCH_STATS_EMITTED_EVENTS
-);
-register_event_producer!(DEMO_EVENT_PRODUCER, "demo", DEMO_EMITTED_EVENTS);
-register_event_producer!(
-    BACKBOARD_BOUNCE_STATE_EVENT_PRODUCER,
-    "backboard_bounce_state",
-    BACKBOARD_BOUNCE_STATE_EMITTED_EVENTS
-);
-register_event_producer!(
-    CEILING_SHOT_EVENT_PRODUCER,
-    "ceiling_shot",
-    CEILING_SHOT_EMITTED_EVENTS
-);
-register_event_producer!(
-    WALL_AERIAL_EVENT_PRODUCER,
-    "wall_aerial",
-    WALL_AERIAL_EMITTED_EVENTS
-);
-register_event_producer!(
-    WALL_AERIAL_SHOT_EVENT_PRODUCER,
-    "wall_aerial_shot",
-    WALL_AERIAL_SHOT_EMITTED_EVENTS
-);
-register_event_producer!(CENTER_EVENT_PRODUCER, "center", CENTER_EMITTED_EVENTS);
-register_event_producer!(FLICK_EVENT_PRODUCER, "flick", FLICK_EMITTED_EVENTS);
-register_event_producer!(
-    MUSTY_FLICK_EVENT_PRODUCER,
-    "musty_flick",
-    MUSTY_FLICK_EMITTED_EVENTS
-);
-register_event_producer!(
-    DODGE_RESET_EVENT_PRODUCER,
-    "dodge_reset",
-    DODGE_RESET_EMITTED_EVENTS
-);
-register_event_producer!(
-    DOUBLE_TAP_EVENT_PRODUCER,
-    "double_tap",
-    DOUBLE_TAP_EMITTED_EVENTS
-);
-register_event_producer!(
-    ONE_TIMER_EVENT_PRODUCER,
-    "one_timer",
-    ONE_TIMER_EMITTED_EVENTS
-);
-register_event_producer!(PASS_EVENT_PRODUCER, "pass", PASS_EMITTED_EVENTS);
-register_event_producer!(
-    BALL_CARRY_EVENT_PRODUCER,
-    "ball_carry",
-    BALL_CARRY_EMITTED_EVENTS
-);
-register_event_producer!(
-    CONTROLLED_PLAY_EVENT_PRODUCER,
-    "controlled_play",
-    CONTROLLED_PLAY_EMITTED_EVENTS
-);
-register_event_producer!(
-    FIFTY_FIFTY_EVENT_PRODUCER,
-    "fifty_fifty",
-    FIFTY_FIFTY_EMITTED_EVENTS
-);
-register_event_producer!(RUSH_EVENT_PRODUCER, "rush", RUSH_EMITTED_EVENTS);
-register_event_producer!(DODGE_EVENT_PRODUCER, "dodge", DODGE_EMITTED_EVENTS);
-register_event_producer!(
-    SPEED_FLIP_EVENT_PRODUCER,
-    "speed_flip",
-    SPEED_FLIP_EMITTED_EVENTS
-);
-register_event_producer!(
-    HALF_FLIP_EVENT_PRODUCER,
-    "half_flip",
-    HALF_FLIP_EMITTED_EVENTS
-);
-register_event_producer!(
-    HALF_VOLLEY_EVENT_PRODUCER,
-    "half_volley",
-    HALF_VOLLEY_EMITTED_EVENTS
-);
-register_event_producer!(WAVEDASH_EVENT_PRODUCER, "wavedash", WAVEDASH_EMITTED_EVENTS);
-register_event_producer!(WHIFF_EVENT_PRODUCER, "whiff", WHIFF_EMITTED_EVENTS);
-register_event_producer!(
-    POWERSLIDE_EVENT_PRODUCER,
-    "powerslide",
-    POWERSLIDE_EMITTED_EVENTS
-);
-register_event_producer!(TOUCH_EVENT_PRODUCER, "touch", TOUCH_EMITTED_EVENTS);
-register_event_producer!(BOOST_EVENT_PRODUCER, "boost", BOOST_EMITTED_EVENTS);
-register_event_producer!(BUMP_EVENT_PRODUCER, "bump", BUMP_EMITTED_EVENTS);
-register_event_producer!(
-    POSSESSION_EVENT_PRODUCER,
-    "possession",
-    POSSESSION_EMITTED_EVENTS
-);
-register_event_producer!(
-    PLAYER_POSSESSION_EVENT_PRODUCER,
-    "player_possession",
-    PLAYER_POSSESSION_EMITTED_EVENTS
-);
-register_event_producer!(
-    BALL_HALF_EVENT_PRODUCER,
-    "ball_half",
-    BALL_HALF_EMITTED_EVENTS
-);
-register_event_producer!(
-    TERRITORIAL_BALL_HALF_EVENT_PRODUCER,
-    "territorial_pressure",
-    TERRITORIAL_BALL_HALF_EMITTED_EVENTS
-);
-register_event_producer!(MOVEMENT_EVENT_PRODUCER, "movement", MOVEMENT_EMITTED_EVENTS);
-register_event_producer!(
-    POSITIONING_EVENT_PRODUCER,
-    "positioning",
-    POSITIONING_EMITTED_EVENTS
-);
-register_event_producer!(ROTATION_EVENT_PRODUCER, "rotation", ROTATION_EMITTED_EVENTS);
-register_event_producer!(
-    STATS_TIMELINE_EVENTS_EVENT_PRODUCER,
-    "stats_timeline_events",
-    STATS_TIMELINE_EVENTS_EMITTED_EVENTS
-);
 
 #[cfg(test)]
 #[path = "event_definition_tests.rs"]

--- a/src/stats/calculators/event_definition_tests.rs
+++ b/src/stats/calculators/event_definition_tests.rs
@@ -109,22 +109,6 @@ fn event_definition_ids_are_unique() {
 }
 
 #[test]
-fn every_produced_event_has_a_registered_definition() {
-    let registered: std::collections::BTreeSet<&str> =
-        all_event_definitions().iter().map(|def| def.id).collect();
-    for producer in event_producers() {
-        for emitted in producer.emitted_events {
-            assert!(
-                registered.contains(emitted.event.id),
-                "event {:?} is produced by {:?} but is missing from the definition registry",
-                emitted.event.id,
-                producer.node_name
-            );
-        }
-    }
-}
-
-#[test]
 fn expansion_parents_are_hidden_from_review() {
     // A parent that declares variants surfaces those instead of itself, so it
     // must be hidden or the raw parent key leaks into the review picker.


### PR DESCRIPTION
## Summary

`AnalysisGraph::emitted_events()` used to take the entire global `EVENT_PRODUCERS` catalog — a `linkme` distributed slice populated by 35 `register_event_producer!("flick", …)` calls — and filter it down to a graph's nodes by **string-matching `node.name()` against a hand-written `producer.node_name` literal**. The nodes themselves couldn't report what they emit, so the producer list lived in a separate registry keyed by a stringly-typed name. A typo, rename, or forgotten registration silently dropped a node's events, with no compile error and no guard.

This makes each node the source of truth: nodes report their own events via a new `emitted_events()` trait method, and the graph derives a match's emitted events by walking its actual nodes.

### Before
```rust
let node_names = self.nodes.iter().map(|n| n.name()).collect::<HashSet<_>>();
self.event_producers().iter()
    .filter(|p| node_names.contains(p.node_name))   // stringly-typed join
    .flat_map(|p| p.emitted_events.iter().copied()).collect()
```

### After
```rust
self.nodes.iter().flat_map(|n| n.emitted_events().iter().copied()).collect()
```

## Changes
- `AnalysisNode`/`AnalysisNodeDyn` gain `emitted_events()` (default `&[]`); the 35 producing nodes return their `*_EMITTED_EVENTS` const, wired via a new optional `emitted_events =` arg in `impl_analysis_node!` (5 macro nodes) or a one-line method (30 hand-written nodes).
- Deleted `EventProducerDefinition`, `EVENT_PRODUCERS`, both `event_producers()` fns, and `register_event_producer!` + its 35 invocations (`event_definition.rs` shed ~190 net lines).
- The doc generator walks `all_analysis_nodes()` instead of the static slice; **`docs/event-definitions.md` regenerates byte-identical**.
- The definition-coverage test now walks nodes (a stronger, real guarantee).

## Why it's drift-proof now
- Node→events linkage is **compile-checked** — a real const, not a string.
- An unreferenced const is dead code → fails CI's `-D warnings`.
- A node with no events inherits the `&[]` default; there's no second list to forget to update.

## Verification
- `just check-rust` green: `fmt --check`, `clippy --all-targets --all-features -D warnings`, `metadata --locked`, `cargo rdme --check`
- `docs/event-definitions.md` regenerates byte-identical (doc-gen port preserves behavior exactly)
- Tests pass: golden `builtin_event_metadata_contains_emitted_event_payloads`, new `every_emitted_event_has_a_registered_definition`, all `analysis_graph` tests
- `cargo test -p subtr-actor-bakkesmod --no-run` ✓ · `wasm32-unknown-unknown` target ✓ · no ts-rs drift (deleted types weren't `#[ts(export)]`)

Side effect: `emitted_events()` now returns real data on wasm32, where the `linkme`-backed slice was always empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
