### PR TITLE
Show emitted stats events automatically

### DIFF
--- a/js/stat-evaluation-player/src/eventTimelineSources.test.ts
+++ b/js/stat-evaluation-player/src/eventTimelineSources.test.ts
@@ -263,6 +263,150 @@ test("event playlist sources include generic stats event streams such as positio
   );
 });
 
+test("ball carry events fall back to generic event stream sources", () => {
+  const replay = {
+    frames: Array.from({ length: 13 }, (_, frame) => ({ time: frame })),
+    players: [{ id: "Steam:blue-id", name: "Blue" }],
+    timelineEvents: [],
+  } as ReplayModel;
+  const statsTimeline = createStatsTimeline({
+    events: {
+      ball_carry: [
+        {
+          player_id: { Steam: "blue-id" },
+          is_team_0: true,
+          kind: "carry",
+          start_position: [0, 0, 120],
+          end_position: [100, 0, 120],
+          start_frame: 2,
+          end_frame: 8,
+          start_time: 2,
+          end_time: 8,
+          duration: 6,
+          straight_line_distance: 100,
+          path_distance: 120,
+          average_horizontal_gap: 40,
+          average_vertical_gap: 35,
+          average_speed: 800,
+          touch_count: 2,
+          air_touch_count: 0,
+          air_dribble_origin: null,
+        },
+      ],
+    },
+  });
+  const ctx = { replay, statsTimeline } as StatModuleContext;
+  const timelineSources = getTestTimelineSources(ctx);
+  const ballCarrySource = timelineSources.find((source) => source.id === "stats-stream:ball_carry");
+
+  assert.ok(ballCarrySource);
+  assert.equal(ballCarrySource.group, "Event streams");
+  assert.equal(ballCarrySource.label, "Ball Carry");
+  assert.equal(ballCarrySource.count, 1);
+  assert.deepEqual(ballCarrySource.buildTimelineEvents(), []);
+  assert.deepEqual(
+    ballCarrySource.buildTimelineRanges?.().map((range) => range.label),
+    ["Blue ball carry"],
+  );
+
+  const playlistSources = getEventPlaylistSources(ctx, timelineSources);
+  const items = buildEventPlaylistItems({
+    sources: playlistSources,
+    activeSourceIds: new Set(["stats-stream:ball_carry"]),
+    replayPlayers: replay.players,
+  });
+
+  assert.deepEqual(
+    items.map((item) => ({
+      sourceId: item.sourceId,
+      sourceLabel: item.sourceLabel,
+      label: item.event.label,
+      shortLabel: item.event.shortLabel,
+      playerId: item.event.playerId,
+    })),
+    [
+      {
+        sourceId: "stats-stream:ball_carry",
+        sourceLabel: "Ball Carry",
+        label: "Blue ball carry | 6s",
+        shortLabel: "BC",
+        playerId: "Steam:blue-id",
+      },
+    ],
+  );
+});
+
+test("event sources include emitted streams missing from the canonical stream list", () => {
+  const replay = {
+    frames: Array.from({ length: 13 }, (_, frame) => ({ time: frame })),
+    players: [{ id: "Steam:blue-id", name: "Blue" }],
+    timelineEvents: [],
+  } as ReplayModel;
+  const statsTimeline = createStatsTimeline({
+    events: {
+      events: [
+        {
+          meta: {
+            id: "air_dribble:3:9:0",
+            stream: "air_dribble",
+            label: "Air Dribble",
+            scope: "player",
+            timing: {
+              type: "span",
+              start_time: 3,
+              start_frame: 3,
+              end_time: 9,
+              end_frame: 9,
+            },
+            primary_player: { Steam: "blue-id" },
+            secondary_player: undefined,
+            player_position: [100, 0, 300],
+            ball_position: [100, 0, 300],
+            team_is_team_0: true,
+            confidence: undefined,
+            properties: [],
+          },
+          payload: {
+            kind: "ball_carry",
+            payload: {
+              player_id: { Steam: "blue-id" },
+              is_team_0: true,
+              kind: "air_dribble",
+              start_position: [0, 0, 300],
+              end_position: [100, 0, 300],
+              start_frame: 3,
+              end_frame: 9,
+              start_time: 3,
+              end_time: 9,
+              duration: 6,
+              straight_line_distance: 100,
+              path_distance: 140,
+              average_horizontal_gap: 60,
+              average_vertical_gap: 120,
+              average_speed: 900,
+              touch_count: 3,
+              air_touch_count: 3,
+              air_dribble_origin: "ground_to_air",
+            },
+          },
+        } satisfies Event,
+      ],
+    },
+  });
+  const ctx = { replay, statsTimeline } as StatModuleContext;
+  const timelineSources = getTestTimelineSources(ctx);
+  const airDribbleSource = timelineSources.find(
+    (source) => source.id === "stats-stream:air_dribble",
+  );
+
+  assert.ok(airDribbleSource);
+  assert.equal(airDribbleSource.label, "Air Dribble");
+  assert.equal(airDribbleSource.count, 1);
+
+  const playlistSources = getEventPlaylistSources(ctx, timelineSources);
+  assert.ok(playlistSources.some((source) => source.id === "stats-stream:air_dribble"));
+});
+
 test("controlled play timeline source renders spans as timeline ranges", () => {
   const replay = {
     frames: Array.from({ length: 13 }, (_, frame) => ({

--- a/js/stat-evaluation-player/src/eventTimelineSources.ts
+++ b/js/stat-evaluation-player/src/eventTimelineSources.ts
@@ -11,31 +11,6 @@ import {
 
 const DEFAULT_UNSELECTED_EVENT_PLAYLIST_SOURCE_IDS = new Set(["module:touch", "module:powerslide"]);
 const DEFAULT_UNSELECTED_EVENT_PLAYLIST_SOURCE_PREFIXES = ["stats-stream:"] as const;
-const CURATED_STATS_EVENT_STREAM_IDS = new Set<string>([
-  "timeline",
-  "backboard",
-  "ceiling_shot",
-  "wall_aerial",
-  "wall_aerial_shot",
-  "center",
-  "flick",
-  "dodge_reset",
-  "double_tap",
-  "fifty_fifty",
-  "one_timer",
-  "pass",
-  "ball_carry",
-  "rush",
-  "dodge",
-  "speed_flip",
-  "half_flip",
-  "half_volley",
-  "wavedash",
-  "whiff",
-  "powerslide",
-  "touch",
-  "bump",
-]);
 const EVENT_PLAYLIST_PLAYER_COLORS = [
   "#3b82f6",
   "#06b6d4",
@@ -334,6 +309,11 @@ function formatGenericStatsEventLabel({
     return joinEventDetails([prefix, duration]);
   }
 
+  if (event.payload.kind === "ball_carry") {
+    const prefix = playerName ? `${playerName} ${streamLabel.toLowerCase()}` : streamLabel;
+    return joinEventDetails([prefix, duration]);
+  }
+
   if (event.payload.kind === "player_activity") {
     const state = titleCaseValue(payload.state);
     const prefix = playerName ? `${playerName} positioning` : streamLabel;
@@ -496,12 +476,20 @@ function buildGenericStatsEventSources(
   ctx: StatModuleContext,
   activeTimelineEventSourceIds: ReadonlySet<string>,
   toggleEventSource: (id: string, enabled: boolean) => void,
+  specializedStreamIds: ReadonlySet<string>,
 ): EventTimelineSource[] {
-  return STATS_EVENT_STREAM_COUNT_TYPES.flatMap((streamId) => {
+  const streamIds = [
+    ...new Set([
+      ...STATS_EVENT_STREAM_COUNT_TYPES,
+      ...statsEventEnvelopes(ctx.statsTimeline).map((event) => event.meta.stream),
+    ]),
+  ];
+
+  return streamIds.flatMap((streamId) => {
     const events = statsEventEnvelopes(ctx.statsTimeline).filter(
       (event) => event.meta.stream === streamId,
     );
-    if (CURATED_STATS_EVENT_STREAM_IDS.has(streamId) && events.length > 0) {
+    if (specializedStreamIds.has(streamId) && events.length > 0) {
       return [];
     }
 
@@ -536,6 +524,13 @@ function buildGenericStatsEventSources(
       },
     ];
   });
+}
+
+function getSpecializedStatsEventStreamIds(modules: readonly StatModule[]): Set<string> {
+  return new Set([
+    ...modules.filter((module) => module.getTimelineEvents).map((module) => module.id),
+    ...EVENT_TYPE_TIMELINE_KINDS,
+  ]);
 }
 
 function getEventTimelineMechanicKinds(): string[] {
@@ -630,7 +625,12 @@ export function getEventTimelineSources({
   }
 
   sources.push(
-    ...buildGenericStatsEventSources(ctx, activeTimelineEventSourceIds, toggleEventSource),
+    ...buildGenericStatsEventSources(
+      ctx,
+      activeTimelineEventSourceIds,
+      toggleEventSource,
+      getSpecializedStatsEventStreamIds(modules),
+    ),
   );
 
   for (const kind of getEventTimelineMechanicKinds()) {


### PR DESCRIPTION
## Summary
- derive stats-player event-window sources from emitted timeline event streams instead of a hand-maintained curated suppression list
- keep specialized event renderers where they already exist, while falling back to generic stream sources for newly emitted streams
- add regression coverage for ball carry and dynamically discovered air-dribble streams

## Root Cause
`ball_carry` was marked as curated, so the generic event-stream source was suppressed when events existed, but there was no dedicated Event types builder to replace it. That made the event disappear from the event window and playlist menu.

## Validation
- `npx tsx --tsconfig tsconfig.test.json --test src/eventTimelineSources.test.ts`
- `npm run check:tsc`
- `npx tsx --tsconfig tsconfig.test.json --test src/*.test.ts`
- pre-commit `cargo clippy --all-targets --all-features -- -D warnings`