### PR TITLE
fix(stats-flick): bridge brief control gaps + tolerate dodge-byte lag

### DIFF
--- a/src/stats/calculators/flick.rs
+++ b/src/stats/calculators/flick.rs
@@ -13,8 +13,21 @@ const BALL_GRAVITY_Z: f32 = -650.0;
 const FLICK_IMPULSE_WINDOW_SECONDS: f32 = 0.15;
 
 const FLICK_MAX_DODGE_TO_TOUCH_SECONDS: f32 = 0.32;
+/// How far *before* the dodge transition the flick contact may register. The
+/// ball can start accelerating a frame or two before the dodge-active byte
+/// flips, so the touch that the pending flick anchors to sometimes precedes the
+/// recorded dodge start. Allow a small negative `time_since_dodge` rather than
+/// rejecting these as "touch before dodge".
+const FLICK_DODGE_LEAD_TOLERANCE_SECONDS: f32 = 0.12;
 const FLICK_MAX_CONTROL_TO_DODGE_SECONDS: f32 = 0.08;
 const FLICK_MAX_SETUP_STALE_SECONDS: f32 = 0.35;
+/// How long a control setup survives without a fresh control observation before
+/// it is finished. A real carry/dribble lets the ball wobble in and out of the
+/// tight control volume (the ball briefly exceeds the gap thresholds), so
+/// finishing the setup on the first dropped frame fragments one ~0.5s carry into
+/// sub-`FLICK_MIN_SETUP_SECONDS` pieces that never qualify. Bridging brief gaps
+/// keeps the setup continuous while still ending it when the carry truly stops.
+const FLICK_SETUP_GAP_GRACE_SECONDS: f32 = 0.12;
 const FLICK_MIN_PENDING_DODGE_SETUP_SECONDS: f32 = 0.10;
 const FLICK_MIN_SETUP_SECONDS: f32 = 0.20;
 const FLICK_MIN_BALL_SPEED_CHANGE: f32 = 325.0;
@@ -552,7 +565,18 @@ impl FlickCalculator {
 
         let active_ids: Vec<_> = self.active_setups.keys().cloned().collect();
         for player_id in active_ids {
-            if !observed_players.contains(&player_id) {
+            if observed_players.contains(&player_id) {
+                continue;
+            }
+            // Keep the setup alive across brief observation gaps; only finish it
+            // once the ball has been out of the control volume long enough that
+            // the carry is genuinely over.
+            let gap_elapsed = self
+                .active_setups
+                .get(&player_id)
+                .map(|setup| frame.time - setup.last_time > FLICK_SETUP_GAP_GRACE_SECONDS)
+                .unwrap_or(true);
+            if gap_elapsed {
                 self.finish_setup(&player_id);
             }
         }
@@ -615,7 +639,9 @@ impl FlickCalculator {
         let player_rigid_body = player.rigid_body.as_ref()?;
         let player_position = player.position()?;
         let time_since_dodge = touch_event.time - dodge_start.time;
-        if !(0.0..=FLICK_MAX_DODGE_TO_TOUCH_SECONDS).contains(&time_since_dodge) {
+        if !(-FLICK_DODGE_LEAD_TOLERANCE_SECONDS..=FLICK_MAX_DODGE_TO_TOUCH_SECONDS)
+            .contains(&time_since_dodge)
+        {
             return None;
         }
 

--- a/src/stats/calculators/flick_tests.rs
+++ b/src/stats/calculators/flick_tests.rs
@@ -935,3 +935,135 @@ fn counts_flick_whose_ball_impulse_arrives_after_the_touch_frame() {
     assert!(calculator.events()[0].ball_speed_change >= FLICK_MIN_BALL_SPEED_CHANGE);
     assert_eq!(calculator.player_stats().get(&player_id).unwrap().count, 1);
 }
+
+// Builds the control touch a dribbling team-zero player taps each frame.
+fn carry_touch(frame_number: usize, time: f32) -> TouchEvent {
+    TouchEvent {
+        touch_id: None,
+        time,
+        frame: frame_number,
+        team_is_team_0: true,
+        player: Some(boxcars::RemoteId::Steam(1)),
+        player_position: None,
+        closest_approach_distance: Some(0.0),
+        dodge_contact: false,
+    }
+}
+
+#[test]
+fn bridges_brief_control_gaps_into_one_setup() {
+    // A real carry lets the ball wobble in and out of the tight control volume.
+    // Here the ball leaves the volume every other frame, so without gap bridging
+    // no continuous run reaches FLICK_MIN_SETUP_SECONDS (each isolated frame is
+    // only one dt) and the flick is never recognized. With bridging the observed
+    // frames accumulate into one qualifying setup.
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = FlickCalculator::new();
+    let live_play = live_play();
+
+    let in_volume = || ball(glam::Vec3::new(60.0, 0.0, 112.0), glam::Vec3::ZERO);
+    let out_of_volume = || ball(glam::Vec3::new(260.0, 0.0, 112.0), glam::Vec3::ZERO);
+
+    // Observe / drop / observe / drop: isolated single-frame carries.
+    for (frame_number, time, observed) in [
+        (1usize, 0.1f32, true),
+        (2, 0.2, false),
+        (3, 0.3, true),
+        (4, 0.4, false),
+    ] {
+        calculator
+            .update(
+                &frame(frame_number, time),
+                &if observed {
+                    in_volume()
+                } else {
+                    out_of_volume()
+                },
+                &players(false),
+                &touch_state(vec![carry_touch(frame_number, time)]),
+                &TouchCalculator::new(),
+                &live_play,
+            )
+            .unwrap();
+    }
+
+    // Dodge + flick touch on an observed frame, with the ball launched.
+    calculator
+        .update(
+            &frame(5, 0.5),
+            &ball(
+                glam::Vec3::new(60.0, 0.0, 160.0),
+                glam::Vec3::new(1350.0, 0.0, 520.0),
+            ),
+            &players(true),
+            &touch_state(vec![carry_touch(5, 0.5)]),
+            &TouchCalculator::new(),
+            &live_play,
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    assert!(calculator.events()[0].setup_duration >= FLICK_MIN_SETUP_SECONDS);
+    assert_eq!(calculator.player_stats().get(&player_id).unwrap().count, 1);
+}
+
+#[test]
+fn counts_flick_when_dodge_byte_lags_the_contact() {
+    // The ball can start accelerating a frame or two before the dodge-active byte
+    // flips, so the flick touch precedes the recorded dodge start (a negative
+    // `time_since_dodge`). That must not be rejected as "touch before dodge".
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = FlickCalculator::new();
+    let live_play = live_play();
+
+    // Carry setup (no dodge yet) long enough to qualify.
+    for (frame_number, time) in [(1, 0.1), (2, 0.2), (3, 0.3)] {
+        calculator
+            .update(
+                &frame(frame_number, time),
+                &ball(glam::Vec3::new(60.0, 0.0, 112.0), glam::Vec3::ZERO),
+                &players(false),
+                &touch_state(vec![carry_touch(frame_number, time)]),
+                &TouchCalculator::new(),
+                &live_play,
+            )
+            .unwrap();
+    }
+
+    // Contact frame: the ball is launched but the dodge byte has not flipped yet.
+    calculator
+        .update(
+            &frame(4, 0.4),
+            &ball(
+                glam::Vec3::new(60.0, 0.0, 160.0),
+                glam::Vec3::new(1350.0, 0.0, 520.0),
+            ),
+            &players(false),
+            &touch_state(vec![carry_touch(4, 0.4)]),
+            &TouchCalculator::new(),
+            &live_play,
+        )
+        .unwrap();
+    assert!(calculator.events().is_empty());
+
+    // Dodge byte flips one frame later. No fresh touch this frame, so the flick
+    // stays anchored to the earlier contact and resolves despite the negative
+    // time-since-dodge.
+    calculator
+        .update(
+            &frame(5, 0.5),
+            &ball(
+                glam::Vec3::new(60.0, 0.0, 200.0),
+                glam::Vec3::new(1350.0, 0.0, 540.0),
+            ),
+            &players(true),
+            &touch_state(Vec::new()),
+            &TouchCalculator::new(),
+            &live_play,
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    assert!(calculator.events()[0].time_since_dodge < 0.0);
+    assert_eq!(calculator.player_stats().get(&player_id).unwrap().count, 1);
+}


### PR DESCRIPTION
Draft — follow-up to #199. Catches two more missed flicks in `problematic-private-duel-2026-03-20`, found via the missed-event capture loop.

## 1. Bridge brief control gaps (bounce dribbles)
A bounce dribble lets the ball wobble in and out of the tight control volume, so the flick "setup" fragmented into sub-`FLICK_MIN_SETUP_SECONDS` pieces that never qualified — at the dodge there was *no* setup at all. A setup now survives brief observation gaps (`FLICK_SETUP_GAP_GRACE_SECONDS = 0.12`) so the dribble accumulates as one continuous setup. (The 63.3s IcedSpace flick: a ~0.5s bounce dribble that previously fragmented to ~0.10s pieces.)

## 2. Tolerate dodge-byte lag
A flick's contact can register a frame or two *before* the dodge-active byte flips, leaving the anchoring touch slightly before the recorded dodge start (a negative `time_since_dodge`). Allow a small lead (`FLICK_DODGE_LEAD_TOLERANCE_SECONDS = 0.12`) instead of rejecting these as "touch before dodge".

## Verification
- `cargo test -p subtr-actor flick` — 24 pass, incl. two new regression tests: `bridges_brief_control_gaps_into_one_setup`, `counts_flick_when_dodge_byte_lags_the_contact`.
- `cargo fmt --check` + `cargo clippy --all-targets --all-features -D warnings` clean.
- On the replay: the 63.3s flick now fires; previously-correct flicks unchanged; the 52.9s loose-ball false positive stays rejected.

## Known limit (not addressed here)
A near-zero-setup *catch flick* (CaleMaCar @ ~433.7s in a separate replay) is still missed — it's kinematically near-identical to a loose-ball knock, so it needs the recall-oriented soft-signal approach, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)