### PR TITLE
Match ballcam boost trail visuals

### DIFF
--- a/js/player/src/player/managers/EffectsManager.js
+++ b/js/player/src/player/managers/EffectsManager.js
@@ -1962,7 +1962,7 @@ class BoostTrail {
   constructor(carMesh) {
     this.carMesh = carMesh;
     this.active = false;
-    this.particleCount = 120;
+    this.particleCount = 200;
     this.particles = [];
 
     // Create geometry for boost particles
@@ -1991,7 +1991,6 @@ class BoostTrail {
         maxLife: 0.5,
         velocity: new THREE.Vector3(),
         active: false,
-        initialAlpha: 0,
       });
     }
 
@@ -2016,7 +2015,7 @@ class BoostTrail {
                     vColor = color;
                     vAlpha = alpha;
                     vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
-                    gl_PointSize = size * (1500.0 / -mvPosition.z);
+                    gl_PointSize = size * (2500.0 / -mvPosition.z); // Slightly larger for flame effect
                     gl_Position = projectionMatrix * mvPosition;
                 }
             `,
@@ -2028,18 +2027,17 @@ class BoostTrail {
                     float dist = length(gl_PointCoord - vec2(0.5));
                     if (dist > 0.5) discard;
 
-                    // Soft halo so neighbouring sprites merge into a cohesive
-                    // flame instead of reading as separate dots.
+                    // Softer glow with hot center
                     float glow = 1.0 - (dist * 2.0);
-                    glow = pow(glow, 1.35);
+                    glow = pow(glow, 0.6); // Softer falloff for more glow
 
-                    // Hot specular core: a small white-gold center that gives the
-                    // exhaust the glossy, almost-reflective sheen of the in-game
-                    // boost flame. Concentrated near the sprite center (high power).
-                    float core = pow(clamp(1.0 - dist * 2.0, 0.0, 1.0), 6.0);
-                    vec3 col = vColor * glow + vec3(1.0, 0.92, 0.7) * core * 0.75;
+                    // Brighter center (white-hot core)
+                    vec3 flameColor = vColor;
+                    if (dist < 0.15) {
+                        flameColor = mix(vec3(1.0, 1.0, 0.9), vColor, dist / 0.15); // White-yellow core
+                    }
 
-                    gl_FragColor = vec4(col, vAlpha * glow);
+                    gl_FragColor = vec4(flameColor * glow * 1.5, vAlpha * glow);
                 }
             `,
       transparent: true,
@@ -2060,8 +2058,8 @@ class BoostTrail {
     if (!this.active) return;
 
     // Emit particles proportional to playbackSpeed
-    // At 1.0x: 2-3 particles, at 0.5x: 1-2 particles, at 2.0x: 4-6 particles
-    const baseEmit = Math.floor(Math.random() * 2) + 3;
+    // At 1.0x: 3-5 particles, at 0.5x: 1-2 particles, at 2.0x: 6-10 particles
+    const baseEmit = Math.floor(Math.random() * 3) + 3;
     const emitCount = Math.max(1, Math.round(baseEmit * playbackSpeed));
 
     for (let i = 0; i < emitCount; i++) {
@@ -2078,9 +2076,9 @@ class BoostTrail {
 
       // Tighter spread for more focused flame (in UU)
       const spread = new THREE.Vector3(
-        (Math.random() - 0.5) * 7,
-        (Math.random() - 0.5) * 9,
-        (Math.random() - 0.5) * 9,
+        (Math.random() - 0.5) * 10,
+        (Math.random() - 0.5) * 15,
+        (Math.random() - 0.5) * 15,
       );
 
       const startPos = position.clone().add(rearOffset).add(spread);
@@ -2091,7 +2089,7 @@ class BoostTrail {
       // Velocity: opposite to car direction + inherit some car velocity (in UU)
       const backwardDir = new THREE.Vector3(-1, 0, 0);
       backwardDir.applyQuaternion(rotation);
-      backwardDir.multiplyScalar(95 + Math.random() * 45);
+      backwardDir.multiplyScalar(150 + Math.random() * 80); // Slightly slower for denser look
 
       particle.velocity.copy(backwardDir);
       particle.velocity.add(velocity.clone().multiplyScalar(0.2)); // Inherit 20% of car velocity
@@ -2106,18 +2104,18 @@ class BoostTrail {
       );
 
       particle.life = 0;
-      particle.maxLife = 0.2 + Math.random() * 0.18;
+      particle.maxLife = 0.3 + Math.random() * 0.3; // Shorter life (0.3-0.6s) for tighter flame
       particle.active = true;
 
-      particle.initialAlpha = 0.52 + Math.random() * 0.18;
-      alphas[idx] = particle.initialAlpha;
-      sizes[idx] = 1.5 + Math.random() * 0.9;
+      // Start with high alpha and larger size (intense at exhaust)
+      alphas[idx] = 1.0;
+      sizes[idx] = 3.0 + Math.random() * 2.0; // Larger initial size (3-5 UU)
       particle.initialSize = sizes[idx];
 
-      // Warmer exhaust colors without the bright yellow-white core.
+      // Color gradient: white/yellow at start, orange/red at end
       colors[idx * 3] = 1.0; // R
-      colors[idx * 3 + 1] = 0.45 + Math.random() * 0.2;
-      colors[idx * 3 + 2] = 0.12 + Math.random() * 0.12;
+      colors[idx * 3 + 1] = 0.8 + Math.random() * 0.2; // G (0.8-1.0 for yellow-white)
+      colors[idx * 3 + 2] = 0.3 + Math.random() * 0.3; // B (0.3-0.6 for warm tint)
 
       this.nextParticleIndex = (this.nextParticleIndex + 1) % this.particleCount;
     }
@@ -2155,18 +2153,17 @@ class BoostTrail {
       // Life factor (0 = just born, 1 = about to die)
       const lifeFactor = particle.life / particle.maxLife;
 
-      // Fade out with smooth curve while preserving the softer initial opacity.
-      const initialAlpha = particle.initialAlpha || 0.6;
-      alphas[i] = initialAlpha * Math.pow(1.0 - lifeFactor, 0.75);
+      // Fade out with smooth curve
+      alphas[i] = Math.pow(1.0 - lifeFactor, 0.5);
 
       // Shrink particles as they age (rocket flame tapers off)
       const initialSize = particle.initialSize || 3.0;
       sizes[i] = initialSize * (1.0 - lifeFactor * 0.7); // Shrink to 30% of original
 
-      // Color transition: orange → deep red as particle ages.
+      // Color transition: yellow-white -> orange -> red as particle ages
       colors[i * 3] = 1.0; // R stays at 1.0
-      colors[i * 3 + 1] = Math.max(0.16, 0.52 - lifeFactor * 0.34);
-      colors[i * 3 + 2] = Math.max(0.0, 0.16 - lifeFactor * 0.16);
+      colors[i * 3 + 1] = Math.max(0.2, 0.9 - lifeFactor * 0.7); // G: 0.9 -> 0.2
+      colors[i * 3 + 2] = Math.max(0.0, 0.4 - lifeFactor * 0.4); // B: 0.4 -> 0.0
 
       // Very light gravity (flames rise slightly)
       particle.velocity.y += 20 * delta;


### PR DESCRIPTION
## Summary
- restore the player boost trail particle/shader settings to match the current ballcam.tv GameEngine implementation
- keep the change scoped to the replay player EffectsManager boost trail

## Checks
- just check