### PR TITLE
feat(stats-player): capture "missed events" for recall labeling

### DIFF
--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -64,6 +64,7 @@ import {
 } from "./playbackReadouts.ts";
 import { installMountEventListeners } from "./mountEventListeners.ts";
 import { installFreeCameraKeyboard } from "./freeCameraKeyboard.ts";
+import { installMissedEventCapture } from "./missedEventCaptureWindow.ts";
 import { createActiveModulesRuntime } from "./activeModulesRuntime.ts";
 import { getMechanicsReviewMechanicKind, type MechanicsReviewItem } from "./mechanicsReview.ts";
 import { createMechanicsReviewReplayLoadsController } from "./mechanicsReviewReplayLoads.ts";
@@ -1002,6 +1003,14 @@ export function mountStatEvaluationPlayer(
   cameraControlsController?.installEventListeners(listeners.signal);
   // WASD flies the free camera whenever no text field has focus.
   installFreeCameraKeyboard({
+    getReplayPlayer: () => replayPlayer,
+    signal: listeners.signal,
+  });
+  // `M` captures a "missed event" (a mechanic the detector failed to emit) at
+  // the current playhead for export / upload to rocket-sense. Uploading needs
+  // the replay's rocket-sense UUID, supplied via a `?replayId=` query param;
+  // without it, capture still works for JSON export.
+  installMissedEventCapture({
     getReplayPlayer: () => replayPlayer,
     signal: listeners.signal,
   });

--- a/js/stat-evaluation-player/src/missedEventCapture.test.ts
+++ b/js/stat-evaluation-player/src/missedEventCapture.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { StatsReplayPlayer } from "./statsReplayPlayer.ts";
+import {
+  buildMissedEventReviewPayload,
+  captureMissedEventFromPlayer,
+  resolveCaptureReplayId,
+  type MissedEventCaptureRecord,
+} from "./missedEventCapture.ts";
+
+const REPLAY_UUID = "0196f449-e997-7413-af77-28082e6478f0";
+
+function record(overrides: Partial<MissedEventCaptureRecord> = {}): MissedEventCaptureRecord {
+  return {
+    localId: "missed-1",
+    mechanic: "flick",
+    frame: 1187,
+    time: 52.89,
+    subjectKind: "player",
+    subjectId: "steam:76561198298819443",
+    playerName: "strangy",
+    startFrame: null,
+    endFrame: null,
+    notes: null,
+    confidence: 1,
+    replayId: REPLAY_UUID,
+    context: {},
+    ...overrides,
+  };
+}
+
+test("resolveCaptureReplayId prefers the replayId query param", () => {
+  assert.equal(resolveCaptureReplayId(`?replayId=${REPLAY_UUID}`, "fallback"), REPLAY_UUID);
+  assert.equal(resolveCaptureReplayId(`?replay-id=${REPLAY_UUID}`), REPLAY_UUID);
+});
+
+test("resolveCaptureReplayId falls back then yields null", () => {
+  assert.equal(resolveCaptureReplayId("", "fallback-id"), "fallback-id");
+  assert.equal(resolveCaptureReplayId(""), null);
+  assert.equal(resolveCaptureReplayId("?other=1", "  "), null);
+});
+
+test("buildMissedEventReviewPayload returns null without a replay id", () => {
+  assert.equal(buildMissedEventReviewPayload(record({ replayId: null })), null);
+});
+
+test("buildMissedEventReviewPayload includes subject, span, and confirmed status", () => {
+  const payload = buildMissedEventReviewPayload(
+    record({ startFrame: 1182, endFrame: 1190, notes: " missed " }),
+  );
+  assert.ok(payload);
+  assert.equal(payload.replay_id, REPLAY_UUID);
+  assert.equal(payload.reviewed_mechanic, "flick");
+  assert.equal(payload.reviewed_event_frame, 1187);
+  assert.equal(payload.reviewed_subject_kind, "player");
+  assert.equal(payload.reviewed_subject_id, "steam:76561198298819443");
+  assert.equal(payload.reviewed_start_frame, 1182);
+  assert.equal(payload.reviewed_end_frame, 1190);
+  assert.equal(payload.reviewed_event_time, 52.89);
+  assert.equal(payload.status, "confirmed");
+  assert.equal(payload.notes, "missed");
+});
+
+test("buildMissedEventReviewPayload omits subject when there is no attached player", () => {
+  const payload = buildMissedEventReviewPayload(
+    record({ subjectKind: null, subjectId: null, playerName: null }),
+  );
+  assert.ok(payload);
+  assert.equal(payload.reviewed_subject_kind, undefined);
+  assert.equal(payload.reviewed_subject_id, undefined);
+});
+
+test("captureMissedEventFromPlayer snapshots frame, time, and attached subject", () => {
+  const player = {
+    getState: () => ({
+      frameIndex: 1187.4,
+      currentTime: 52.89,
+      attachedPlayerId: "steam:76561198298819443",
+    }),
+    replay: {
+      duration: 412.7,
+      players: [{ id: "steam:76561198298819443", name: "strangy" }],
+    },
+  } as unknown as StatsReplayPlayer;
+
+  const captured = captureMissedEventFromPlayer(player, {
+    mechanic: "flick",
+    replayId: REPLAY_UUID,
+    localId: "missed-7",
+  });
+
+  assert.equal(captured.frame, 1187);
+  assert.equal(captured.time, 52.89);
+  assert.equal(captured.subjectKind, "player");
+  assert.equal(captured.subjectId, "steam:76561198298819443");
+  assert.equal(captured.playerName, "strangy");
+  assert.equal(captured.confidence, 1);
+  assert.equal(captured.replayId, REPLAY_UUID);
+  assert.equal(captured.context.durationSeconds, 412.7);
+});
+
+test("captureMissedEventFromPlayer tolerates no attached player", () => {
+  const player = {
+    getState: () => ({ frameIndex: 10, currentTime: 1.2, attachedPlayerId: null }),
+    replay: { duration: 100, players: [] },
+  } as unknown as StatsReplayPlayer;
+
+  const captured = captureMissedEventFromPlayer(player, {
+    mechanic: "whiff",
+    replayId: null,
+    localId: "missed-8",
+  });
+
+  assert.equal(captured.subjectKind, null);
+  assert.equal(captured.subjectId, null);
+  assert.equal(captured.playerName, null);
+  assert.equal(captured.replayId, null);
+});

--- a/js/stat-evaluation-player/src/missedEventCapture.ts
+++ b/js/stat-evaluation-player/src/missedEventCapture.ts
@@ -1,0 +1,230 @@
+import type { StatsReplayPlayer } from "./statsReplayPlayer.ts";
+
+/**
+ * Capture of a mechanic a human observed during playback that the detector
+ * never emitted — a "missed event" / false negative. The capture is anchored to
+ * the engine-authoritative frame plus the wall-clock time and (optionally) the
+ * attached player as subject, so it can later be matched against detector output
+ * to measure recall.
+ *
+ * The capture is intentionally self-contained: it carries everything needed to
+ * round-trip to a JSON export OR to the rocket-sense missed-event endpoint
+ * (`POST /api/v1/events/reviews`, which accepts a review with a null detected
+ * `event_id`). See `crates/rocket-sense-server/src/api/mechanics.rs`
+ * (`create_missed_event_review`).
+ */
+export interface MissedEventCaptureRecord {
+  /** Stable client id for list management (not sent to the server). */
+  readonly localId: string;
+  /** Canonical-ish mechanic key (e.g. `flick`); rocket-sense re-normalizes it. */
+  readonly mechanic: string;
+  /** Engine frame index the mechanic occurs on. */
+  readonly frame: number;
+  /** Wall-clock playback time in seconds. */
+  readonly time: number;
+  readonly subjectKind: "player" | null;
+  readonly subjectId: string | null;
+  readonly playerName: string | null;
+  /** Optional span around the event, in frames. */
+  readonly startFrame: number | null;
+  readonly endFrame: number | null;
+  readonly notes: string | null;
+  /** Reviewer-asserted confidence (defaults to 1.0 — a confirmed positive). */
+  readonly confidence: number;
+  /** Resolved rocket-sense replay UUID, when known; null disables upload. */
+  readonly replayId: string | null;
+  /** Free-form context preserved verbatim in the export and the snapshot. */
+  readonly context: Record<string, unknown>;
+}
+
+/** Request body for `POST /api/v1/events/reviews` (missed-event review). */
+export interface MissedEventReviewPayload {
+  replay_id: string;
+  reviewed_mechanic: string;
+  reviewed_subject_kind?: string;
+  reviewed_subject_id?: string;
+  reviewed_event_frame: number;
+  reviewed_start_frame?: number;
+  reviewed_end_frame?: number;
+  reviewed_event_time?: number;
+  confidence?: number;
+  notes?: string;
+  status?: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Resolve the rocket-sense replay UUID for the current viewer session.
+ *
+ * Capture works without it (JSON export is always available), but uploading to
+ * rocket-sense needs the replay's DB id. Priority: an explicit `replayId` /
+ * `replay-id` query param (how rocket-sense should launch the viewer for
+ * capture), then a caller-supplied fallback (e.g. the active review item).
+ */
+export function resolveCaptureReplayId(search: string, fallback?: string | null): string | null {
+  const params = new URLSearchParams(search);
+  const fromQuery = params.get("replayId") ?? params.get("replay-id");
+  const candidate = (fromQuery ?? fallback ?? "").trim();
+  return candidate.length > 0 ? candidate : null;
+}
+
+/**
+ * Auth headers for review submission. Mirrors `mechanicsReviewAuthHeaders` in
+ * `mechanicsReviewWindow.ts`: a `reviewToken`/`token` query param or the
+ * `rocket_sense_access_token` localStorage value becomes a bearer token.
+ */
+export function reviewAuthHeaders(): Record<string, string> {
+  const params = new URLSearchParams(window.location.search);
+  const token =
+    params.get("reviewToken") ??
+    params.get("token") ??
+    window.localStorage.getItem("rocket_sense_access_token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/** Build the endpoint request body from a capture, omitting absent fields. */
+export function buildMissedEventReviewPayload(
+  record: MissedEventCaptureRecord,
+): MissedEventReviewPayload | null {
+  if (!record.replayId) {
+    return null;
+  }
+  const payload: MissedEventReviewPayload = {
+    replay_id: record.replayId,
+    reviewed_mechanic: record.mechanic,
+    reviewed_event_frame: record.frame,
+    reviewed_event_time: record.time,
+    confidence: record.confidence,
+    status: "confirmed",
+  };
+  if (record.subjectKind && record.subjectId) {
+    payload.reviewed_subject_kind = record.subjectKind;
+    payload.reviewed_subject_id = record.subjectId;
+  }
+  if (record.startFrame !== null) {
+    payload.reviewed_start_frame = record.startFrame;
+  }
+  if (record.endFrame !== null) {
+    payload.reviewed_end_frame = record.endFrame;
+  }
+  if (record.notes && record.notes.trim()) {
+    payload.notes = record.notes.trim();
+  }
+  if (Object.keys(record.context).length > 0) {
+    payload.context = record.context;
+  }
+  return payload;
+}
+
+export interface CaptureFromPlayerOptions {
+  readonly mechanic: string;
+  readonly replayId: string | null;
+  readonly notes?: string | null;
+  readonly localId: string;
+}
+
+/**
+ * Snapshot a missed-event capture from the live player state: current frame /
+ * time as the anchor, the attached (camera-followed) player as subject.
+ */
+export function captureMissedEventFromPlayer(
+  player: StatsReplayPlayer,
+  options: CaptureFromPlayerOptions,
+): MissedEventCaptureRecord {
+  const state = player.getState();
+  const frame = Math.max(0, Math.round(state.frameIndex ?? 0));
+  const time = state.currentTime ?? 0;
+  const subjectId = state.attachedPlayerId ?? null;
+  const playerName = subjectId
+    ? (player.replay.players.find((entry) => entry.id === subjectId)?.name ?? null)
+    : null;
+
+  return {
+    localId: options.localId,
+    mechanic: options.mechanic,
+    frame,
+    time,
+    subjectKind: subjectId ? "player" : null,
+    subjectId,
+    playerName,
+    startFrame: null,
+    endFrame: null,
+    notes: options.notes?.trim() ? options.notes.trim() : null,
+    confidence: 1,
+    replayId: options.replayId,
+    context: {
+      capturedFrom: "stat-evaluation-player",
+      attachedPlayerId: subjectId,
+      playerName,
+      durationSeconds: player.replay.duration ?? null,
+    },
+  };
+}
+
+export interface MissedEventUploadResult {
+  readonly record: MissedEventCaptureRecord;
+  readonly ok: boolean;
+  readonly message: string;
+}
+
+/**
+ * POST a single capture to the rocket-sense missed-event endpoint. Returns a
+ * structured result rather than throwing so the controller can report per-row
+ * outcomes.
+ */
+export async function uploadMissedEvent(
+  record: MissedEventCaptureRecord,
+  endpoint = "/api/v1/events/reviews",
+): Promise<MissedEventUploadResult> {
+  const payload = buildMissedEventReviewPayload(record);
+  if (!payload) {
+    return {
+      record,
+      ok: false,
+      message: "No replay id — cannot upload (export JSON instead).",
+    };
+  }
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...reviewAuthHeaders() },
+      credentials: "same-origin",
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      let message = `${response.status}${response.statusText ? ` ${response.statusText}` : ""}`;
+      try {
+        const body = (await response.json()) as { error?: unknown };
+        if (typeof body.error === "string") {
+          message = body.error;
+        }
+      } catch {
+        // Keep the HTTP status fallback.
+      }
+      return { record, ok: false, message };
+    }
+    return { record, ok: true, message: "uploaded" };
+  } catch (error) {
+    return {
+      record,
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/** Mechanic keys offered in the capture picker. rocket-sense normalizes these. */
+export const MISSED_EVENT_MECHANIC_OPTIONS = [
+  "flick",
+  "musty_flick",
+  "whiff",
+  "double_tap",
+  "ceiling_shot",
+  "wall_aerial",
+  "flip_reset",
+  "one_timer",
+  "speed_flip",
+  "half_flip",
+  "wavedash",
+  "demo",
+] as const;

--- a/js/stat-evaluation-player/src/missedEventCaptureWindow.ts
+++ b/js/stat-evaluation-player/src/missedEventCaptureWindow.ts
@@ -1,0 +1,241 @@
+import type { StatsReplayPlayer } from "./statsReplayPlayer.ts";
+import {
+  MISSED_EVENT_MECHANIC_OPTIONS,
+  captureMissedEventFromPlayer,
+  resolveCaptureReplayId,
+  uploadMissedEvent,
+  type MissedEventCaptureRecord,
+} from "./missedEventCapture.ts";
+
+export interface MissedEventCaptureOptions {
+  getReplayPlayer(): StatsReplayPlayer | null;
+  signal: AbortSignal;
+  /** Fallback replay id when no `replayId` query param is present. */
+  getReplayId?(): string | null;
+  /** Defaults to `document.body`. */
+  mountParent?: HTMLElement;
+}
+
+/** Capture-at-playhead hotkey. */
+const CAPTURE_KEY = "m";
+
+function isTextEntryFocused(): boolean {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement)) {
+    return false;
+  }
+  if (active.isContentEditable) {
+    return true;
+  }
+  const tag = active.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
+
+function downloadJson(filename: string, value: unknown): void {
+  const blob = new Blob([JSON.stringify(value, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Install the "missed event" capture affordance: an `M` hotkey that records the
+ * selected mechanic at the current playhead (attached player as subject), a
+ * compact panel listing captures, and Export-JSON / Upload-all actions. Upload
+ * targets the rocket-sense missed-event endpoint; export always works even with
+ * no replay id / backend.
+ */
+export function installMissedEventCapture(options: MissedEventCaptureOptions): {
+  capture(): void;
+  records(): readonly MissedEventCaptureRecord[];
+} {
+  const { getReplayPlayer, signal } = options;
+  const parent = options.mountParent ?? document.body;
+  const records: MissedEventCaptureRecord[] = [];
+  let localIdSeq = 0;
+
+  const panel = document.createElement("section");
+  panel.className = "missed-capture";
+  panel.hidden = true;
+  panel.innerHTML = `
+    <header class="missed-capture__head">
+      <span class="missed-capture__title">Missed events (<span data-count>0</span>)</span>
+      <button type="button" data-action="hide" title="Hide">×</button>
+    </header>
+    <div class="missed-capture__controls">
+      <label>Mechanic
+        <select data-mechanic></select>
+      </label>
+      <button type="button" data-action="capture">Capture (M)</button>
+    </div>
+    <ol class="missed-capture__list" data-list></ol>
+    <div class="missed-capture__actions">
+      <button type="button" data-action="export">Export JSON</button>
+      <button type="button" data-action="upload">Upload all</button>
+      <button type="button" data-action="clear">Clear</button>
+    </div>
+    <p class="missed-capture__status" data-status></p>
+  `;
+  parent.appendChild(panel);
+
+  const select = panel.querySelector<HTMLSelectElement>("[data-mechanic]")!;
+  for (const mechanic of MISSED_EVENT_MECHANIC_OPTIONS) {
+    const option = document.createElement("option");
+    option.value = mechanic;
+    option.textContent = mechanic.replaceAll("_", " ");
+    select.appendChild(option);
+  }
+  const listEl = panel.querySelector<HTMLOListElement>("[data-list]")!;
+  const countEl = panel.querySelector<HTMLElement>("[data-count]")!;
+  const statusEl = panel.querySelector<HTMLElement>("[data-status]")!;
+
+  const setStatus = (message: string): void => {
+    statusEl.textContent = message;
+  };
+
+  const resolveReplayId = (): string | null =>
+    resolveCaptureReplayId(window.location.search, options.getReplayId?.() ?? null);
+
+  const render = (): void => {
+    countEl.textContent = String(records.length);
+    listEl.replaceChildren();
+    for (const record of records) {
+      const item = document.createElement("li");
+      const subject = record.playerName ?? record.subjectId ?? "no subject";
+      item.innerHTML = `
+        <span class="missed-capture__row">
+          <strong>${record.mechanic}</strong>
+          @ ${record.time.toFixed(2)}s · f${record.frame} · ${subject}
+          ${record.replayId ? "" : "· <em>no replay id</em>"}
+        </span>
+      `;
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.textContent = "✕";
+      remove.title = "Remove";
+      remove.addEventListener(
+        "click",
+        () => {
+          const index = records.findIndex((entry) => entry.localId === record.localId);
+          if (index >= 0) {
+            records.splice(index, 1);
+            render();
+          }
+        },
+        { signal },
+      );
+      item.appendChild(remove);
+      listEl.appendChild(item);
+    }
+    panel.hidden = records.length === 0;
+  };
+
+  const capture = (): void => {
+    const player = getReplayPlayer();
+    if (!player) {
+      setStatus("No replay loaded.");
+      return;
+    }
+    localIdSeq += 1;
+    const record = captureMissedEventFromPlayer(player, {
+      mechanic: select.value || "flick",
+      replayId: resolveReplayId(),
+      localId: `missed-${localIdSeq}`,
+    });
+    records.push(record);
+    render();
+    setStatus(
+      `Captured ${record.mechanic} @ ${record.time.toFixed(2)}s` +
+        (record.replayId ? "." : " (no replay id — export only)."),
+    );
+  };
+
+  const uploadAll = async (): Promise<void> => {
+    if (records.length === 0) {
+      setStatus("Nothing to upload.");
+      return;
+    }
+    let uploaded = 0;
+    const failures: string[] = [];
+    for (const record of [...records]) {
+      const result = await uploadMissedEvent(record);
+      if (result.ok) {
+        uploaded += 1;
+        const index = records.findIndex((entry) => entry.localId === record.localId);
+        if (index >= 0) {
+          records.splice(index, 1);
+        }
+      } else {
+        failures.push(`${record.mechanic}@${record.time.toFixed(1)}s: ${result.message}`);
+      }
+    }
+    render();
+    setStatus(
+      failures.length === 0
+        ? `Uploaded ${uploaded}.`
+        : `Uploaded ${uploaded}, ${failures.length} failed — ${failures[0]}`,
+    );
+  };
+
+  panel.querySelector("[data-action='capture']")?.addEventListener("click", capture, { signal });
+  panel.querySelector("[data-action='hide']")?.addEventListener(
+    "click",
+    () => {
+      panel.hidden = true;
+    },
+    { signal },
+  );
+  panel.querySelector("[data-action='export']")?.addEventListener(
+    "click",
+    () => {
+      if (records.length === 0) {
+        setStatus("Nothing to export.");
+        return;
+      }
+      downloadJson("missed-events.json", {
+        capturedFrom: "stat-evaluation-player",
+        replayId: resolveReplayId(),
+        missedEvents: records,
+      });
+      setStatus(`Exported ${records.length}.`);
+    },
+    { signal },
+  );
+  panel
+    .querySelector("[data-action='upload']")
+    ?.addEventListener("click", () => void uploadAll(), { signal });
+  panel.querySelector("[data-action='clear']")?.addEventListener(
+    "click",
+    () => {
+      records.length = 0;
+      render();
+      setStatus("Cleared.");
+    },
+    { signal },
+  );
+
+  window.addEventListener(
+    "keydown",
+    (event) => {
+      if (event.key.toLowerCase() !== CAPTURE_KEY || event.repeat) {
+        return;
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey || isTextEntryFocused()) {
+        return;
+      }
+      event.preventDefault();
+      capture();
+    },
+    { signal },
+  );
+
+  return {
+    capture,
+    records: () => records,
+  };
+}

--- a/js/stat-evaluation-player/src/styles.css
+++ b/js/stat-evaluation-player/src/styles.css
@@ -4,3 +4,78 @@
 @import "./styles/stats-windows.css";
 @import "./styles/controls.css";
 @import "./styles/responsive.css";
+
+/* Missed-event capture panel: a compact floating list of mechanics the
+   detector failed to emit, captured at the playhead with the `M` hotkey. */
+.missed-capture {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 40;
+  width: 18rem;
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 0.5rem;
+  background: rgba(8, 13, 16, 0.92);
+  color: #f2f6f8;
+  font-size: 0.8rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.45);
+}
+
+.missed-capture__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.missed-capture__title {
+  font-weight: 600;
+}
+
+.missed-capture__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.missed-capture__controls select {
+  flex: 1 1 auto;
+}
+
+.missed-capture__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.missed-capture__list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  padding: 0.2rem 0.3rem;
+  border-radius: 0.3rem;
+  background: rgba(28, 39, 46, 0.9);
+}
+
+.missed-capture__actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.missed-capture__actions button {
+  flex: 1 1 auto;
+}
+
+.missed-capture__status {
+  margin: 0;
+  min-height: 1rem;
+  color: #9fadb7;
+}


### PR DESCRIPTION
## What

Adds a way for a human watching a replay in the **stat-evaluation-player** to capture a *perceived missed event* — a mechanic the detector failed to emit (a false negative) — and export/upload it as a labeled positive instance for recall measurement.

Motivated by investigating false negatives/positives in mechanic detection (e.g. a flick the engine missed): we had a confirm/reject loop for *detected* events, but no way to record the ones it *didn't* detect.

## How it works

- Press **M** during playback to capture the selected mechanic at the current playhead. The capture records the engine **frame**, wall-clock **time**, and the **attached (camera-followed) player** as subject.
- Captures accumulate in a compact floating panel with:
  - **Export JSON** — always available, even with no backend / no replay id.
  - **Upload all** — POSTs each capture to the rocket-sense missed-event endpoint.

### Integration contract

Upload targets `POST /api/v1/events/reviews` (the new rocket-sense endpoint that stores a review with a **null detected `event_id`**, anchored to the replay + frames). The replay's rocket-sense UUID is read from a `?replayId=<uuid>` query param, reusing the existing `reviewToken`/`token` auth used by the mechanics-review flow. Without a replay id, capture still works for JSON export.

> The rocket-sense backend endpoint is a companion PR; until it lands, the Export-JSON path is fully functional on its own.

## Structure

- `missedEventCapture.ts` — pure, unit-tested logic: replay-id resolution, request-payload building, capture-from-player-state, upload.
- `missedEventCaptureWindow.ts` — DOM panel + `M` hotkey, installed alongside the other input handlers in `main.ts`.
- `styles.css` — compact dark-theme panel styling.

## Testing

- `missedEventCapture.test.ts` — 7 unit tests (replay-id resolution, payload shape with/without subject/span, capture snapshot). All pass.
- `tsc --noEmit` clean; eslint + prettier clean.

## Not in this PR

- Building + syncing the viewer into rocket-sense's vendored static assets (deploy step).
- Wiring these manual labels into the `missed_positive_label_count` recall evaluation query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)