### PR TITLE
[codex] Fix sequential 50/50 detection

### DIFF
--- a/src/stats/calculators/fifty_fifty_state.rs
+++ b/src/stats/calculators/fifty_fifty_state.rs
@@ -5,7 +5,14 @@ use super::*;
 pub struct FiftyFiftyStateCalculator {
     active_event: Option<ActiveFiftyFifty>,
     last_resolved_event: Option<FiftyFiftyEvent>,
+    pending_initial_touch: Option<PendingFiftyFiftyTouch>,
     kickoff_touch_window_open: bool,
+}
+
+#[derive(Clone)]
+struct PendingFiftyFiftyTouch {
+    touch: TouchEvent,
+    is_kickoff: bool,
 }
 
 impl FiftyFiftyStateCalculator {
@@ -15,6 +22,7 @@ impl FiftyFiftyStateCalculator {
 
     fn reset(&mut self) {
         self.active_event = None;
+        self.pending_initial_touch = None;
     }
 
     fn maybe_resolve_active_event(
@@ -80,6 +88,48 @@ impl FiftyFiftyStateCalculator {
         active_event.last_touch_frame = touch.frame;
     }
 
+    fn touch_pair_in_initial_window(previous: &TouchEvent, current: &TouchEvent) -> bool {
+        current.frame >= previous.frame
+            && current.time >= previous.time
+            && current.time - previous.time <= FIFTY_FIFTY_CONTINUATION_TOUCH_WINDOW_SECONDS
+    }
+
+    fn contested_touch_from_pending(
+        frame: &FrameInfo,
+        players: &PlayerFrameState,
+        pending: &PendingFiftyFiftyTouch,
+        touch_events: &[TouchEvent],
+        is_kickoff: bool,
+    ) -> Option<ActiveFiftyFifty> {
+        let latest_opposing_touch = touch_events
+            .iter()
+            .filter(|touch| touch.team_is_team_0 != pending.touch.team_is_team_0)
+            .filter(|touch| Self::touch_pair_in_initial_window(&pending.touch, touch))
+            .max_by(|left, right| TouchEvent::timestamp_ordering(left, right))?;
+
+        let combined_touches = vec![pending.touch.clone(), latest_opposing_touch.clone()];
+        let mut active = FiftyFiftyCalculator::contested_touch(
+            frame,
+            players,
+            &combined_touches,
+            pending.is_kickoff || is_kickoff,
+        )?;
+        active.start_time = pending.touch.time.min(latest_opposing_touch.time);
+        active.start_frame = pending.touch.frame.min(latest_opposing_touch.frame);
+        Some(active)
+    }
+
+    fn pending_touch_from_events(
+        touch_events: &[TouchEvent],
+        is_kickoff: bool,
+    ) -> Option<PendingFiftyFiftyTouch> {
+        touch_events
+            .iter()
+            .max_by(|left, right| TouchEvent::timestamp_ordering(left, right))
+            .cloned()
+            .map(|touch| PendingFiftyFiftyTouch { touch, is_kickoff })
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn update(
         &mut self,
@@ -95,7 +145,7 @@ impl FiftyFiftyStateCalculator {
             self.kickoff_touch_window_open = true;
         }
 
-        if !live_play_state.is_live_play {
+        if !live_play_state.counts_toward_player_motion() {
             self.reset();
             return FiftyFiftyState {
                 active_event: None,
@@ -135,8 +185,30 @@ impl FiftyFiftyStateCalculator {
                     &touch_state.touch_events,
                     self.kickoff_touch_window_open,
                 );
+                if self.active_event.is_some() {
+                    self.pending_initial_touch = None;
+                }
             }
         } else if has_touch {
+            if self.active_event.is_none() {
+                if let Some(pending) = self.pending_initial_touch.as_ref() {
+                    self.active_event = Self::contested_touch_from_pending(
+                        frame,
+                        players,
+                        pending,
+                        &touch_state.touch_events,
+                        self.kickoff_touch_window_open,
+                    );
+                }
+                if self.active_event.is_some() {
+                    self.pending_initial_touch = None;
+                } else {
+                    self.pending_initial_touch = Self::pending_touch_from_events(
+                        &touch_state.touch_events,
+                        self.kickoff_touch_window_open,
+                    );
+                }
+            }
             if let Some(active_event) = self.active_event.as_mut() {
                 Self::update_active_last_touch_from_continuation(
                     frame,

--- a/src/stats/calculators/fifty_fifty_state_tests.rs
+++ b/src/stats/calculators/fifty_fifty_state_tests.rs
@@ -25,6 +25,57 @@ fn touch(frame: usize, time: f32, player: PlayerId, team_is_team_0: bool) -> Tou
     }
 }
 
+fn rigid_body(position: glam::Vec3) -> boxcars::RigidBody {
+    boxcars::RigidBody {
+        sleeping: false,
+        location: glam_to_vec(&position),
+        rotation: boxcars::Quaternion {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 1.0,
+        },
+        linear_velocity: Some(glam_to_vec(&glam::Vec3::ZERO)),
+        angular_velocity: Some(glam_to_vec(&glam::Vec3::ZERO)),
+    }
+}
+
+fn player(player_id: PlayerId, is_team_0: bool, position: glam::Vec3) -> PlayerSample {
+    PlayerSample {
+        player_id,
+        is_team_0,
+        hitbox: default_car_hitbox(),
+        rigid_body: Some(rigid_body(position)),
+        boost_amount: None,
+        last_boost_amount: None,
+        boost_active: false,
+        dodge_active: false,
+        powerslide_active: false,
+        match_goals: None,
+        match_assists: None,
+        match_saves: None,
+        match_shots: None,
+        match_score: None,
+    }
+}
+
+fn two_player_state(team_zero_player: &PlayerId, team_one_player: &PlayerId) -> PlayerFrameState {
+    PlayerFrameState {
+        players: vec![
+            player(
+                team_zero_player.clone(),
+                true,
+                glam::Vec3::new(0.0, -100.0, 0.0),
+            ),
+            player(
+                team_one_player.clone(),
+                false,
+                glam::Vec3::new(0.0, 100.0, 0.0),
+            ),
+        ],
+    }
+}
+
 fn active_event(team_zero_player: PlayerId) -> ActiveFiftyFifty {
     ActiveFiftyFifty {
         start_time: 1.0,
@@ -48,11 +99,104 @@ fn active_event(team_zero_player: PlayerId) -> ActiveFiftyFifty {
 }
 
 #[test]
+fn sequential_opposing_touches_start_fifty_fifty_within_short_window() {
+    let team_zero_player = PlayerId::Steam(1);
+    let team_one_player = PlayerId::Steam(2);
+    let players = two_player_state(&team_zero_player, &team_one_player);
+    let mut calculator = FiftyFiftyStateCalculator::new();
+
+    let first_state = calculator.update(
+        &frame(100, 1.0),
+        &GameplayState::default(),
+        &BallFrameState::default(),
+        &players,
+        &TouchState {
+            touch_events: vec![touch(100, 1.0, team_zero_player.clone(), true)],
+            ..TouchState::default()
+        },
+        &PossessionState::default(),
+        &LivePlayState::active_play(),
+    );
+    assert!(first_state.active_event.is_none());
+
+    let second_state = calculator.update(
+        &frame(103, 1.08),
+        &GameplayState::default(),
+        &BallFrameState::default(),
+        &players,
+        &TouchState {
+            touch_events: vec![touch(103, 1.08, team_one_player.clone(), false)],
+            ..TouchState::default()
+        },
+        &PossessionState::default(),
+        &LivePlayState::active_play(),
+    );
+
+    let active = second_state
+        .active_event
+        .expect("expected sequential opposing touches to start a 50/50");
+    assert_eq!(active.start_frame, 100);
+    assert_eq!(active.start_time, 1.0);
+    assert_eq!(active.team_zero_player, Some(team_zero_player));
+    assert_eq!(active.team_one_player, Some(team_one_player));
+    assert_eq!(active.team_zero_touch_frame, Some(100));
+    assert_eq!(active.team_one_touch_frame, Some(103));
+}
+
+#[test]
+fn sequential_kickoff_touches_keep_kickoff_phase_from_first_touch() {
+    let team_zero_player = PlayerId::Steam(1);
+    let team_one_player = PlayerId::Steam(2);
+    let players = two_player_state(&team_zero_player, &team_one_player);
+    let mut calculator = FiftyFiftyStateCalculator::new();
+    let kickoff_gameplay = GameplayState {
+        ball_has_been_hit: Some(false),
+        ..GameplayState::default()
+    };
+
+    calculator.update(
+        &frame(100, 1.0),
+        &kickoff_gameplay,
+        &BallFrameState::default(),
+        &players,
+        &TouchState {
+            touch_events: vec![touch(100, 1.0, team_zero_player, true)],
+            ..TouchState::default()
+        },
+        &PossessionState::default(),
+        &LivePlayState {
+            gameplay_phase: GameplayPhase::KickoffWaitingForTouch,
+            is_live_play: false,
+        },
+    );
+    let state = calculator.update(
+        &frame(103, 1.08),
+        &GameplayState::default(),
+        &BallFrameState::default(),
+        &players,
+        &TouchState {
+            touch_events: vec![touch(103, 1.08, team_one_player, false)],
+            ..TouchState::default()
+        },
+        &PossessionState::default(),
+        &LivePlayState::active_play(),
+    );
+
+    assert!(
+        state
+            .active_event
+            .expect("expected delayed kickoff contact to start a 50/50")
+            .is_kickoff
+    );
+}
+
+#[test]
 fn continuation_touch_updates_last_touch_from_latest_touch_event_not_sample_frame() {
     let player = PlayerId::Steam(1);
     let mut calculator = FiftyFiftyStateCalculator {
         active_event: Some(active_event(player.clone())),
         last_resolved_event: None,
+        pending_initial_touch: None,
         kickoff_touch_window_open: false,
     };
 


### PR DESCRIPTION
## Summary

- allow the 50/50 state calculator to start contests from sequential opposing touches inside the existing short touch window
- keep kickoff 50/50 attribution when the first touch lands during kickoff-waiting frames
- add regression coverage for sequential open-play and kickoff touches

## Root cause

50/50 detection only started when both teams had touch events in the same sampled frame. Kickoff contacts often arrive one or more frames apart, and the first touch can occur while gameplay is still classified as kickoff waiting, so those contests were dropped before they could resolve.

## Validation

- `cargo test -q stats::calculators::fifty_fifty_state`
- `just check`
