### PR TITLE
Reuse replay player across replay loads

### DIFF
--- a/js/player/src/player/ReplayPlayer.ts
+++ b/js/player/src/player/ReplayPlayer.ts
@@ -200,7 +200,7 @@ function createReplayRoot(scene: THREE.Scene): THREE.Group {
 export class ReplayPlayer extends EventTarget {
   readonly container: HTMLElement;
   /** The subtr-actor adapter — the sole data source (timelines + live entities). */
-  readonly adapter: SubtrActorPlayer;
+  adapter: SubtrActorPlayer;
   /**
    * @rlrml/player's normalized `ReplayModel` over the same raw WASM output the
    * adapter consumes (docs/player/PLAYER_PARITY.md Phase 2) — the data surface
@@ -208,7 +208,7 @@ export class ReplayPlayer extends EventTarget {
    * first frame) and player-id format. Null when constructed directly with an
    * adapter only; `createPlayer()` always provides it.
    */
-  readonly replay: ReplayModel | null;
+  replay: ReplayModel | null;
   readonly options: PlayerOptions;
 
   readonly sceneManager: any;
@@ -235,7 +235,7 @@ export class ReplayPlayer extends EventTarget {
   readonly sceneState: ReplayScene;
   private readonly effectsEnabled: boolean;
   /** Resolves when async assets (arena meshes, ball model) are in the scene. */
-  readonly ready: Promise<void>;
+  ready: Promise<void>;
 
   private readonly plugins: InstalledPlugin[] = [];
   private readonly beforeRenderCallbacks: BeforeRenderCallback[] = [];
@@ -272,8 +272,8 @@ export class ReplayPlayer extends EventTarget {
   private attachmentTouched = false;
 
   // ── Timeline projection / skip windows (require a ReplayModel) ──────────────
-  private readonly liveGameState: number | null = null;
-  private readonly kickoffGameState: number | null = null;
+  private liveGameState: number | null = null;
+  private kickoffGameState: number | null = null;
   private timelineSegmentsCacheKey: string | null = null;
   private timelineSegmentsCache: ReplayPlayerTimelineSegment[] = [];
 
@@ -288,10 +288,7 @@ export class ReplayPlayer extends EventTarget {
     this.adapter = adapter;
     this.replay = replay;
     this.options = options;
-    if (replay) {
-      this.liveGameState = inferLiveGameState(replay);
-      this.kickoffGameState = inferKickoffGameState(replay, this.liveGameState);
-    }
+    this.updateReplayGameStates();
     this.speed = Math.max(0.1, options.initialPlaybackRate ?? options.speed ?? 1);
     this.loop = options.loop ?? false;
     this.cameraDistanceScaleValue = Math.max(0.25, options.initialCameraDistanceScale ?? 1);
@@ -335,22 +332,7 @@ export class ReplayPlayer extends EventTarget {
     // Hitbox wireframes (driven by the hitboxWireframesEnabled /
     // hitboxOnlyModeEnabled parity toggles; updated per frame in render()).
     this.hitboxManager = new HitboxManager(this.scene);
-    // Feed the replay's goal events (frame, time, scoring team, scorer) to the
-    // effects system. ActorManager fires the matching explosion as playback
-    // crosses each goal. Uses the normalized ReplayModel timeline, so scorer
-    // name + team resolution is shared with the rest of the player.
-    if (this.effectsEnabled && this.replay) {
-      this.effectsManager.setGoalEvents(
-        this.replay.timelineEvents
-          .filter((event) => event.kind === "goal")
-          .map((event) => ({
-            frame: event.frame,
-            time: event.time,
-            team: event.isTeamZero ? 0 : 1,
-            playerName: event.playerName ?? "",
-          })),
-      );
-    }
+    this.syncGoalEvents();
     // setRenderContext() pre-warms the explosion shader pools — a multi-second,
     // main-thread-blocking compile. Deferred behind `ready` (below) so it
     // finishes under the load overlay, well before the first goal, instead of
@@ -373,16 +355,8 @@ export class ReplayPlayer extends EventTarget {
       this.arenaManager.loadArenaMeshes().catch((e: unknown) => {
         console.warn("[player] arena load failed", e);
       }),
-      this.actorManager.waitForBallModel().catch(() => false),
-    ]).then(() => {
-      if (this.effectsEnabled) {
-        try {
-          this.effectsManager.setRenderContext(this.renderer, this.camera);
-        } catch (e) {
-          console.warn("[player] explosion warmup failed", e);
-        }
-      }
-    });
+      this.prepareReplayAssets(),
+    ]).then(() => undefined);
 
     this.installResizeHandling();
     for (const definition of options.plugins ?? []) {
@@ -415,6 +389,73 @@ export class ReplayPlayer extends EventTarget {
   }
   get duration(): number {
     return this.adapter.duration;
+  }
+
+  /**
+   * Replace the replay data feeding this player without replacing the renderer,
+   * canvas, arena, camera controls, or player instance. This is the replay-boundary
+   * path for playlist/review UIs: replay-specific actors, effects, timelines,
+   * and plugin setup are refreshed against the new adapter while the static
+   * render shell remains mounted.
+   */
+  async replaceReplay(
+    adapter: SubtrActorPlayer,
+    replay: ReplayModel | null,
+    options: { currentTime?: number; preservePlayback?: boolean } = {},
+  ): Promise<void> {
+    if (this.disposed) {
+      throw new Error("Cannot replace replay on a disposed ReplayPlayer");
+    }
+
+    const shouldResume = options.preservePlayback ?? this.playing;
+    if (this.playing) {
+      this.setPlayingInternal(false);
+    }
+
+    this.teardownPlugins();
+    this.effectsManager.reset();
+    this.effectsManager.clearEvents?.();
+    this.hitboxManager.reset();
+    this.actorManager.reset();
+
+    this.adapter = adapter;
+    this.replay = replay;
+    this.updateReplayGameStates();
+    this.timelineSegmentsCacheKey = null;
+    this.timelineSegmentsCache = [];
+    this.hitboxTypeByName = null;
+    this.hitboxesActive = false;
+    this.freeCameraTransition = null;
+
+    this.actorManager.initFromFramework(adapter);
+    this.actorManager.initInterpolants(adapter.getTimelines());
+    this.syncGoalEvents();
+
+    const attachedPlayerId =
+      this.attachedPlayerIdValue &&
+      this.adapter.playerList.some((player) => player.id === this.attachedPlayerIdValue)
+        ? this.attachedPlayerIdValue
+        : null;
+    if (attachedPlayerId !== this.attachedPlayerIdValue) {
+      this.attachedPlayerIdValue = attachedPlayerId;
+      if (this.cameraViewModeValue === "follow") {
+        this.cameraViewModeValue = "free";
+      }
+    }
+
+    this.seekInternal(options.currentTime ?? 0);
+    this.ready = this.prepareReplayAssets();
+    await this.ready;
+
+    this.setupPlugins();
+    this.applyInitialCameraOptions();
+    this.skipPostGoalTransitionIfNeeded();
+    this.skipPastKickoffIfNeeded();
+    if (shouldResume) {
+      this.setPlayingInternal(true);
+    }
+    this.render();
+    this.emitChange();
   }
 
   // ── Environment (skybox + IBL) ──────────────────────────────────────────────
@@ -852,6 +893,65 @@ export class ReplayPlayer extends EventTarget {
       this.actorManager.resumeAnimations();
     } else {
       this.actorManager.pauseAnimations();
+    }
+  }
+
+  private prepareReplayAssets(): Promise<void> {
+    return this.actorManager
+      .waitForBallModel()
+      .catch(() => false)
+      .then(() => {
+        if (this.effectsEnabled) {
+          try {
+            this.effectsManager.setRenderContext(this.renderer, this.camera);
+          } catch (e) {
+            console.warn("[player] explosion warmup failed", e);
+          }
+        }
+      });
+  }
+
+  private updateReplayGameStates(): void {
+    if (!this.replay) {
+      this.liveGameState = null;
+      this.kickoffGameState = null;
+      return;
+    }
+
+    this.liveGameState = inferLiveGameState(this.replay);
+    this.kickoffGameState = inferKickoffGameState(this.replay, this.liveGameState);
+  }
+
+  private syncGoalEvents(): void {
+    if (!this.effectsEnabled) return;
+    this.effectsManager.clearEvents?.();
+    if (!this.replay) return;
+    this.effectsManager.setGoalEvents(
+      this.replay.timelineEvents
+        .filter((event) => event.kind === "goal")
+        .map((event) => ({
+          frame: event.frame,
+          time: event.time,
+          team: event.isTeamZero ? 0 : 1,
+          playerName: event.playerName ?? "",
+        })),
+    );
+  }
+
+  private teardownPlugins(): void {
+    const context = this.createPluginContext();
+    for (const entry of this.plugins) {
+      entry.plugin.teardown?.(context);
+    }
+  }
+
+  private setupPlugins(): void {
+    for (const entry of this.plugins) {
+      entry.plugin.setup?.(this.createPluginContext());
+      if (entry.plugin.id === "camera") {
+        this.pushCameraParityState();
+      }
+      entry.plugin.onStateChange?.(this.createPluginStateContext(this.getState()));
     }
   }
 

--- a/js/player/src/player/managers/ActorManager.js
+++ b/js/player/src/player/managers/ActorManager.js
@@ -223,12 +223,36 @@ export class ActorManager {
     }
     this.actorToPlayer = {};
     this.actorLinks = {};
+    this.playerNames.clear();
     this.playerNameToCarActorId = {};
     this.playerNameToPriActorId = {};
+    this.playerTeams = {};
     this.actorLoadouts = {};
+    this.carBodyIds = {};
+    this.pendingCarReplacements.clear();
     this._lastGoalScanTime = null;
     this._firedGoalTimes.clear();
-    // playerTeams are static per replay, usually
+    this.ballTimeline = [];
+    this.playerTimelineMap = {};
+    this.ballTimelineCorrected = [];
+    this.playerTimelineMapCorrected = {};
+    this.ballTimelineFiltered = [];
+    this.playerTimelineMapFiltered = {};
+    this.timelineIndices = { ball: 0, players: {} };
+    this.timelineIndicesFiltered = { ball: 0, players: {} };
+    this.timelineIndicesCorrected = { ball: 0, players: {} };
+    this.interpolantsInitialized = false;
+    this.animationMixer?.stopAllAction?.();
+    this.animationMixer = null;
+    this.animationActions = {};
+    this.replayDuration = 0;
+    this.positionBuffers = {};
+    this.rotationBuffers = {};
+    this._lowPassState.clear();
+    this._predictState.clear();
+    this._smoothingBuffers.clear();
+    this._adaptiveState.clear();
+    this._ballModelReplaced = false;
   }
 
   setPlayerTeams(teams) {
@@ -2767,6 +2791,7 @@ export class ActorManager {
     this.scene.add(mesh);
     this.actors[actorId] = mesh;
     this.playerNameToCarActorId[playerName] = actorId;
+    this.playerTeams[playerName] = team;
     this.playerNames.add(playerName);
 
     // Create boost trail for this car

--- a/js/player/src/playlist.ts
+++ b/js/player/src/playlist.ts
@@ -1,4 +1,4 @@
-import { ReplayPlayer, createPlayerFromParsed } from "./player/lib";
+import { ReplayPlayer, SubtrActorPlayer, createPlayerFromParsed } from "./player/lib";
 import { findFrameIndexAtTime } from "./replay-data";
 import type {
   CameraSettings,
@@ -624,6 +624,21 @@ export class ReplayPlaylistPlayer extends EventTarget {
       this.preferences.cameraViewMode = "free";
     }
 
+    if (this.player) {
+      const adapter = new SubtrActorPlayer(raw as never, {
+        motionSmoothing: this.options.motionSmoothing,
+        smoothingBlendFactor: this.options.smoothingBlendFactor,
+        smoothingAnchorInterval: this.options.smoothingAnchorInterval,
+        timelineCompaction: this.options.timelineCompaction,
+        disableFrameFiltering: this.options.disableFrameFiltering,
+      });
+      await this.player.replaceReplay(adapter, replay, {
+        currentTime: resolvedItem.start.time,
+        preservePlayback: this.playbackIntent,
+      });
+      return !(this.disposed || generation !== this.loadGeneration);
+    }
+
     const player = createPlayerFromParsed(
       this.container,
       { replay, raw },
@@ -642,11 +657,7 @@ export class ReplayPlaylistPlayer extends EventTarget {
         plugins: this.options.plugins,
       },
     );
-    const { style } = player.renderer.domElement;
-    style.visibility = "hidden";
-    style.pointerEvents = "none";
     player.seek(resolvedItem.start.time);
-
     try {
       await player.ready;
     } catch (error) {
@@ -659,8 +670,6 @@ export class ReplayPlaylistPlayer extends EventTarget {
     }
 
     this.detachPlayer();
-    style.visibility = "";
-    style.pointerEvents = "";
     this.player = player;
     this.playerUnsubscribe = player.subscribe((state) => {
       this.handlePlayerState(state);

--- a/js/player/src/playlist.ts
+++ b/js/player/src/playlist.ts
@@ -567,7 +567,10 @@ export class ReplayPlaylistPlayer extends EventTarget {
       this.currentItemIndex = clampedIndex;
       this.pendingItemIndex = null;
       this.currentResolvedItem = resolvedItem;
-      this.attachPlayer(resolvedItem);
+      const attached = await this.attachPlayer(resolvedItem, generation);
+      if (!attached || this.disposed || generation !== this.loadGeneration) {
+        return;
+      }
       this.loading = false;
       this.error = null;
       this.prefetchNearbyReplays(clampedIndex);
@@ -600,9 +603,10 @@ export class ReplayPlaylistPlayer extends EventTarget {
     return uniqueSourcesFromItems(this.items).map((source) => this.replayCache.getState(source));
   }
 
-  private attachPlayer(resolvedItem: ResolvedPlaylistItem): void {
-    this.detachPlayer();
-
+  private async attachPlayer(
+    resolvedItem: ResolvedPlaylistItem,
+    generation: number,
+  ): Promise<boolean> {
     const loadedReplay = resolvedItem.replay;
     const { replay, raw } = loadedReplay;
     if (!raw) {
@@ -620,7 +624,7 @@ export class ReplayPlaylistPlayer extends EventTarget {
       this.preferences.cameraViewMode = "free";
     }
 
-    this.player = createPlayerFromParsed(
+    const player = createPlayerFromParsed(
       this.container,
       { replay, raw },
       {
@@ -638,14 +642,34 @@ export class ReplayPlaylistPlayer extends EventTarget {
         plugins: this.options.plugins,
       },
     );
-    this.player.seek(resolvedItem.start.time);
-    this.playerUnsubscribe = this.player.subscribe((state) => {
+    const { style } = player.renderer.domElement;
+    style.visibility = "hidden";
+    style.pointerEvents = "none";
+    player.seek(resolvedItem.start.time);
+
+    try {
+      await player.ready;
+    } catch (error) {
+      player.destroy();
+      throw error;
+    }
+    if (this.disposed || generation !== this.loadGeneration) {
+      player.destroy();
+      return false;
+    }
+
+    this.detachPlayer();
+    style.visibility = "";
+    style.pointerEvents = "";
+    this.player = player;
+    this.playerUnsubscribe = player.subscribe((state) => {
       this.handlePlayerState(state);
     });
 
     if (this.playbackIntent) {
-      this.player.play();
+      player.play();
     }
+    return true;
   }
 
   private detachPlayer(): void {

--- a/js/stat-evaluation-player/src/replayDisplayRuntime.ts
+++ b/js/stat-evaluation-player/src/replayDisplayRuntime.ts
@@ -13,6 +13,7 @@ import {
   createFpsOverlayPlugin,
   createPlayerFromParsed,
   fromReplayPlayerPlugin,
+  SubtrActorPlayer,
 } from "@rlrml/player";
 import type { StatsReplayPlayer } from "./statsReplayPlayer.ts";
 import type { CameraControlsController } from "./cameraControls.ts";
@@ -83,7 +84,12 @@ function setReplayPlayerCanvasPending(player: StatsReplayPlayer, pending: boolea
   style.pointerEvents = pending ? "none" : "";
 }
 
-function clearDisplayedReplay(options: ReplayDisplayRuntimeOptions): void {
+function clearDisplayedReplay(
+  options: ReplayDisplayRuntimeOptions,
+  settings: { destroyPlayer?: boolean; clearPlayerPluginHandles?: boolean } = {},
+): void {
+  const destroyPlayer = settings.destroyPlayer ?? true;
+  const clearPlayerPluginHandles = settings.clearPlayerPluginHandles ?? true;
   const unsubscribe = options.getUnsubscribe();
   if (unsubscribe) {
     unsubscribe();
@@ -91,11 +97,15 @@ function clearDisplayedReplay(options: ReplayDisplayRuntimeOptions): void {
   }
 
   options.teardownActiveModules();
-  options.getReplayPlayer()?.destroy();
-  options.setReplayPlayer(null);
-  options.setCanvasRecorder(null);
+  if (destroyPlayer) {
+    options.getReplayPlayer()?.destroy();
+    options.setReplayPlayer(null);
+  }
+  if (clearPlayerPluginHandles) {
+    options.setCanvasRecorder(null);
+    options.setTimelineOverlay(null);
+  }
   options.setLoadedReplayName(null);
-  options.setTimelineOverlay(null);
   options.setStatsTimeline(null);
   options.setStatsFrameLookup(null);
   options.setStatRegistry(createStatRegistry(null));
@@ -133,6 +143,56 @@ export async function loadReplayBundleForDisplay(
     options.getReplayLoadModal()?.show(source.name, "Parsing replay...");
     const loadedReplay = await bundlePromise;
     const { replay } = loadedReplay;
+    const existingReplayPlayer = options.getReplayPlayer();
+
+    if (existingReplayPlayer) {
+      clearDisplayedReplay(options, {
+        destroyPlayer: false,
+        clearPlayerPluginHandles: false,
+      });
+      const adapter = new SubtrActorPlayer(loadedReplay.raw as never);
+      await existingReplayPlayer.replaceReplay(adapter, replay, { preservePlayback: false });
+
+      options.setStatsTimeline(loadedReplay.statsTimeline);
+      options.setStatsFrameLookup(loadedReplay.statsFrameLookup);
+      options.setStatRegistry(createStatRegistry(null));
+      options.setReplayPlayer(existingReplayPlayer);
+      options.syncBoostPadOverlayPlugin();
+
+      options.setupActiveModules();
+      options.setUnsubscribe(existingReplayPlayer.subscribe(options.renderSnapshot));
+
+      const config = options.getInitialConfig();
+      if (config) {
+        options.setApplyingConfig(true);
+        try {
+          options.applyConfigToReplayPlayer(config);
+        } finally {
+          options.setApplyingConfig(false);
+        }
+      }
+
+      options.getCameraControlsController()?.populateAttachedPlayerOptions(replay.players);
+      elements.emptyState.hidden = true;
+      elements.statusReadout.textContent = `Loaded ${source.name}`;
+      options.setLoadedReplayName(source.name);
+      elements.playersReadout.textContent = replay.players.map((player) => player.name).join(", ");
+      elements.framesReadout.textContent = `${replay.frameCount}`;
+      options.renderTimelineEventCount();
+      options.renderMechanicsTimelineControls();
+      options.resetEventPlaylistWindow();
+      options.renderEventPlaylistWindow();
+      options.setTransportEnabled(true);
+      options.getCameraControlsController()?.syncAvailability(existingReplayPlayer.getState());
+      options.renderSnapshot(existingReplayPlayer.getState());
+      options.renderStatsWindows(existingReplayPlayer.getState().frameIndex);
+      options.renderScoreboard(existingReplayPlayer.getState().frameIndex);
+      options.syncEventPlaylistTimeline(existingReplayPlayer.getState(), { forceScroll: true });
+      options.renderModuleSettings();
+      options.syncRecordingWindow();
+      options.getReplayLoadModal()?.hide();
+      return;
+    }
 
     const timelineOverlay = createTimelineOverlayPlugin({
       replayEventsLabel: "Replay",

--- a/js/stat-evaluation-player/src/replayDisplayRuntime.ts
+++ b/js/stat-evaluation-player/src/replayDisplayRuntime.ts
@@ -77,19 +77,13 @@ export interface ReplayDisplayRuntimeOptions {
   getCameraControlsController(): CameraControlsController | null;
 }
 
-export async function loadReplayBundleForDisplay(
-  source: ReplayInputSource,
-  bundlePromise: Promise<ReplayLoadBundle>,
-  options: ReplayDisplayRuntimeOptions,
-): Promise<void> {
-  const { elements } = options;
-  elements.statusReadout.textContent = source.preparingStatus;
-  elements.fileInput.disabled = true;
-  options.getReplayLoadModal()?.show(source.name, source.preparingStatus);
-  options.setTransportEnabled(false);
-  options.getCameraControlsController()?.syncAvailability();
-  elements.emptyState.hidden = false;
+function setReplayPlayerCanvasPending(player: StatsReplayPlayer, pending: boolean): void {
+  const { style } = player.renderer.domElement;
+  style.visibility = pending ? "hidden" : "";
+  style.pointerEvents = pending ? "none" : "";
+}
 
+function clearDisplayedReplay(options: ReplayDisplayRuntimeOptions): void {
   const unsubscribe = options.getUnsubscribe();
   if (unsubscribe) {
     unsubscribe();
@@ -116,15 +110,29 @@ export async function loadReplayBundleForDisplay(
   options.renderEventPlaylistWindow();
   options.renderModuleSettings();
   options.syncRecordingWindow();
+}
+
+export async function loadReplayBundleForDisplay(
+  source: ReplayInputSource,
+  bundlePromise: Promise<ReplayLoadBundle>,
+  options: ReplayDisplayRuntimeOptions,
+): Promise<void> {
+  const { elements } = options;
+  let pendingReplayPlayer: StatsReplayPlayer | null = null;
+
+  elements.statusReadout.textContent = source.preparingStatus;
+  elements.fileInput.disabled = true;
+  options.getReplayLoadModal()?.show(source.name, source.preparingStatus);
+  options.setTransportEnabled(false);
+  options.getCameraControlsController()?.syncAvailability();
+  elements.emptyState.hidden = options.getReplayPlayer() !== null;
+  options.getReplayPlayer()?.pause();
 
   try {
     elements.statusReadout.textContent = "Parsing replay...";
     options.getReplayLoadModal()?.show(source.name, "Parsing replay...");
     const loadedReplay = await bundlePromise;
     const { replay } = loadedReplay;
-    options.setStatsTimeline(loadedReplay.statsTimeline);
-    options.setStatsFrameLookup(loadedReplay.statsFrameLookup);
-    options.setStatRegistry(createStatRegistry(null));
 
     const timelineOverlay = createTimelineOverlayPlugin({
       replayEventsLabel: "Replay",
@@ -182,6 +190,17 @@ export async function loadReplayBundleForDisplay(
         fromReplayPlayerPlugin(timelineOverlay),
       ],
     }) as StatsReplayPlayer;
+    pendingReplayPlayer = replayPlayer;
+    setReplayPlayerCanvasPending(replayPlayer, true);
+    await replayPlayer.ready;
+
+    clearDisplayedReplay(options);
+    pendingReplayPlayer = null;
+    setReplayPlayerCanvasPending(replayPlayer, false);
+
+    options.setStatsTimeline(loadedReplay.statsTimeline);
+    options.setStatsFrameLookup(loadedReplay.statsFrameLookup);
+    options.setStatRegistry(createStatRegistry(null));
     if (import.meta.env.DEV) {
       // Console/debug handle (dev server only): inspect playback, A/B camera or
       // motion-interpolation settings live, sample mesh positions, etc.
@@ -223,9 +242,11 @@ export async function loadReplayBundleForDisplay(
     options.getReplayLoadModal()?.hide();
   } catch (error) {
     options.getReplayLoadModal()?.hide();
-    options.getReplayPlayer()?.destroy();
-    options.setReplayPlayer(null);
-    options.setCanvasRecorder(null);
+    pendingReplayPlayer?.destroy();
+    if (!options.getReplayPlayer()) {
+      elements.emptyState.hidden = false;
+      options.setCanvasRecorder(null);
+    }
     options.syncRecordingWindow();
     throw error;
   } finally {


### PR DESCRIPTION
## Summary
- add ReplayPlayer.replaceReplay(...) so replay data can be swapped without replacing the canvas, renderer, arena, camera controls, or player instance
- reset replay-specific actor/effect/timeline state in ActorManager for safe in-place reuse
- make the shared playlist player and stats review loader reuse the active ReplayPlayer across replay boundaries

## Test
- just check