### PR TITLE
[codex] Cache shared player assets

### DIFF
--- a/js/player/src/player/managers/ActorManager.js
+++ b/js/player/src/player/managers/ActorManager.js
@@ -9,6 +9,35 @@ import { CarModelLoader } from "./CarModelLoader.js";
 // skipped/scrubbed-past celebration never leaves the ball stuck hidden.
 const GOAL_BALL_HIDE_DURATION = 2.0;
 
+/** @type {Map<string, Promise<THREE.Group | null>>} */
+const ballModelTemplatePromises = new Map();
+
+/** @returns {Promise<THREE.Group | null>} */
+function loadBallModelTemplate(assetBase) {
+  const url = resolvePlayerAssetUrl("models/ball/scene.gltf", assetBase);
+  let templatePromise = ballModelTemplatePromises.get(url);
+  if (!templatePromise) {
+    const gltfLoader = new GLTFLoader();
+    templatePromise = new Promise((resolve) => {
+      gltfLoader.load(
+        url,
+        (gltf) => {
+          console.log("✓ Ball model loaded");
+          resolve(gltf.scene);
+        },
+        undefined,
+        (error) => {
+          console.error("Failed to load ball model:", error);
+          ballModelTemplatePromises.delete(url);
+          resolve(null); // Resolve even on error to not block shader compilation
+        },
+      );
+    });
+    ballModelTemplatePromises.set(url, templatePromise);
+  }
+  return templatePromise;
+}
+
 export class ActorManager {
   constructor(scene, effectsManager, options = {}) {
     this.scene = scene;
@@ -106,23 +135,11 @@ export class ActorManager {
     // Load ball GLTF model - store promise so we can await it before shader compilation
     this.ballModel = null;
     this._ballModelReplaced = false; // Track if ball model has been replaced
-    const gltfLoader = new GLTFLoader();
-    this.ballModelReady = new Promise((resolve) => {
-      gltfLoader.load(
-        resolvePlayerAssetUrl("models/ball/scene.gltf", this.assetBase),
-        (gltf) => {
-          this.ballModel = gltf.scene;
-          console.log("✓ Ball model loaded");
-          // Note: Don't replace ball mesh here - let GameEngine control when it's safe
-          // This prevents race conditions with shader compilation
-          resolve(true);
-        },
-        undefined,
-        (error) => {
-          console.error("Failed to load ball model:", error);
-          resolve(false); // Resolve even on error to not block shader compilation
-        },
-      );
+    this.ballModelReady = loadBallModelTemplate(this.assetBase).then((template) => {
+      this.ballModel = template;
+      // Note: Don't replace ball mesh here - let GameEngine control when it's safe
+      // This prevents race conditions with shader compilation
+      return template !== null;
     });
   }
 

--- a/js/player/src/player/managers/ArenaManager.js
+++ b/js/player/src/player/managers/ArenaManager.js
@@ -4,6 +4,117 @@ import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader.js";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js";
 import { resolvePlayerAssetUrl } from "../asset-url.js";
 
+const stadiumTemplatePromises = new Map();
+
+async function loadStadiumTemplate(gltfLoader, assetBase) {
+  const url = resolvePlayerAssetUrl("models/stadium/stadium.glb", assetBase);
+  let templatePromise = stadiumTemplatePromises.get(url);
+  if (!templatePromise) {
+    templatePromise = gltfLoader
+      .loadAsync(url)
+      .then((gltf) => {
+        const arena = gltf.scene;
+        prepareArenaTemplate(arena);
+        return arena;
+      })
+      .catch((error) => {
+        stadiumTemplatePromises.delete(url);
+        throw error;
+      });
+    stadiumTemplatePromises.set(url, templatePromise);
+  }
+  return templatePromise;
+}
+
+function prepareArenaTemplate(arena) {
+  // Materials that need visibility fix (disappear at certain camera angles)
+  const visibilityFixMaterials = [
+    "Sol_Trait_T0",
+    "Sol_Trait_T1",
+    "Milieu_Forme",
+    "Milieu_Forme.001",
+    "cage_T0",
+    "cage_T1",
+    "Couleur_Hexagone_T0",
+    "Couleur_Hexagone_T1",
+    "wall_gradient_color_2",
+    "wall_gradient_color_2.001",
+    "Fond_BackBoard_Transparent", // For Transparant_BackBoard_+_Cage meshes
+    "dégradé_transparent_T0",
+    "dégradé_transparent_T1", // Glow effects on field edges
+    "grid_transperant", // Goal glass mesh
+    "Detail_Milieu",
+    "Detail_Milieu.001", // Field mid details
+  ];
+
+  // Mesh name patterns that need frustum culling disabled (glow effects with incorrect bounding box)
+  const disableFrustumCullingPatterns = ["Glow", "Glass"];
+
+  // Meshes that should NOT cast shadows (ceilings, transparent elements)
+  const noCastShadowMeshes = [
+    "Plafond_Hexagone_T0",
+    "Plafond_Hexagone_T1",
+    "Plafond_Transparent",
+  ];
+
+  arena.traverse((child) => {
+    if (!child.isMesh) {
+      return;
+    }
+
+    child.receiveShadow = true;
+    // Disable castShadow for ceiling meshes
+    child.castShadow = !noCastShadowMeshes.includes(child.name);
+
+    // Disable frustum culling for glow meshes (they have incorrect bounding boxes)
+    const shouldDisableFrustumCulling = disableFrustumCullingPatterns.some((pattern) =>
+      child.name.includes(pattern),
+    );
+    if (shouldDisableFrustumCulling) {
+      console.log(`[ArenaManager] Disabling frustum culling for: ${child.name}`);
+      child.frustumCulled = false;
+    }
+
+    // Hexagon patterns render far louder here than the game's subtle originals.
+    if (child.material && /^Hexagone_T[01]$/.test(child.material.name ?? "")) {
+      child.material = child.material.clone();
+      child.material.transparent = true;
+      child.material.opacity = 0.18;
+      child.material.depthWrite = false;
+      child.renderOrder = 1;
+    }
+
+    // Field advert strip carries a baked ballcam.tv ad texture; hide the ad face.
+    if (child.material && child.material.name === "bannière_pub") {
+      child.visible = false;
+    }
+
+    // Floor hex overlay + OOB honeycomb apron.
+    if (child.material && child.material.name === "Sol_Hexagone") {
+      child.material = child.material.clone();
+      child.material.color.setScalar(0.35);
+      child.material.metalness = 0;
+      child.material.roughness = 1;
+    }
+
+    // Fix visibility issues (disappearing at certain angles)
+    if (
+      child.material &&
+      child.material.name &&
+      visibilityFixMaterials.includes(child.material.name)
+    ) {
+      console.log(
+        `[ArenaManager] Fixing visibility for: ${child.name} (material: ${child.material.name})`,
+      );
+      child.material = child.material.clone();
+      child.material.side = THREE.DoubleSide; // Render both sides
+      child.material.depthWrite = false; // Don't write to depth buffer
+      child.renderOrder = 1; // Render after floor
+      child.frustumCulled = false; // Also disable frustum culling for these
+    }
+  });
+}
+
 export class ArenaManager {
   constructor(scene, options = {}) {
     this.scene = scene;
@@ -27,10 +138,8 @@ export class ArenaManager {
     try {
       console.log("Loading arena mesh...");
 
-      const gltf = await this.gltfLoader.loadAsync(
-        resolvePlayerAssetUrl("models/stadium/stadium.glb", this.assetBase),
-      );
-      const arena = gltf.scene;
+      const template = await loadStadiumTemplate(this.gltfLoader, this.assetBase);
+      const arena = template.clone(true);
 
       // Rotate arena 180 degrees around Y axis to match replay coordinate system
       // In Rocket League replays, team 0 (blue) spawns at negative Y coordinates
@@ -38,104 +147,13 @@ export class ArenaManager {
       // This rotation ensures the blue side of the arena mesh faces the blue team's spawn
       // arena.rotation.y = Math.PI; // 180 degrees
 
-      // Materials that need visibility fix (disappear at certain camera angles)
-      const visibilityFixMaterials = [
-        "Sol_Trait_T0",
-        "Sol_Trait_T1",
-        "Milieu_Forme",
-        "Milieu_Forme.001",
-        "cage_T0",
-        "cage_T1",
-        "Couleur_Hexagone_T0",
-        "Couleur_Hexagone_T1",
-        "wall_gradient_color_2",
-        "wall_gradient_color_2.001",
-        "Fond_BackBoard_Transparent", // For Transparant_BackBoard_+_Cage meshes
-        "dégradé_transparent_T0",
-        "dégradé_transparent_T1", // Glow effects on field edges
-        "grid_transperant", // Goal glass mesh
-        "Detail_Milieu",
-        "Detail_Milieu.001", // Field mid details
-      ];
-
-      // Mesh name patterns that need frustum culling disabled (glow effects with incorrect bounding box)
-      const disableFrustumCullingPatterns = ["Glow", "Glass"];
-
-      // Meshes that should NOT cast shadows (ceilings, transparent elements)
-      const noCastShadowMeshes = [
-        "Plafond_Hexagone_T0",
-        "Plafond_Hexagone_T1",
-        "Plafond_Transparent",
-      ];
-
-      // Enable shadow receiving on arena meshes and collect for raycasting
+      // Collect instance meshes for raycasting. The immutable decoded template
+      // is shared across player instances with the same asset root, so event
+      // review can switch replays without reparsing the stadium GLB every time.
       arena.traverse((child) => {
         if (child.isMesh) {
-          child.receiveShadow = true;
-          // Disable castShadow for ceiling meshes
-          child.castShadow = !noCastShadowMeshes.includes(child.name);
-
           // Store mesh reference for raycasting (drawing/pings)
           this.arenaMeshes.push(child);
-
-          // Disable frustum culling for glow meshes (they have incorrect bounding boxes)
-          const shouldDisableFrustumCulling = disableFrustumCullingPatterns.some((pattern) =>
-            child.name.includes(pattern),
-          );
-          if (shouldDisableFrustumCulling) {
-            console.log(`[ArenaManager] Disabling frustum culling for: ${child.name}`);
-            child.frustumCulled = false;
-          }
-
-          // Hexagon patterns render far louder here than the game's subtle
-          // originals. They're baked into the model (outline geometry for the
-          // force-field cage, a texture for the floor/out-of-bounds honeycomb),
-          // so line width can't be thinned directly.
-          //
-          // Force-field cage walls + center-circle accents (Hexagone_T0/T1):
-          // translucency (+ no depth write, so the cage never occludes gameplay)
-          // gets the barely-there in-game look and makes the lines read thinner.
-          if (child.material && /^Hexagone_T[01]$/.test(child.material.name ?? "")) {
-            child.material = child.material.clone();
-            child.material.transparent = true;
-            child.material.opacity = 0.18;
-            child.material.depthWrite = false;
-            child.renderOrder = 1;
-          }
-
-          // Field advert strip carries a baked ballcam.tv ad texture
-          // (bannière_pub material on AdvertStrip_Field) — hide the ad face and
-          // keep the AdvertStrip_Frame structure as a neutral board.
-          if (child.material && child.material.name === "bannière_pub") {
-            child.visible = false;
-          }
-
-          // Floor hex overlay + OOB honeycomb apron (Sol_Hexagone): opacity is
-          // the wrong tool here — the floor stack has solid team-color layers
-          // underneath that show through. Instead dim the texture and drop the
-          // metallic sheen that makes the grid glow at glancing camera angles.
-          if (child.material && child.material.name === "Sol_Hexagone") {
-            child.material = child.material.clone();
-            child.material.color.setScalar(0.35);
-            child.material.metalness = 0;
-            child.material.roughness = 1;
-          }
-
-          // Fix visibility issues (disappearing at certain angles)
-          if (
-            child.material &&
-            child.material.name &&
-            visibilityFixMaterials.includes(child.material.name)
-          ) {
-            console.log(
-              `[ArenaManager] Fixing visibility for: ${child.name} (material: ${child.material.name})`,
-            );
-            child.material = child.material.clone();
-            child.material.side = THREE.DoubleSide; // Render both sides
-            child.material.depthWrite = false; // Don't write to depth buffer
-            child.renderOrder = 1; // Render after floor
-            child.frustumCulled = false; // Also disable frustum culling for these
-          }
         }
       });
 

--- a/js/player/src/player/managers/CarModelLoader.js
+++ b/js/player/src/player/managers/CarModelLoader.js
@@ -5,6 +5,11 @@ import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader.js";
 import { clone as skeletonClone } from "three/examples/jsm/utils/SkeletonUtils.js";
 import { resolvePlayerAssetUrl } from "../asset-url.js";
 
+const sharedModelCache = new Map();
+const sharedLoadingPromises = new Map();
+const sharedWheelModelCache = new Map();
+const sharedWheelLoadingPromises = new Map();
+
 /**
  * CarModelLoader - Loads and manages car models (GLB format) with team-colored materials
  *
@@ -31,9 +36,10 @@ export class CarModelLoader {
     dracoLoader.setDecoderPath(resolvePlayerAssetUrl("draco/", this.assetBase));
     this.gltfLoader.setDRACOLoader(dracoLoader);
 
-    // Cache for loaded models (we clone them for each car)
-    this.modelCache = new Map(); // modelType -> { model, chassisTexture }
-    this.loadingPromises = new Map(); // modelType -> Promise
+    // Cache for loaded models (we clone them for each car). Shared at module
+    // scope so switching review replays does not reparse the same car GLBs.
+    this.modelCache = sharedModelCache; // asset-root + modelType -> { model, chassisTexture }
+    this.loadingPromises = sharedLoadingPromises; // asset-root + modelType -> Promise
 
     // Model configuration: all models are GLB format
     // format: 'glb'
@@ -94,8 +100,8 @@ export class CarModelLoader {
     };
 
     // Cache for wheel models
-    this.wheelModelCache = new Map();
-    this.wheelLoadingPromises = new Map();
+    this.wheelModelCache = sharedWheelModelCache;
+    this.wheelLoadingPromises = sharedWheelLoadingPromises;
 
     // Deferred preload - will be set when preloadModelsForReplay() is called
     this.preloadReady = Promise.resolve();
@@ -245,27 +251,32 @@ export class CarModelLoader {
    * @returns {Promise<{model: THREE.Group, chassisTexture: THREE.Texture}>}
    */
   async loadModel(modelType) {
+    const cacheKey = this.modelCacheKey(modelType);
     // Return cached if available
-    if (this.modelCache.has(modelType)) {
-      return this.modelCache.get(modelType);
+    if (this.modelCache.has(cacheKey)) {
+      return this.modelCache.get(cacheKey);
     }
 
     // Return existing loading promise if in progress
-    if (this.loadingPromises.has(modelType)) {
-      return this.loadingPromises.get(modelType);
+    if (this.loadingPromises.has(cacheKey)) {
+      return this.loadingPromises.get(cacheKey);
     }
 
     // Start loading
     const loadPromise = this._loadModelInternal(modelType);
-    this.loadingPromises.set(modelType, loadPromise);
+    this.loadingPromises.set(cacheKey, loadPromise);
 
     try {
       const result = await loadPromise;
-      this.modelCache.set(modelType, result);
+      this.modelCache.set(cacheKey, result);
       return result;
     } finally {
-      this.loadingPromises.delete(modelType);
+      this.loadingPromises.delete(cacheKey);
     }
+  }
+
+  modelCacheKey(modelType) {
+    return resolvePlayerAssetUrl(`models/cars/${modelType}`, this.assetBase);
   }
 
   async _loadModelInternal(modelType) {
@@ -462,21 +473,20 @@ export class CarModelLoader {
    * @returns {Promise<THREE.Group>}
    */
   async loadWheelModel(wheelModelName) {
+    const wheelPath = resolvePlayerAssetUrl(`models/wheels/${wheelModelName}`, this.assetBase);
     // Return cached if available
-    if (this.wheelModelCache.has(wheelModelName)) {
-      return this.wheelModelCache.get(wheelModelName);
+    if (this.wheelModelCache.has(wheelPath)) {
+      return this.wheelModelCache.get(wheelPath);
     }
 
     // Return existing loading promise if in progress
-    if (this.wheelLoadingPromises.has(wheelModelName)) {
-      return this.wheelLoadingPromises.get(wheelModelName);
+    if (this.wheelLoadingPromises.has(wheelPath)) {
+      return this.wheelLoadingPromises.get(wheelPath);
     }
 
     // Start loading
-    const loadPromise = this._loadGLB(
-      resolvePlayerAssetUrl(`models/wheels/${wheelModelName}`, this.assetBase),
-    );
-    this.wheelLoadingPromises.set(wheelModelName, loadPromise);
+    const loadPromise = this._loadGLB(wheelPath);
+    this.wheelLoadingPromises.set(wheelPath, loadPromise);
 
     try {
       const wheelModel = await loadPromise;
@@ -490,13 +500,13 @@ export class CarModelLoader {
         }
       });
 
-      this.wheelModelCache.set(wheelModelName, wheelModel);
+      this.wheelModelCache.set(wheelPath, wheelModel);
       return wheelModel;
     } catch (error) {
       console.error(`Failed to load wheel model ${wheelModelName}:`, error);
       throw error;
     } finally {
-      this.wheelLoadingPromises.delete(wheelModelName);
+      this.wheelLoadingPromises.delete(wheelPath);
     }
   }
 
@@ -792,7 +802,7 @@ export class CarModelLoader {
    */
   isModelReady(carName, hitboxType) {
     const modelType = this.getModelTypeForCar(carName, hitboxType);
-    return this.modelCache.has(modelType);
+    return this.modelCache.has(this.modelCacheKey(modelType));
   }
 
   /**
@@ -804,7 +814,7 @@ export class CarModelLoader {
    */
   getCarMeshSync(carName, hitboxType, team = 0) {
     const modelType = this.getModelTypeForCar(carName, hitboxType);
-    const cached = this.modelCache.get(modelType);
+    const cached = this.modelCache.get(this.modelCacheKey(modelType));
 
     if (!cached || !cached.model) {
       return null;
@@ -1041,29 +1051,8 @@ export class CarModelLoader {
   }
 
   dispose() {
-    // Dispose all cached car models and textures
-    this.modelCache.forEach(({ model, chassisTexture }) => {
-      model.traverse((child) => {
-        if (child.isMesh) {
-          if (child.geometry) child.geometry.dispose();
-          const materials = Array.isArray(child.material) ? child.material : [child.material];
-          materials.forEach((mat) => mat.dispose());
-        }
-      });
-      if (chassisTexture) chassisTexture.dispose();
-    });
-    this.modelCache.clear();
-
-    // Dispose all cached wheel models
-    this.wheelModelCache.forEach((wheelModel) => {
-      wheelModel.traverse((child) => {
-        if (child.isMesh) {
-          if (child.geometry) child.geometry.dispose();
-          const materials = Array.isArray(child.material) ? child.material : [child.material];
-          materials.forEach((mat) => mat.dispose());
-        }
-      });
-    });
-    this.wheelModelCache.clear();
+    // Model caches are shared across player instances for the lifetime of the
+    // page. Per-instance disposal must not free shared templates that another
+    // playlist/review player may reuse or currently be cloning.
   }
 }


### PR DESCRIPTION
## Summary
- Cache decoded immutable player assets at module scope so replay review can switch between replays without reparsing the same stadium, ball, car, and wheel models
- Key shared caches by resolved asset URL / asset base so embedded deployments with different roots do not share the wrong templates
- Keep per-player scene instances cloning templates, while allowing failed stadium/ball loads to retry on later player instances

## Context
Stacked on #210 (`colonelpanic/player-nomenclature`), which moves the implementation from the old viewer package paths into `@rlrml/player`.

Root cause: event review creates a fresh player scene when it moves to a new replay. Replay bundles were cached, but static 3D assets were cached only inside each scene manager instance, so every replay transition rebuilt the same expensive model resources.

## Validation
- `npm --prefix js/player run build:dist`
