### PR TITLE
[codex] Defer replay playback until player readiness

### DIFF
--- a/js/player/src/player/ReplayPlayer.ts
+++ b/js/player/src/player/ReplayPlayer.ts
@@ -243,6 +243,7 @@ export class ReplayPlayer extends EventTarget {
   private animationFrameId: number | null = null;
   private disposed = false;
   private playing = false;
+  private readyResolved = false;
   private speed: number;
   private loop: boolean;
   private currentTime = 0;
@@ -356,7 +357,9 @@ export class ReplayPlayer extends EventTarget {
         console.warn("[player] arena load failed", e);
       }),
       this.prepareReplayAssets(),
-    ]).then(() => undefined);
+    ]).then(() => {
+      this.markReady();
+    });
 
     this.installResizeHandling();
     for (const definition of options.plugins ?? []) {
@@ -444,7 +447,10 @@ export class ReplayPlayer extends EventTarget {
     }
 
     this.seekInternal(options.currentTime ?? 0);
-    this.ready = this.prepareReplayAssets();
+    this.readyResolved = false;
+    this.ready = this.prepareReplayAssets().then(() => {
+      this.markReady();
+    });
     await this.ready;
 
     this.setupPlugins();
@@ -911,6 +917,14 @@ export class ReplayPlayer extends EventTarget {
       });
   }
 
+  private markReady(): void {
+    this.readyResolved = true;
+    // Playback may have been requested before async assets/effects were ready.
+    // Reset the clock baseline so the first real tick after readiness does not
+    // include the asset-loading delay as elapsed replay time.
+    this.lastTickAt = null;
+  }
+
   private updateReplayGameStates(): void {
     if (!this.replay) {
       this.liveGameState = null;
@@ -1124,7 +1138,7 @@ export class ReplayPlayer extends EventTarget {
 
     let timeChanged = false;
     let dt = 0;
-    if (this.playing) {
+    if (this.playing && this.readyResolved) {
       dt = this.lastTickAt === null ? 0 : Math.min(0.1, (now - this.lastTickAt) / 1000);
       this.lastTickAt = now;
       let next = this.currentTime + dt * this.speed;
@@ -1149,6 +1163,8 @@ export class ReplayPlayer extends EventTarget {
         timeChanged = this.skipPostGoalTransitionIfNeeded() || timeChanged;
         timeChanged = this.skipPastKickoffIfNeeded() || timeChanged;
       }
+    } else if (this.playing) {
+      this.lastTickAt = null;
     }
 
     this.render(dt);


### PR DESCRIPTION
## Summary
- keep ReplayPlayer playback intent immediately observable when `play()` or autoplay is used
- prevent the replay clock from advancing until async player readiness completes
- reset the tick baseline when readiness resolves so asset-loading time is not counted as replay time

## Why
Replay effects such as goal explosions are initialized as part of the player readiness lifecycle. Embedders should not need to await `player.ready` before calling `play()` just to make built-in effects reliable. The player now preserves that lifecycle internally.

## Validation
- `nix shell nixpkgs#wasm-pack --command npm --prefix js/player run check`
- `npm --prefix js/player test`
- `npm --prefix js run format:check`
- `npm --prefix js run lint`