### PR TITLE
refactor(stats-player): make missed-event capture a window, not an overlay

### DIFF
--- a/js/stat-evaluation-player/src/appTemplate.ts
+++ b/js/stat-evaluation-player/src/appTemplate.ts
@@ -33,6 +33,7 @@ export function getAppTemplate(): string {
               <button type="button" data-window-toggle="boost-pickups">Boost pickup filters</button>
               <button type="button" data-window-toggle="touch-controls">Touch controls</button>
               <button type="button" data-window-toggle="shot-visualization">Shot chart</button>
+              <button type="button" data-window-toggle="missed-events">Missed events</button>
               <button type="button" data-create-stats-window="player">New player stats</button>
               <button type="button" data-create-stats-window="team">New team stats</button>
               <button type="button" data-create-stats-window="all-players">New all players stats</button>
@@ -365,6 +366,40 @@ export function getAppTemplate(): string {
                 <dt>Type</dt>
                 <dd id="recording-type">WebM</dd>
               </div>
+            </div>
+          </section>
+
+          <section
+            class="floating-window floating-window-missed-events"
+            data-window-id="missed-events"
+            hidden
+            style="--window-x: calc(100vw - 28rem); --window-y: 28rem;"
+          >
+            <header class="floating-window-header">
+              <div>
+                <h2>Missed events</h2>
+              </div>
+              <button class="floating-window-hide" type="button" data-window-hide="missed-events">
+                Hide
+              </button>
+            </header>
+            <div class="missed-event-body">
+              <div class="missed-event-controls">
+                <label>
+                  <span class="label">Mechanic</span>
+                  <select id="missed-event-mechanic"></select>
+                </label>
+                <button id="missed-event-capture" type="button">Capture (M)</button>
+              </div>
+              <ol id="missed-event-list" class="missed-event-list"></ol>
+              <div class="transport-row">
+                <button id="missed-event-export" type="button">Export JSON</button>
+                <button id="missed-event-upload" type="button">Upload all</button>
+                <button id="missed-event-clear" type="button">Clear</button>
+              </div>
+              <p id="missed-event-status" class="missed-event-status">
+                Press M to capture a missed event at the playhead.
+              </p>
             </div>
           </section>
 

--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -64,7 +64,10 @@ import {
 } from "./playbackReadouts.ts";
 import { installMountEventListeners } from "./mountEventListeners.ts";
 import { installFreeCameraKeyboard } from "./freeCameraKeyboard.ts";
-import { installMissedEventCapture } from "./missedEventCaptureWindow.ts";
+import {
+  createMissedEventCaptureController,
+  type MissedEventCaptureController,
+} from "./missedEventCaptureWindow.ts";
 import { createActiveModulesRuntime } from "./activeModulesRuntime.ts";
 import { getMechanicsReviewMechanicKind, type MechanicsReviewItem } from "./mechanicsReview.ts";
 import { createMechanicsReviewReplayLoadsController } from "./mechanicsReviewReplayLoads.ts";
@@ -226,6 +229,7 @@ let currentMountCleanup: (() => void) | null = null;
 let statRegistry: StatDefinition[] = createStatRegistry(null);
 let cameraControlsController: CameraControlsController | null = null;
 let recordingWindowController: RecordingWindowController | null = null;
+let missedEventCaptureController: MissedEventCaptureController | null = null;
 let statsWindowsController: StatsWindowsController | null = null;
 let eventPlaylistController: EventPlaylistWindowController | null = null;
 let eventTimelineControlsController: EventTimelineControlsController | null = null;
@@ -844,6 +848,19 @@ export function mountStatEvaluationPlayer(
     },
     requestConfigSync: scheduleConfigUrlUpdate,
   });
+  missedEventCaptureController = createMissedEventCaptureController({
+    elements: {
+      mechanic: mustElement<HTMLSelectElement>(root, "#missed-event-mechanic"),
+      capture: mustElement<HTMLButtonElement>(root, "#missed-event-capture"),
+      list: mustElement<HTMLOListElement>(root, "#missed-event-list"),
+      export: mustElement<HTMLButtonElement>(root, "#missed-event-export"),
+      upload: mustElement<HTMLButtonElement>(root, "#missed-event-upload"),
+      clear: mustElement<HTMLButtonElement>(root, "#missed-event-clear"),
+      status: mustElement<HTMLElement>(root, "#missed-event-status"),
+    },
+    getReplayPlayer: () => replayPlayer,
+    showWindow: () => windowCommands.showWindow("missed-events"),
+  });
   configBindings = createPlayerConfigBindings({
     modules: MODULES,
     playbackRate,
@@ -1000,21 +1017,13 @@ export function mountStatEvaluationPlayer(
 
   mechanicsReviewController?.installEventListeners(listeners.signal);
   recordingWindowController?.installEventListeners(listeners.signal);
+  missedEventCaptureController?.installEventListeners(listeners.signal);
   cameraControlsController?.installEventListeners(listeners.signal);
   // WASD flies the free camera whenever no text field has focus.
   installFreeCameraKeyboard({
     getReplayPlayer: () => replayPlayer,
     signal: listeners.signal,
   });
-  // `M` captures a "missed event" (a mechanic the detector failed to emit) at
-  // the current playhead for export / upload to rocket-sense. Uploading needs
-  // the replay's rocket-sense UUID, supplied via a `?replayId=` query param;
-  // without it, capture still works for JSON export.
-  installMissedEventCapture({
-    getReplayPlayer: () => replayPlayer,
-    signal: listeners.signal,
-  });
-
   // Allow an embedding parent window (e.g. the Rocket Sense stats UI) to drive
   // the active review clip without reloading the replay, so hovering a goal can
   // scrub the player to that goal's clip. Messages are only honored from the

--- a/js/stat-evaluation-player/src/missedEventCaptureWindow.ts
+++ b/js/stat-evaluation-player/src/missedEventCaptureWindow.ts
@@ -7,13 +7,23 @@ import {
   type MissedEventCaptureRecord,
 } from "./missedEventCapture.ts";
 
+export interface MissedEventCaptureElements {
+  readonly mechanic: HTMLSelectElement;
+  readonly capture: HTMLButtonElement;
+  readonly list: HTMLOListElement;
+  readonly export: HTMLButtonElement;
+  readonly upload: HTMLButtonElement;
+  readonly clear: HTMLButtonElement;
+  readonly status: HTMLElement;
+}
+
 export interface MissedEventCaptureOptions {
+  readonly elements: MissedEventCaptureElements;
   getReplayPlayer(): StatsReplayPlayer | null;
-  signal: AbortSignal;
   /** Fallback replay id when no `replayId` query param is present. */
   getReplayId?(): string | null;
-  /** Defaults to `document.body`. */
-  mountParent?: HTMLElement;
+  /** Reveal the missed-events window (e.g. when capturing via the hotkey). */
+  showWindow(): void;
 }
 
 /** Capture-at-playhead hotkey. */
@@ -44,198 +54,161 @@ function downloadJson(filename: string, value: unknown): void {
 }
 
 /**
- * Install the "missed event" capture affordance: an `M` hotkey that records the
- * selected mechanic at the current playhead (attached player as subject), a
- * compact panel listing captures, and Export-JSON / Upload-all actions. Upload
- * targets the rocket-sense missed-event endpoint; export always works even with
- * no replay id / backend.
+ * Drives the "Missed events" window: an `M` hotkey records the selected mechanic
+ * at the current playhead (attached player as subject), the window lists the
+ * captures, and Export-JSON / Upload-all act on them. Upload targets the
+ * rocket-sense missed-event endpoint; export always works even with no replay id
+ * / backend. The window itself (chrome, drag, show/hide) is owned by the shared
+ * floating-window system; this controller only owns its body content.
  */
-export function installMissedEventCapture(options: MissedEventCaptureOptions): {
-  capture(): void;
-  records(): readonly MissedEventCaptureRecord[];
-} {
-  const { getReplayPlayer, signal } = options;
-  const parent = options.mountParent ?? document.body;
-  const records: MissedEventCaptureRecord[] = [];
-  let localIdSeq = 0;
+export class MissedEventCaptureController {
+  private readonly records: MissedEventCaptureRecord[] = [];
+  private localIdSeq = 0;
 
-  const panel = document.createElement("section");
-  panel.className = "missed-capture";
-  panel.hidden = true;
-  panel.innerHTML = `
-    <header class="missed-capture__head">
-      <span class="missed-capture__title">Missed events (<span data-count>0</span>)</span>
-      <button type="button" data-action="hide" title="Hide">×</button>
-    </header>
-    <div class="missed-capture__controls">
-      <label>Mechanic
-        <select data-mechanic></select>
-      </label>
-      <button type="button" data-action="capture">Capture (M)</button>
-    </div>
-    <ol class="missed-capture__list" data-list></ol>
-    <div class="missed-capture__actions">
-      <button type="button" data-action="export">Export JSON</button>
-      <button type="button" data-action="upload">Upload all</button>
-      <button type="button" data-action="clear">Clear</button>
-    </div>
-    <p class="missed-capture__status" data-status></p>
-  `;
-  parent.appendChild(panel);
+  constructor(private readonly options: MissedEventCaptureOptions) {}
 
-  const select = panel.querySelector<HTMLSelectElement>("[data-mechanic]")!;
-  for (const mechanic of MISSED_EVENT_MECHANIC_OPTIONS) {
-    const option = document.createElement("option");
-    option.value = mechanic;
-    option.textContent = mechanic.replaceAll("_", " ");
-    select.appendChild(option);
-  }
-  const listEl = panel.querySelector<HTMLOListElement>("[data-list]")!;
-  const countEl = panel.querySelector<HTMLElement>("[data-count]")!;
-  const statusEl = panel.querySelector<HTMLElement>("[data-status]")!;
+  installEventListeners(signal: AbortSignal): void {
+    const { elements } = this.options;
 
-  const setStatus = (message: string): void => {
-    statusEl.textContent = message;
-  };
-
-  const resolveReplayId = (): string | null =>
-    resolveCaptureReplayId(window.location.search, options.getReplayId?.() ?? null);
-
-  const render = (): void => {
-    countEl.textContent = String(records.length);
-    listEl.replaceChildren();
-    for (const record of records) {
-      const item = document.createElement("li");
-      const subject = record.playerName ?? record.subjectId ?? "no subject";
-      item.innerHTML = `
-        <span class="missed-capture__row">
-          <strong>${record.mechanic}</strong>
-          @ ${record.time.toFixed(2)}s · f${record.frame} · ${subject}
-          ${record.replayId ? "" : "· <em>no replay id</em>"}
-        </span>
-      `;
-      const remove = document.createElement("button");
-      remove.type = "button";
-      remove.textContent = "✕";
-      remove.title = "Remove";
-      remove.addEventListener(
-        "click",
-        () => {
-          const index = records.findIndex((entry) => entry.localId === record.localId);
-          if (index >= 0) {
-            records.splice(index, 1);
-            render();
-          }
-        },
-        { signal },
-      );
-      item.appendChild(remove);
-      listEl.appendChild(item);
+    for (const mechanic of MISSED_EVENT_MECHANIC_OPTIONS) {
+      const option = document.createElement("option");
+      option.value = mechanic;
+      option.textContent = mechanic.replaceAll("_", " ");
+      elements.mechanic.appendChild(option);
     }
-    panel.hidden = records.length === 0;
-  };
 
-  const capture = (): void => {
-    const player = getReplayPlayer();
+    elements.capture.addEventListener("click", () => this.capture(), { signal });
+    elements.export.addEventListener("click", () => this.exportJson(), { signal });
+    elements.upload.addEventListener("click", () => void this.uploadAll(), { signal });
+    elements.clear.addEventListener(
+      "click",
+      () => {
+        this.records.length = 0;
+        this.render();
+        this.setStatus("Cleared.");
+      },
+      { signal },
+    );
+
+    window.addEventListener(
+      "keydown",
+      (event) => {
+        if (event.key.toLowerCase() !== CAPTURE_KEY || event.repeat) {
+          return;
+        }
+        if (event.metaKey || event.ctrlKey || event.altKey || isTextEntryFocused()) {
+          return;
+        }
+        event.preventDefault();
+        this.capture();
+      },
+      { signal },
+    );
+
+    this.render();
+  }
+
+  capture(): void {
+    const player = this.options.getReplayPlayer();
     if (!player) {
-      setStatus("No replay loaded.");
+      this.setStatus("No replay loaded.");
       return;
     }
-    localIdSeq += 1;
+    this.localIdSeq += 1;
     const record = captureMissedEventFromPlayer(player, {
-      mechanic: select.value || "flick",
-      replayId: resolveReplayId(),
-      localId: `missed-${localIdSeq}`,
+      mechanic: this.options.elements.mechanic.value || "flick",
+      replayId: this.resolveReplayId(),
+      localId: `missed-${this.localIdSeq}`,
     });
-    records.push(record);
-    render();
-    setStatus(
+    this.records.push(record);
+    this.options.showWindow();
+    this.render();
+    this.setStatus(
       `Captured ${record.mechanic} @ ${record.time.toFixed(2)}s` +
         (record.replayId ? "." : " (no replay id — export only)."),
     );
-  };
+  }
 
-  const uploadAll = async (): Promise<void> => {
-    if (records.length === 0) {
-      setStatus("Nothing to upload.");
+  private exportJson(): void {
+    if (this.records.length === 0) {
+      this.setStatus("Nothing to export.");
+      return;
+    }
+    downloadJson("missed-events.json", {
+      capturedFrom: "stat-evaluation-player",
+      replayId: this.resolveReplayId(),
+      missedEvents: this.records,
+    });
+    this.setStatus(`Exported ${this.records.length}.`);
+  }
+
+  private async uploadAll(): Promise<void> {
+    if (this.records.length === 0) {
+      this.setStatus("Nothing to upload.");
       return;
     }
     let uploaded = 0;
     const failures: string[] = [];
-    for (const record of [...records]) {
+    for (const record of [...this.records]) {
       const result = await uploadMissedEvent(record);
       if (result.ok) {
         uploaded += 1;
-        const index = records.findIndex((entry) => entry.localId === record.localId);
+        const index = this.records.findIndex((entry) => entry.localId === record.localId);
         if (index >= 0) {
-          records.splice(index, 1);
+          this.records.splice(index, 1);
         }
       } else {
         failures.push(`${record.mechanic}@${record.time.toFixed(1)}s: ${result.message}`);
       }
     }
-    render();
-    setStatus(
+    this.render();
+    this.setStatus(
       failures.length === 0
         ? `Uploaded ${uploaded}.`
         : `Uploaded ${uploaded}, ${failures.length} failed — ${failures[0]}`,
     );
-  };
+  }
 
-  panel.querySelector("[data-action='capture']")?.addEventListener("click", capture, { signal });
-  panel.querySelector("[data-action='hide']")?.addEventListener(
-    "click",
-    () => {
-      panel.hidden = true;
-    },
-    { signal },
-  );
-  panel.querySelector("[data-action='export']")?.addEventListener(
-    "click",
-    () => {
-      if (records.length === 0) {
-        setStatus("Nothing to export.");
-        return;
-      }
-      downloadJson("missed-events.json", {
-        capturedFrom: "stat-evaluation-player",
-        replayId: resolveReplayId(),
-        missedEvents: records,
+  private render(): void {
+    const { list } = this.options.elements;
+    list.replaceChildren();
+    for (const record of this.records) {
+      const item = document.createElement("li");
+      const subject = record.playerName ?? record.subjectId ?? "no subject";
+      const detail = document.createElement("span");
+      detail.className = "missed-event-row";
+      detail.textContent =
+        `${record.mechanic} @ ${record.time.toFixed(2)}s · f${record.frame} · ${subject}` +
+        (record.replayId ? "" : " · no replay id");
+
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.textContent = "✕";
+      remove.title = "Remove";
+      remove.addEventListener("click", () => {
+        const index = this.records.findIndex((entry) => entry.localId === record.localId);
+        if (index >= 0) {
+          this.records.splice(index, 1);
+          this.render();
+        }
       });
-      setStatus(`Exported ${records.length}.`);
-    },
-    { signal },
-  );
-  panel
-    .querySelector("[data-action='upload']")
-    ?.addEventListener("click", () => void uploadAll(), { signal });
-  panel.querySelector("[data-action='clear']")?.addEventListener(
-    "click",
-    () => {
-      records.length = 0;
-      render();
-      setStatus("Cleared.");
-    },
-    { signal },
-  );
 
-  window.addEventListener(
-    "keydown",
-    (event) => {
-      if (event.key.toLowerCase() !== CAPTURE_KEY || event.repeat) {
-        return;
-      }
-      if (event.metaKey || event.ctrlKey || event.altKey || isTextEntryFocused()) {
-        return;
-      }
-      event.preventDefault();
-      capture();
-    },
-    { signal },
-  );
+      item.append(detail, remove);
+      list.appendChild(item);
+    }
+  }
 
-  return {
-    capture,
-    records: () => records,
-  };
+  private setStatus(message: string): void {
+    this.options.elements.status.textContent = message;
+  }
+
+  private resolveReplayId(): string | null {
+    return resolveCaptureReplayId(window.location.search, this.options.getReplayId?.() ?? null);
+  }
+}
+
+export function createMissedEventCaptureController(
+  options: MissedEventCaptureOptions,
+): MissedEventCaptureController {
+  return new MissedEventCaptureController(options);
 }

--- a/js/stat-evaluation-player/src/playerConfig.ts
+++ b/js/stat-evaluation-player/src/playerConfig.ts
@@ -24,7 +24,8 @@ export type SingletonWindowId =
   | "replay-loading"
   | "boost-pickups"
   | "touch-controls"
-  | "shot-visualization";
+  | "shot-visualization"
+  | "missed-events";
 export type ConfigWindowKind = SingletonWindowId | "stats";
 
 export interface ConfigViewportSize {
@@ -449,7 +450,8 @@ function isSingletonWindowId(value: unknown): value is SingletonWindowId {
     value === "mechanics-review" ||
     value === "replay-loading" ||
     value === "boost-pickups" ||
-    value === "touch-controls"
+    value === "touch-controls" ||
+    value === "missed-events"
   );
 }
 

--- a/js/stat-evaluation-player/src/styles.css
+++ b/js/stat-evaluation-player/src/styles.css
@@ -5,47 +5,28 @@
 @import "./styles/controls.css";
 @import "./styles/responsive.css";
 
-/* Missed-event capture panel: a compact floating list of mechanics the
-   detector failed to emit, captured at the playhead with the `M` hotkey. */
-.missed-capture {
-  position: fixed;
-  right: 1rem;
-  bottom: 1rem;
-  z-index: 40;
-  width: 18rem;
-  max-height: 60vh;
+/* Body of the "Missed events" floating window — the window chrome (frame,
+   header, drag, show/hide) comes from the shared floating-window styles. */
+.missed-event-body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   padding: 0.6rem 0.7rem;
-  border-radius: 0.5rem;
-  background: rgba(8, 13, 16, 0.92);
-  color: #f2f6f8;
+  max-height: 50vh;
   font-size: 0.8rem;
-  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.45);
 }
 
-.missed-capture__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.missed-capture__title {
-  font-weight: 600;
-}
-
-.missed-capture__controls {
+.missed-event-controls {
   display: flex;
   align-items: center;
   gap: 0.4rem;
 }
 
-.missed-capture__controls select {
+.missed-event-controls select {
   flex: 1 1 auto;
 }
 
-.missed-capture__list {
+.missed-event-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -55,7 +36,7 @@
   gap: 0.25rem;
 }
 
-.missed-capture__list li {
+.missed-event-list li {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -65,16 +46,7 @@
   background: rgba(28, 39, 46, 0.9);
 }
 
-.missed-capture__actions {
-  display: flex;
-  gap: 0.4rem;
-}
-
-.missed-capture__actions button {
-  flex: 1 1 auto;
-}
-
-.missed-capture__status {
+.missed-event-status {
   margin: 0;
   min-height: 1rem;
   color: #9fadb7;


### PR DESCRIPTION
## Why

The missed-event capture UI (from #196) shipped as a permanent `position: fixed` overlay pinned to the corner of the viewport. It should be a normal **floating window** like Recording / Events review — openable from the launcher, draggable, and hideable — rather than always-on chrome.

## What changed

- Registered a `missed-events` `SingletonWindowId` (+ launcher entry "Missed events").
- Added the window markup (`data-window-id="missed-events"` with a header, hide button, and body), so the shared window system owns the chrome (toggle / hide / drag / position persistence). The controller now owns only the body content.
- Replaced `installMissedEventCapture` (which built and appended the overlay element) with a `MissedEventCaptureController` exposing `installEventListeners(signal)`, mirroring `RecordingWindowController` et al. and wired in `main.ts` alongside the other window controllers.
- The `M` hotkey still captures at the playhead and now **reveals the window** via `windowCommands.showWindow("missed-events")`.
- Swapped the fixed-overlay CSS for window-body styles.

## Unchanged

Capture / export / upload behavior and the pure logic in `missedEventCapture.ts` are untouched — its 7 unit tests still pass.

## Checks

`tsc --noEmit`, the 7 unit tests, prettier, and eslint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)