### PR TITLE
Support clip perspective in mechanics review playlists

### DIFF
--- a/js/stat-evaluation-player/src/cameraControls.ts
+++ b/js/stat-evaluation-player/src/cameraControls.ts
@@ -124,6 +124,25 @@ export class CameraControlsController {
     return mode === "player" ? null : mode === "on";
   }
 
+  followPlayerWithReplayCamera(
+    playerId: string,
+    options: { ballCam?: BallCamMode; usePlayerCameraSettings?: boolean } = {},
+  ): void {
+    const replayPlayer = this.options.getReplayPlayer();
+    if (!replayPlayer) {
+      return;
+    }
+
+    replayPlayer.setAttachedPlayer(playerId);
+    replayPlayer.setCameraViewMode("follow");
+    if (options.usePlayerCameraSettings !== false) {
+      replayPlayer.setCustomCameraSettings(null);
+    }
+    this.setBallCamMode(options.ballCam ?? "player");
+    this.lastFreeCameraPreset = null;
+    this.options.requestConfigSync();
+  }
+
   private renderBallCamButtons(): void {
     const { ballCamOffButton, ballCamOnButton, ballCamPlayerButton } = this.options.elements;
     const buttons: ReadonlyArray<[BallCamMode, HTMLButtonElement]> = [

--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -679,17 +679,18 @@ export function mountStatEvaluationPlayer(
     },
     replayLoads: mechanicsReviewReplayLoadsController,
     getReplayPlayer: () => replayPlayer,
-    clearFreeCameraPreset() {
-      if (cameraControlsController) {
-        cameraControlsController.freeCameraPreset = null;
-      }
-    },
     resetReplayTransitionControls() {
       skipPostGoalTransitions.checked = false;
       skipKickoffs.checked = false;
     },
     activateTimelineSource: activateMechanicsReviewTimelineSource,
     loadReplayBundleForDisplay,
+    applyClipPerspective(options) {
+      cameraControlsController?.followPlayerWithReplayCamera(options.playerId, {
+        ballCam: options.ballCam,
+        usePlayerCameraSettings: options.usePlayerCameraSettings,
+      });
+    },
     showReplayLoadingWindow() {
       windowCommands.showWindow("replay-loading");
     },

--- a/js/stat-evaluation-player/src/mechanicsReview.test.ts
+++ b/js/stat-evaluation-player/src/mechanicsReview.test.ts
@@ -2,11 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  parseMechanicsReviewPlaylist,
+  resolveMechanicsReviewPerspectivePlayerTrack,
   resolveMechanicsReviewBoundTime,
   resolveMechanicsReviewTargetTime,
   type MechanicsReviewItem,
   type MechanicsReviewTimingReplay,
 } from "./mechanicsReview.ts";
+import type { ReplayPlayerTrack } from "@rlrml/player";
 
 function replayWithFrame(frameIndex: number, time: number): MechanicsReviewTimingReplay {
   const frames = Array.from({ length: frameIndex + 1 }, (_, index) => ({ time: index / 30 }));
@@ -90,3 +93,87 @@ test("review playlist frame bounds use replay frame playback time directly", () 
 
   assert.equal(resolveMechanicsReviewBoundTime(item, item.start, replay), 63);
 });
+
+test("review playlists preserve optional clip perspective", () => {
+  const playlist = parseMechanicsReviewPlaylist({
+    items: [
+      {
+        replay: "replay-id",
+        start: { kind: "time", value: 1 },
+        end: { kind: "time", value: 2 },
+        perspective: {
+          kind: "player",
+          playerId: "Steam:76561198000000000",
+          playerName: "Scorer",
+          ballCam: "player",
+          usePlayerCameraSettings: true,
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(playlist.items[0]?.perspective, {
+    kind: "player",
+    playerId: "Steam:76561198000000000",
+    playerName: "Scorer",
+    ballCam: "player",
+    usePlayerCameraSettings: true,
+  });
+});
+
+test("review playlist perspectives reject invalid ball cam modes", () => {
+  assert.throws(
+    () =>
+      parseMechanicsReviewPlaylist({
+        items: [
+          {
+            replay: "replay-id",
+            start: { kind: "time", value: 1 },
+            end: { kind: "time", value: 2 },
+            perspective: {
+              kind: "player",
+              playerName: "Scorer",
+              ballCam: "sometimes",
+            },
+          },
+        ],
+      }),
+    /perspective ballCam/,
+  );
+});
+
+test("review clip perspectives match exact replay track ids", () => {
+  const track = playerTrack("Steam:76561198000000000", "Scorer");
+  assert.equal(
+    resolveMechanicsReviewPerspectivePlayerTrack(
+      { kind: "player", playerId: "Steam:76561198000000000" },
+      [track],
+    )?.id,
+    track.id,
+  );
+});
+
+test("review clip perspectives fall back to player name when ids differ", () => {
+  const track = playerTrack("replay-track-id", "Known Alias");
+  assert.equal(
+    resolveMechanicsReviewPerspectivePlayerTrack(
+      {
+        kind: "player",
+        playerId: "source-event-id",
+        playerName: "Known Alias",
+      },
+      [track],
+    )?.id,
+    track.id,
+  );
+});
+
+function playerTrack(id: string, name: string): ReplayPlayerTrack {
+  return {
+    id,
+    name,
+    isTeamZero: true,
+    cameraSettings: {},
+    frames: [],
+  } as unknown as ReplayPlayerTrack;
+}

--- a/js/stat-evaluation-player/src/mechanicsReview.ts
+++ b/js/stat-evaluation-player/src/mechanicsReview.ts
@@ -1,4 +1,4 @@
-import type { PlaylistManifestPage } from "@rlrml/player";
+import type { PlaylistManifestPage, ReplayPlayerTrack } from "@rlrml/player";
 import type { ReplayLoadBundle, ReplayLoadProgress } from "./replayLoader.ts";
 import { formatMechanicKind } from "./timelineMarkers.ts";
 
@@ -17,6 +17,16 @@ export interface MechanicsReviewTimingReplay {
 export interface MechanicsReviewPlaybackConfig {
   timeBase?: MechanicsReviewTimeBase;
   [key: string]: unknown;
+}
+
+export type MechanicsReviewBallCamMode = "off" | "on" | "player";
+
+export interface MechanicsReviewClipPerspective {
+  kind: "player";
+  playerId?: string;
+  playerName?: string;
+  ballCam?: MechanicsReviewBallCamMode;
+  usePlayerCameraSettings?: boolean;
 }
 
 export interface MechanicsReviewReplay {
@@ -51,6 +61,7 @@ export interface MechanicsReviewItem {
   start: MechanicsReviewPlaybackBound;
   end: MechanicsReviewPlaybackBound;
   label?: string;
+  perspective?: MechanicsReviewClipPerspective;
   meta?: MechanicsReviewItemMeta;
 }
 
@@ -175,6 +186,54 @@ function parseMechanicsReviewPlayback(value: unknown): MechanicsReviewPlaybackCo
   };
 }
 
+function parseMechanicsReviewPerspective(
+  value: unknown,
+  itemNumber: number,
+): MechanicsReviewClipPerspective | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new Error(`Review item ${itemNumber} perspective must be an object.`);
+  }
+  if (value.kind !== "player") {
+    throw new Error(`Review item ${itemNumber} perspective kind must be "player".`);
+  }
+  const playerId =
+    typeof value.playerId === "string" && value.playerId.trim() ? value.playerId.trim() : undefined;
+  const playerName =
+    typeof value.playerName === "string" && value.playerName.trim()
+      ? value.playerName.trim()
+      : undefined;
+  if (!playerId && !playerName) {
+    throw new Error(`Review item ${itemNumber} player perspective needs playerId or playerName.`);
+  }
+  if (
+    value.ballCam !== undefined &&
+    value.ballCam !== "off" &&
+    value.ballCam !== "on" &&
+    value.ballCam !== "player"
+  ) {
+    throw new Error(`Review item ${itemNumber} perspective ballCam must be off, on, or player.`);
+  }
+  if (
+    value.usePlayerCameraSettings !== undefined &&
+    typeof value.usePlayerCameraSettings !== "boolean"
+  ) {
+    throw new Error(
+      `Review item ${itemNumber} perspective usePlayerCameraSettings must be boolean.`,
+    );
+  }
+
+  return {
+    kind: "player",
+    playerId,
+    playerName,
+    ballCam: value.ballCam,
+    usePlayerCameraSettings: value.usePlayerCameraSettings,
+  };
+}
+
 export function parseMechanicsReviewPlaylist(value: unknown): MechanicsReviewPlaylist {
   if (!isRecord(value) || !Array.isArray(value.items)) {
     throw new Error("Review playlist must contain an items array.");
@@ -195,6 +254,7 @@ export function parseMechanicsReviewPlaylist(value: unknown): MechanicsReviewPla
       start,
       end,
       label: typeof rawItem.label === "string" ? rawItem.label : undefined,
+      perspective: parseMechanicsReviewPerspective(rawItem.perspective, index + 1),
       meta: isRecord(rawItem.meta) ? rawItem.meta : undefined,
     };
   });
@@ -475,14 +535,35 @@ export function getMechanicsReviewItemLabel(item: MechanicsReviewItem, index: nu
   );
 }
 
-export function getMechanicsReviewPlayerId(item: MechanicsReviewItem): string | null {
-  if (typeof item.meta?.playerId === "string") {
-    return item.meta.playerId;
+export function getMechanicsReviewPlayerName(item: MechanicsReviewItem): string | null {
+  if (typeof item.meta?.playerName === "string" && item.meta.playerName.trim()) {
+    return item.meta.playerName.trim();
   }
-  if (isRecord(item.meta?.target) && typeof item.meta.target.playerId === "string") {
-    return item.meta.target.playerId;
+  if (isRecord(item.meta?.target) && typeof item.meta.target.playerName === "string") {
+    const playerName = item.meta.target.playerName.trim();
+    return playerName ? playerName : null;
   }
   return null;
+}
+
+export function resolveMechanicsReviewPerspectivePlayerTrack(
+  perspective: MechanicsReviewClipPerspective | undefined,
+  players: readonly ReplayPlayerTrack[],
+): ReplayPlayerTrack | null {
+  if (!perspective) {
+    return null;
+  }
+  if (perspective.playerId) {
+    const exact = players.find((player) => player.id === perspective.playerId);
+    if (exact) {
+      return exact;
+    }
+  }
+
+  const playerName = perspective.playerName?.toLowerCase();
+  return playerName
+    ? (players.find((player) => player.name.trim().toLowerCase() === playerName) ?? null)
+    : null;
 }
 
 export function getMechanicsReviewMechanicLabel(item: MechanicsReviewItem): string {

--- a/js/stat-evaluation-player/src/mechanicsReviewWindow.ts
+++ b/js/stat-evaluation-player/src/mechanicsReviewWindow.ts
@@ -6,12 +6,14 @@ import {
   getMechanicsReviewCategoryLabel,
   getMechanicsReviewItemLabel,
   getMechanicsReviewMechanicLabel,
-  getMechanicsReviewPlayerId,
+  getMechanicsReviewPlayerName,
   parseMechanicsReviewPlaylistJson,
+  resolveMechanicsReviewPerspectivePlayerTrack,
   resolveMechanicsReviewBoundTime,
   resolveMechanicsReviewTargetTime,
   resolveMechanicsReviewUrl,
   type ActiveMechanicsReview,
+  type MechanicsReviewBallCamMode,
   type MechanicsReviewItem,
   type MechanicsReviewPlaybackBound,
   type MechanicsReviewPlaylist,
@@ -55,13 +57,17 @@ export interface MechanicsReviewWindowOptions {
   readonly elements: MechanicsReviewWindowElements;
   readonly replayLoads: MechanicsReviewReplayLoadsController;
   getReplayPlayer(): StatsReplayPlayer | null;
-  clearFreeCameraPreset(): void;
   resetReplayTransitionControls(): void;
   activateTimelineSource(item: MechanicsReviewItem): void;
   loadReplayBundleForDisplay(
     source: MechanicsReviewReplaySource,
     bundlePromise: Promise<ReplayLoadBundle>,
   ): Promise<void>;
+  applyClipPerspective(options: {
+    playerId: string;
+    ballCam?: MechanicsReviewBallCamMode;
+    usePlayerCameraSettings?: boolean;
+  }): void;
   showReplayLoadingWindow(): void;
 }
 
@@ -328,12 +334,19 @@ export class MechanicsReviewWindowController {
         throw new Error("Review item has an empty playback range.");
       }
 
-      const playerId = getMechanicsReviewPlayerId(item);
       const activeReplayPlayer = this.options.getReplayPlayer();
-      if (playerId && activeReplayPlayer?.replay.players.some((player) => player.id === playerId)) {
-        activeReplayPlayer.setAttachedPlayer(playerId);
-        activeReplayPlayer.setCameraViewMode("follow");
-        this.options.clearFreeCameraPreset();
+      const playerTrack = activeReplayPlayer
+        ? resolveMechanicsReviewPerspectivePlayerTrack(
+            item.perspective,
+            activeReplayPlayer.replay.players,
+          )
+        : null;
+      if (playerTrack) {
+        this.options.applyClipPerspective({
+          playerId: playerTrack.id,
+          ballCam: item.perspective?.ballCam,
+          usePlayerCameraSettings: item.perspective?.usePlayerCameraSettings,
+        });
       }
 
       this.options.resetReplayTransitionControls();
@@ -460,14 +473,15 @@ export class MechanicsReviewWindowController {
   }
 
   private getPlayerName(item: MechanicsReviewItem): string {
-    if (typeof item.meta?.playerName === "string" && item.meta.playerName.trim()) {
-      return item.meta.playerName;
+    const playerName = getMechanicsReviewPlayerName(item);
+    if (playerName) {
+      return playerName;
     }
-    const playerId = getMechanicsReviewPlayerId(item);
-    return playerId
-      ? (this.options.getReplayPlayer()?.replay.players.find((player) => player.id === playerId)
-          ?.name ?? playerId)
-      : "--";
+
+    const replayPlayers = this.options.getReplayPlayer()?.replay.players ?? [];
+    return (
+      resolveMechanicsReviewPerspectivePlayerTrack(item.perspective, replayPlayers)?.name ?? "--"
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds an optional generic `perspective` object to mechanics review playlist items.
- Supports player perspectives by exact replay player id, with player-name fallback when the producer provides a display name.
- Applies per-clip camera parameters when the active clip changes, including ball cam mode and whether to use replay camera settings.

## Notes
- This intentionally does not know about Rocket Sense event ids, platforms, or playlist semantics. Producers decide what perspective metadata to emit.

## Validation
- `./node_modules/.bin/prettier --write stat-evaluation-player/src/mechanicsReview.ts stat-evaluation-player/src/mechanicsReviewWindow.ts stat-evaluation-player/src/cameraControls.ts stat-evaluation-player/src/main.ts stat-evaluation-player/src/mechanicsReview.test.ts`
- `./node_modules/.bin/eslint stat-evaluation-player/src/mechanicsReview.ts stat-evaluation-player/src/mechanicsReviewWindow.ts stat-evaluation-player/src/cameraControls.ts stat-evaluation-player/src/main.ts stat-evaluation-player/src/mechanicsReview.test.ts --max-warnings=0`
- `./node_modules/.bin/tsx --tsconfig tsconfig.test.json --test src/mechanicsReview.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `nix shell nixpkgs#wasm-pack --command bash -lc 'cd /home/imalison/Projects/subtr-actor/.worktrees/event-review-associated-player-perspective/js/stat-evaluation-player && npm test'`
