### PR TITLE
Refine half-flip facing reversal detection

### DIFF
--- a/docs/event-definitions.html
+++ b/docs/event-definitions.html
@@ -114,7 +114,7 @@ ul.tight li { margin: .15rem 0; }
 <tr data-search="event event mechanic a shared event envelope with common metadata and a typed event payload."><td><a href="#event-event">Event</a></td><td><code>event</code></td><td class="summary">A shared event envelope with common metadata and a typed event payload.</td></tr>
 <tr data-search="flick flick mechanic a dodge-powered touch following a short controlled carry setup."><td><a href="#event-flick">Flick</a></td><td><code>flick</code></td><td class="summary">A dodge-powered touch following a short controlled carry setup.</td></tr>
 <tr data-search="flip reset flip_reset mechanic an on-ball dodge refresh that is confirmed when the player uses the gained dodge and touches the ball again before landing."><td><a href="#event-flip_reset">Flip Reset</a></td><td><code>flip_reset</code></td><td class="summary">An on-ball dodge refresh that is confirmed when the player uses the gained dodge and touches the ball again before landing.</td></tr>
-<tr data-search="half flip half_flip mechanic a dodge sequence that starts while driving backward and reorients the car to move forward."><td><a href="#event-half_flip">Half Flip</a></td><td><code>half_flip</code></td><td class="summary">A dodge sequence that starts while driving backward and reorients the car to move forward.</td></tr>
+<tr data-search="half flip half_flip mechanic a dodge sequence that cancels a flip into an opposite facing direction."><td><a href="#event-half_flip">Half Flip</a></td><td><code>half_flip</code></td><td class="summary">A dodge sequence that cancels a flip into an opposite facing direction.</td></tr>
 <tr data-search="half volley half_volley mechanic a fast touch shortly after the ball bounces off the floor, paired with a recent player dodge."><td><a href="#event-half_volley">Half Volley</a></td><td><code>half_volley</code></td><td class="summary">A fast touch shortly after the ball bounces off the floor, paired with a recent player dodge.</td></tr>
 <tr data-search="one timer one_timer mechanic a fast receiver touch from a completed pass that is immediately directed toward goal."><td><a href="#event-one_timer">One Timer</a></td><td><code>one_timer</code></td><td class="summary">A fast receiver touch from a completed pass that is immediately directed toward goal.</td></tr>
 <tr data-search="pass pass mechanic a same-team touch sequence where one player sends the ball to a different teammate."><td><a href="#event-pass">Pass</a></td><td><code>pass</code></td><td class="summary">A same-team touch sequence where one player sends the ball to a different teammate.</td></tr>
@@ -488,9 +488,9 @@ ul.tight li { margin: .15rem 0; }
 <li><code>flip_reset</code> via <code>DodgeResetNode</code> / <code>DodgeResetCalculator</code></li>
 </ul>
 </div>
-<div class="event" id="event-half_flip" data-search="half flip half_flip mechanic a dodge sequence that starts while driving backward and reorients the car to move forward.">
+<div class="event" id="event-half_flip" data-search="half flip half_flip mechanic a dodge sequence that cancels a flip into an opposite facing direction.">
 <div class="head"><h3>Half Flip</h3><code class="id">half_flip</code><span class="badge">Mechanic</span><a class="toplink" href="#contents">top ↑</a></div>
-<p class="summary">A dodge sequence that starts while driving backward and reorients the car to move forward.</p>
+<p class="summary">A dodge sequence that cancels a flip into an opposite facing direction.</p>
 <div class="section-label">Confidence</div>
 <div class="conf">
 <span class="badge">Approach <b>Unknown</b></span>
@@ -501,9 +501,9 @@ ul.tight li { margin: .15rem 0; }
 </div>
 <div class="section-label">Approach</div>
 <ul class="tight">
-<li>Start candidates on grounded dodge rising edges when the car is moving backward relative to its facing direction.</li>
-<li>Track reorientation during the evaluation window, including forward-vector reversal, alignment with the resulting velocity, and vertical flip evidence.</li>
-<li>Emit when the candidate shows enough reversal, reorientation, flip motion, and speed evidence to clear the confidence threshold.</li>
+<li>Start candidates on low grounded or low-air dodge rising edges.</li>
+<li>Track the car&#39;s forward vector through the evaluation window, including vertical flip evidence and final horizontal facing direction.</li>
+<li>Emit when the candidate has pitched through a flip, reaches and retains roughly opposite facing instead of rotating through a full end-over-end flip, and finishes with a meaningful horizontal facing direction.</li>
 </ul>
 <div class="section-label">Limitations</div>
 <p class="muted">None documented.</p>

--- a/docs/event-definitions.md
+++ b/docs/event-definitions.md
@@ -744,13 +744,13 @@ _None documented._
 
 **Summary**
 
-A dodge sequence that starts while driving backward and reorients the car to move forward.
+A dodge sequence that cancels a flip into an opposite facing direction.
 
 **Approach**
 
-- Start candidates on grounded dodge rising edges when the car is moving backward relative to its facing direction.
-- Track reorientation during the evaluation window, including forward-vector reversal, alignment with the resulting velocity, and vertical flip evidence.
-- Emit when the candidate shows enough reversal, reorientation, flip motion, and speed evidence to clear the confidence threshold.
+- Start candidates on low grounded or low-air dodge rising edges.
+- Track the car's forward vector through the evaluation window, including vertical flip evidence and final horizontal facing direction.
+- Emit when the candidate has pitched through a flip, reaches and retains roughly opposite facing instead of rotating through a full end-over-end flip, and finishes with a meaningful horizontal facing direction.
 
 **Limitations**
 

--- a/js/stat-evaluation-player/src/generated/HalfFlipEvent.ts
+++ b/js/stat-evaluation-player/src/generated/HalfFlipEvent.ts
@@ -2,6 +2,6 @@
 import type { RemoteIdTs } from "./RemoteIdTs.ts";
 
 /**
- * A dodge sequence starting while driving backward that reorients the car to move forward.
+ * A dodge sequence that cancels a flip into an opposite facing direction.
  */
 export type HalfFlipEvent = { time: number, frame: number, player: RemoteIdTs, is_team_0: boolean, start_position: [number, number, number], end_position: [number, number, number], start_speed: number, end_speed: number, start_backward_alignment: number, best_reorientation_alignment: number, best_forward_reversal: number, max_forward_vertical: number, confidence: number, };

--- a/src/stats/calculators/event_definition.rs
+++ b/src/stats/calculators/event_definition.rs
@@ -702,11 +702,11 @@ define_stats_event!(
     "half_flip",
     "Half Flip",
     EventCategory::Mechanic,
-    summary = "A dodge sequence that starts while driving backward and reorients the car to move forward.",
+    summary = "A dodge sequence that cancels a flip into an opposite facing direction.",
     approach = [
-        "Start candidates on grounded dodge rising edges when the car is moving backward relative to its facing direction.",
-        "Track reorientation during the evaluation window, including forward-vector reversal, alignment with the resulting velocity, and vertical flip evidence.",
-        "Emit when the candidate shows enough reversal, reorientation, flip motion, and speed evidence to clear the confidence threshold.",
+        "Start candidates on low grounded or low-air dodge rising edges.",
+        "Track the car's forward vector through the evaluation window, including vertical flip evidence and final horizontal facing direction.",
+        "Emit when the candidate has pitched through a flip and finishes with a meaningful horizontal facing direction roughly opposite the starting direction.",
     ]
 );
 define_stats_event!(

--- a/src/stats/calculators/event_definition.rs
+++ b/src/stats/calculators/event_definition.rs
@@ -706,7 +706,7 @@ define_stats_event!(
     approach = [
         "Start candidates on low grounded or low-air dodge rising edges.",
         "Track the car's forward vector through the evaluation window, including vertical flip evidence and final horizontal facing direction.",
-        "Emit when the candidate has pitched through a flip and finishes with a meaningful horizontal facing direction roughly opposite the starting direction.",
+        "Emit when the candidate has pitched through a flip, reaches and retains roughly opposite facing instead of rotating through a full end-over-end flip, and finishes with a meaningful horizontal facing direction.",
     ]
 );
 define_stats_event!(

--- a/src/stats/calculators/half_flip.rs
+++ b/src/stats/calculators/half_flip.rs
@@ -2,15 +2,13 @@ use super::*;
 
 const HALF_FLIP_EVALUATION_SECONDS: f32 = 0.65;
 const HALF_FLIP_MAX_CANDIDATE_SECONDS: f32 = 1.0;
-const HALF_FLIP_MAX_START_Z: f32 = PLAYER_GROUND_Z_THRESHOLD + 45.0;
-const HALF_FLIP_MIN_START_SPEED: f32 = 250.0;
-const HALF_FLIP_MIN_START_BACKWARD_ALIGNMENT: f32 = 0.55;
-const HALF_FLIP_MIN_REORIENTATION_ALIGNMENT: f32 = 0.60;
-const HALF_FLIP_MIN_FORWARD_REVERSAL: f32 = 0.55;
-const HALF_FLIP_MIN_FORWARD_VERTICAL: f32 = 0.22;
+const HALF_FLIP_MAX_START_Z: f32 = 90.0;
+const HALF_FLIP_MIN_FORWARD_REVERSAL: f32 = 0.75;
+const HALF_FLIP_MIN_FINAL_FORWARD_HORIZONTAL: f32 = 0.55;
+const HALF_FLIP_MIN_FORWARD_VERTICAL: f32 = 0.55;
 const HALF_FLIP_MIN_CONFIDENCE: f32 = 0.55;
 
-/// A dodge sequence starting while driving backward that reorients the car to move forward.
+/// A dodge sequence that cancels a flip into an opposite facing direction.
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
 pub struct HalfFlipEvent {
@@ -45,6 +43,8 @@ struct ActiveHalfFlipCandidate {
     start_backward_alignment: f32,
     best_reorientation_alignment: f32,
     best_forward_reversal: f32,
+    latest_forward_reversal: f32,
+    latest_forward_horizontal: f32,
     max_forward_vertical: f32,
 }
 
@@ -116,18 +116,12 @@ impl HalfFlipCalculator {
 
         let velocity_xy = Self::horizontal_velocity(player).unwrap_or(glam::Vec2::ZERO);
         let start_speed = velocity_xy.length();
-        if start_speed < HALF_FLIP_MIN_START_SPEED {
-            return;
-        }
 
         let Some(start_forward_xy) = Self::forward_xy(player) else {
             return;
         };
         let velocity_direction = velocity_xy.normalize_or_zero();
         let start_backward_alignment = -start_forward_xy.dot(velocity_direction);
-        if start_backward_alignment < HALF_FLIP_MIN_START_BACKWARD_ALIGNMENT {
-            return;
-        }
 
         let max_forward_vertical =
             Self::forward_vector(player).map_or(0.0, |forward| forward.z.abs());
@@ -148,6 +142,8 @@ impl HalfFlipCalculator {
                 start_backward_alignment,
                 best_reorientation_alignment: 0.0,
                 best_forward_reversal: 0.0,
+                latest_forward_reversal: 0.0,
+                latest_forward_horizontal: start_forward_xy.length(),
                 max_forward_vertical,
             },
         );
@@ -168,11 +164,15 @@ impl HalfFlipCalculator {
 
         if let Some(forward) = Self::forward_vector(player) {
             candidate.max_forward_vertical = candidate.max_forward_vertical.max(forward.z.abs());
-            let forward_xy = forward.truncate().normalize_or_zero();
-            if forward_xy.length_squared() > f32::EPSILON {
+            let forward_xy_raw = forward.truncate();
+            candidate.latest_forward_horizontal = forward_xy_raw.length();
+            if candidate.latest_forward_horizontal >= HALF_FLIP_MIN_FINAL_FORWARD_HORIZONTAL {
+                let forward_xy = forward_xy_raw.normalize_or_zero();
+                candidate.latest_forward_reversal =
+                    (-candidate.start_forward_xy.dot(forward_xy)).clamp(-1.0, 1.0);
                 candidate.best_forward_reversal = candidate
                     .best_forward_reversal
-                    .max((-candidate.start_forward_xy.dot(forward_xy)).clamp(-1.0, 1.0));
+                    .max(candidate.latest_forward_reversal);
                 if velocity_direction.length_squared() > f32::EPSILON {
                     candidate.best_reorientation_alignment = candidate
                         .best_reorientation_alignment
@@ -189,25 +189,15 @@ impl HalfFlipCalculator {
         player_id: &PlayerId,
         candidate: ActiveHalfFlipCandidate,
     ) -> Option<HalfFlipEvent> {
-        if candidate.best_reorientation_alignment < HALF_FLIP_MIN_REORIENTATION_ALIGNMENT
-            || candidate.best_forward_reversal < HALF_FLIP_MIN_FORWARD_REVERSAL
+        if candidate.latest_forward_reversal < HALF_FLIP_MIN_FORWARD_REVERSAL
+            || candidate.latest_forward_horizontal < HALF_FLIP_MIN_FINAL_FORWARD_HORIZONTAL
             || candidate.max_forward_vertical < HALF_FLIP_MIN_FORWARD_VERTICAL
         {
             return None;
         }
 
-        let backward_score = Self::normalize_score(
-            candidate.start_backward_alignment,
-            HALF_FLIP_MIN_START_BACKWARD_ALIGNMENT,
-            0.95,
-        );
-        let reorientation_score = Self::normalize_score(
-            candidate.best_reorientation_alignment,
-            HALF_FLIP_MIN_REORIENTATION_ALIGNMENT,
-            0.98,
-        );
         let reversal_score = Self::normalize_score(
-            candidate.best_forward_reversal,
+            candidate.latest_forward_reversal,
             HALF_FLIP_MIN_FORWARD_REVERSAL,
             0.98,
         );
@@ -216,14 +206,7 @@ impl HalfFlipCalculator {
             HALF_FLIP_MIN_FORWARD_VERTICAL,
             0.85,
         );
-        let speed_score = Self::normalize_score(candidate.end_speed, 900.0, 1800.0).max(
-            Self::normalize_score(candidate.end_speed - candidate.start_speed, 100.0, 700.0) * 0.7,
-        );
-        let confidence = 0.25 * backward_score
-            + 0.30 * reorientation_score
-            + 0.25 * reversal_score
-            + 0.10 * flip_score
-            + 0.10 * speed_score;
+        let confidence = 0.75 * reversal_score + 0.25 * flip_score;
 
         if confidence < HALF_FLIP_MIN_CONFIDENCE {
             return None;

--- a/src/stats/calculators/half_flip.rs
+++ b/src/stats/calculators/half_flip.rs
@@ -4,6 +4,7 @@ const HALF_FLIP_EVALUATION_SECONDS: f32 = 0.65;
 const HALF_FLIP_MAX_CANDIDATE_SECONDS: f32 = 1.0;
 const HALF_FLIP_MAX_START_Z: f32 = 90.0;
 const HALF_FLIP_MIN_FORWARD_REVERSAL: f32 = 0.75;
+const HALF_FLIP_MIN_POST_REVERSAL_RETAINED_REVERSAL: f32 = 0.45;
 const HALF_FLIP_MIN_FINAL_FORWARD_HORIZONTAL: f32 = 0.55;
 const HALF_FLIP_MIN_FORWARD_VERTICAL: f32 = 0.55;
 const HALF_FLIP_MIN_CONFIDENCE: f32 = 0.55;
@@ -44,6 +45,7 @@ struct ActiveHalfFlipCandidate {
     best_reorientation_alignment: f32,
     best_forward_reversal: f32,
     latest_forward_reversal: f32,
+    min_forward_reversal_after_reaching_opposite: f32,
     latest_forward_horizontal: f32,
     max_forward_vertical: f32,
 }
@@ -143,6 +145,7 @@ impl HalfFlipCalculator {
                 best_reorientation_alignment: 0.0,
                 best_forward_reversal: 0.0,
                 latest_forward_reversal: 0.0,
+                min_forward_reversal_after_reaching_opposite: 1.0,
                 latest_forward_horizontal: start_forward_xy.length(),
                 max_forward_vertical,
             },
@@ -173,6 +176,11 @@ impl HalfFlipCalculator {
                 candidate.best_forward_reversal = candidate
                     .best_forward_reversal
                     .max(candidate.latest_forward_reversal);
+                if candidate.best_forward_reversal >= HALF_FLIP_MIN_FORWARD_REVERSAL {
+                    candidate.min_forward_reversal_after_reaching_opposite = candidate
+                        .min_forward_reversal_after_reaching_opposite
+                        .min(candidate.latest_forward_reversal);
+                }
                 if velocity_direction.length_squared() > f32::EPSILON {
                     candidate.best_reorientation_alignment = candidate
                         .best_reorientation_alignment
@@ -190,6 +198,8 @@ impl HalfFlipCalculator {
         candidate: ActiveHalfFlipCandidate,
     ) -> Option<HalfFlipEvent> {
         if candidate.latest_forward_reversal < HALF_FLIP_MIN_FORWARD_REVERSAL
+            || candidate.min_forward_reversal_after_reaching_opposite
+                < HALF_FLIP_MIN_POST_REVERSAL_RETAINED_REVERSAL
             || candidate.latest_forward_horizontal < HALF_FLIP_MIN_FINAL_FORWARD_HORIZONTAL
             || candidate.max_forward_vertical < HALF_FLIP_MIN_FORWARD_VERTICAL
         {

--- a/src/stats/calculators/half_flip_tests.rs
+++ b/src/stats/calculators/half_flip_tests.rs
@@ -38,12 +38,23 @@ fn player(
     forward_pitch: f32,
     dodge_active: bool,
 ) -> PlayerSample {
+    player_at_z(id, 20.0, velocity, yaw, forward_pitch, dodge_active)
+}
+
+fn player_at_z(
+    id: u64,
+    z: f32,
+    velocity: glam::Vec3,
+    yaw: f32,
+    forward_pitch: f32,
+    dodge_active: bool,
+) -> PlayerSample {
     PlayerSample {
         player_id: boxcars::RemoteId::Steam(id),
         is_team_0: true,
         hitbox: default_car_hitbox(),
         rigid_body: Some(rigid_body(
-            glam::Vec3::new(0.0, 0.0, 20.0),
+            glam::Vec3::new(0.0, 0.0, z),
             velocity,
             yaw,
             forward_pitch,
@@ -125,7 +136,158 @@ fn counts_backward_dodge_that_reorients_forward() {
 }
 
 #[test]
-fn rejects_forward_dodge_start() {
+fn counts_low_jump_half_flip_start() {
+    let mut calculator = HalfFlipCalculator::new();
+
+    calculator
+        .update(
+            &frame(1, 1.00),
+            &players(player_at_z(
+                1,
+                82.0,
+                glam::Vec3::new(-520.0, 0.0, 0.0),
+                0.0,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(8, 1.35),
+            &players(player_at_z(
+                1,
+                70.0,
+                glam::Vec3::new(-520.0, 0.0, 0.0),
+                0.0,
+                std::f32::consts::FRAC_PI_2,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(15, 1.70),
+            &players(player_at_z(
+                1,
+                55.0,
+                glam::Vec3::new(-520.0, 0.0, 0.0),
+                std::f32::consts::PI,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+}
+
+#[test]
+fn counts_slow_orientation_clear_half_flip() {
+    let mut calculator = HalfFlipCalculator::new();
+
+    calculator
+        .update(
+            &frame(1, 1.00),
+            &players(player_at_z(
+                1,
+                74.0,
+                glam::Vec3::new(-120.0, 0.0, 0.0),
+                0.0,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(8, 1.35),
+            &players(player_at_z(
+                1,
+                62.0,
+                glam::Vec3::new(-120.0, 0.0, 0.0),
+                0.0,
+                std::f32::consts::FRAC_PI_2,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(15, 1.70),
+            &players(player_at_z(
+                1,
+                42.0,
+                glam::Vec3::new(-120.0, 0.0, 0.0),
+                std::f32::consts::PI,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+}
+
+#[test]
+fn counts_forward_travel_when_facing_reverses() {
+    let mut calculator = HalfFlipCalculator::new();
+
+    calculator
+        .update(
+            &frame(1, 1.00),
+            &players(player_at_z(
+                1,
+                74.0,
+                glam::Vec3::new(600.0, 0.0, 0.0),
+                0.0,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(8, 1.35),
+            &players(player_at_z(
+                1,
+                62.0,
+                glam::Vec3::new(600.0, 0.0, 0.0),
+                0.0,
+                std::f32::consts::FRAC_PI_2,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(15, 1.70),
+            &players(player_at_z(
+                1,
+                42.0,
+                glam::Vec3::new(600.0, 0.0, 0.0),
+                std::f32::consts::PI,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    assert_eq!(calculator.events().len(), 1);
+    assert!(calculator.events()[0].start_backward_alignment < 0.0);
+}
+
+#[test]
+fn rejects_dodge_without_facing_reversal() {
     let player_id = boxcars::RemoteId::Steam(1);
     let mut calculator = HalfFlipCalculator::new();
 
@@ -140,6 +302,44 @@ fn rejects_forward_dodge_start() {
         .update(
             &frame(15, 1.70),
             &players(player(1, glam::Vec3::new(1300.0, 0.0, 0.0), 0.0, 0.0, true)),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    assert!(calculator.player_stats().get(&player_id).is_none());
+    assert!(calculator.events().is_empty());
+}
+
+#[test]
+fn rejects_flip_that_has_not_cancelled_back_to_horizontal_facing() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = HalfFlipCalculator::new();
+
+    calculator
+        .update(
+            &frame(1, 1.00),
+            &players(player_at_z(
+                1,
+                74.0,
+                glam::Vec3::new(-600.0, 0.0, 0.0),
+                0.0,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(15, 1.70),
+            &players(player_at_z(
+                1,
+                62.0,
+                glam::Vec3::new(-600.0, 0.0, 0.0),
+                std::f32::consts::PI,
+                std::f32::consts::FRAC_PI_2,
+                true,
+            )),
             &LivePlayState::active_play(),
         )
         .unwrap();

--- a/src/stats/calculators/half_flip_tests.rs
+++ b/src/stats/calculators/half_flip_tests.rs
@@ -349,6 +349,86 @@ fn rejects_flip_that_has_not_cancelled_back_to_horizontal_facing() {
 }
 
 #[test]
+fn rejects_end_over_end_flip_that_rotates_away_after_reaching_opposite() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = HalfFlipCalculator::new();
+
+    calculator
+        .update(
+            &frame(1, 1.00),
+            &players(player_at_z(
+                1,
+                74.0,
+                glam::Vec3::new(-600.0, 0.0, 0.0),
+                0.0,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(5, 1.20),
+            &players(player_at_z(
+                1,
+                72.0,
+                glam::Vec3::new(-600.0, 0.0, 0.0),
+                0.0,
+                std::f32::consts::FRAC_PI_2,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(8, 1.35),
+            &players(player_at_z(
+                1,
+                66.0,
+                glam::Vec3::new(-600.0, 0.0, 0.0),
+                std::f32::consts::PI,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(11, 1.50),
+            &players(player_at_z(
+                1,
+                58.0,
+                glam::Vec3::new(-600.0, 0.0, 0.0),
+                0.0,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(15, 1.70),
+            &players(player_at_z(
+                1,
+                42.0,
+                glam::Vec3::new(-600.0, 0.0, 0.0),
+                std::f32::consts::PI,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    assert!(calculator.player_stats().get(&player_id).is_none());
+    assert!(calculator.events().is_empty());
+}
+
+#[test]
 fn rejects_backward_dodge_without_reorientation() {
     let player_id = boxcars::RemoteId::Steam(1);
     let mut calculator = HalfFlipCalculator::new();


### PR DESCRIPTION
## Summary

- redefine half-flip detection around dodge-driven facing reversal instead of travel direction or speed
- require low grounded/low-air dodge starts, vertical flip evidence, final opposite horizontal facing, and retention of opposite facing to reject full end-over-end flips
- update half-flip event docs and add regression tests for low starts, slow/forward-travel cases, unfinished cancels, and end-over-end rejection

## Validation

- cargo test -q half_flip --lib
- cargo test -q wavedash --lib
- cargo fmt --all -- --check
- cargo clippy -q --lib --all-features -- -D warnings
