### PR TITLE
Harden CI release build cargo fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_HTTP_MULTIPLEXING: "false"
   RUN_FULL_REPLAY_TESTS: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.full_replay_tests) }}
 
 jobs:
@@ -134,7 +135,18 @@ jobs:
         rustup default stable
 
     - name: Build release
-      run: cargo build --release --verbose
+      shell: bash
+      run: |
+        set -euo pipefail
+        for attempt in 1 2 3; do
+          if cargo build --release --verbose; then
+            exit 0
+          fi
+          if [[ "$attempt" == "3" ]]; then
+            exit 1
+          fi
+          sleep $((attempt * 10))
+        done
 
   player-package:
     name: Player package


### PR DESCRIPTION
## Summary
- disable Cargo HTTP multiplexing in CI to avoid the crates.io HTTP/2 framing failure seen in the release build job
- retry the release build up to three times before failing

## Verification
- ruby YAML parse over .github/workflows/*.yml
- just check
- CARGO_HTTP_MULTIPLEXING=false cargo build --release --verbose

Fixes the failed CI run https://github.com/rlrml/subtr-actor/actions/runs/27809865934, where the Rust release build failed fetching phf with curl error 16.