### PR TITLE
Add kickoff overview stats window

### DIFF
--- a/js/stat-evaluation-player/src/appTemplate.ts
+++ b/js/stat-evaluation-player/src/appTemplate.ts
@@ -38,6 +38,7 @@ export function getAppTemplate(): string {
               <button type="button" data-create-stats-window="team">New team stats</button>
               <button type="button" data-create-stats-window="all-players">New all players stats</button>
               <button type="button" data-create-stats-window="all-teams">New all teams stats</button>
+              <button type="button" data-create-stats-window="kickoff-overview">New kickoff details</button>
               <button type="button" data-create-stats-window="goals-overview">New goal labels</button>
               <button type="button" data-create-stats-window="ad-hoc">New ad hoc stats</button>
             </section>

--- a/js/stat-evaluation-player/src/main.ts
+++ b/js/stat-evaluation-player/src/main.ts
@@ -558,6 +558,7 @@ async function loadReplayBundleForDisplay(
     clearStandalonePlugins,
     clearRenderCaches,
     resetEventPlaylistWindow,
+    renderModuleSummary,
     renderScoreboard,
     renderTimelineEventCount,
     renderMechanicsTimelineControls,

--- a/js/stat-evaluation-player/src/playerConfig.test.ts
+++ b/js/stat-evaluation-player/src/playerConfig.test.ts
@@ -110,6 +110,20 @@ const CONFIG: StatsPlayerConfig = {
         { statId: "team.core.goals", targetId: "blue" },
       ],
     },
+    {
+      id: "stats-2",
+      kind: "kickoff-overview",
+      placement: {
+        x: 760,
+        y: 120,
+        viewport: { width: 1920, height: 1080 },
+        zIndex: 41,
+        visible: true,
+      },
+      playerId: null,
+      team: null,
+      entries: [],
+    },
   ],
   moduleConfigs: {
     boost: {

--- a/js/stat-evaluation-player/src/playerConfig.ts
+++ b/js/stat-evaluation-player/src/playerConfig.ts
@@ -8,6 +8,7 @@ export type StatsWindowKind =
   | "team"
   | "all-players"
   | "all-teams"
+  | "kickoff-overview"
   | "goals-overview"
   | "ad-hoc";
 
@@ -461,6 +462,7 @@ function isStatsWindowKind(value: unknown): value is StatsWindowKind {
     value === "team" ||
     value === "all-players" ||
     value === "all-teams" ||
+    value === "kickoff-overview" ||
     value === "goals-overview" ||
     value === "ad-hoc"
   );

--- a/js/stat-evaluation-player/src/replayDisplayRuntime.ts
+++ b/js/stat-evaluation-player/src/replayDisplayRuntime.ts
@@ -64,6 +64,7 @@ export interface ReplayDisplayRuntimeOptions {
   clearStandalonePlugins(): void;
   clearRenderCaches(): void;
   resetEventPlaylistWindow(): void;
+  renderModuleSummary(): void;
   renderScoreboard(frameIndex?: number): void;
   renderTimelineEventCount(): void;
   renderMechanicsTimelineControls(): void;
@@ -114,6 +115,7 @@ function clearDisplayedReplay(
   options.clearStandalonePlugins();
   options.clearRenderCaches();
   options.resetEventPlaylistWindow();
+  options.renderModuleSummary();
   options.renderScoreboard();
   options.renderTimelineEventCount();
   options.renderMechanicsTimelineControls();
@@ -178,6 +180,7 @@ export async function loadReplayBundleForDisplay(
       options.setLoadedReplayName(source.name);
       elements.playersReadout.textContent = replay.players.map((player) => player.name).join(", ");
       elements.framesReadout.textContent = `${replay.frameCount}`;
+      options.renderModuleSummary();
       options.renderTimelineEventCount();
       options.renderMechanicsTimelineControls();
       options.resetEventPlaylistWindow();
@@ -287,6 +290,7 @@ export async function loadReplayBundleForDisplay(
     options.setLoadedReplayName(source.name);
     elements.playersReadout.textContent = replay.players.map((player) => player.name).join(", ");
     elements.framesReadout.textContent = `${replay.frameCount}`;
+    options.renderModuleSummary();
     options.renderTimelineEventCount();
     options.renderMechanicsTimelineControls();
     options.resetEventPlaylistWindow();

--- a/js/stat-evaluation-player/src/statsWindows.ts
+++ b/js/stat-evaluation-player/src/statsWindows.ts
@@ -8,8 +8,13 @@ import type {
 import { getStatDefinitionSearchMatches } from "./statSearch.ts";
 import type { StatDefinition, StatScopeKind } from "./statRegistry.ts";
 import { getTeamClass } from "./statModules.ts";
-import { getStatsFrameForReplayFrame, statsEventPayloads } from "./statsTimeline.ts";
+import {
+  getStatsFrameForReplayFrame,
+  statsEventEnvelopes,
+  statsEventPayloads,
+} from "./statsTimeline.ts";
 import type {
+  Event,
   PlayerStatsSnapshot,
   StatsFrame,
   StatsFrameLookup,
@@ -18,12 +23,17 @@ import type {
 } from "./statsTimeline.ts";
 import { formatGoalTagPerformer, formatMechanicKind } from "./timelineMarkers.ts";
 import { playerIdToString } from "./touchOverlay.ts";
+import type { KickoffEvent } from "./generated/KickoffEvent.ts";
+import type { KickoffSupportEvent } from "./generated/KickoffSupportEvent.ts";
+import type { KickoffTakerEvent } from "./generated/KickoffTakerEvent.ts";
 
 interface SelectedStatEntry {
   key: string;
   statId: string;
   targetId?: string;
 }
+
+type KickoffEnvelope = Event & { payload: { kind: "kickoff"; payload: KickoffEvent } };
 
 interface StatsWindowState {
   readonly id: string;
@@ -272,6 +282,8 @@ export class StatsWindowsController {
         return "All players stats";
       case "all-teams":
         return "All teams stats";
+      case "kickoff-overview":
+        return "Kickoff details";
       case "goals-overview":
         return "Goal labels";
       case "ad-hoc":
@@ -284,7 +296,7 @@ export class StatsWindowsController {
   }
 
   private hasStatsWindowStatPicker(kind: StatsWindowKind): boolean {
-    return kind !== "goals-overview";
+    return kind !== "goals-overview" && kind !== "kickoff-overview";
   }
 
   private getStatsWindowAllowedScope(kind: StatsWindowKind): StatScopeKind | null {
@@ -295,6 +307,8 @@ export class StatsWindowsController {
       case "team":
       case "all-teams":
         return "team";
+      case "kickoff-overview":
+        return null;
       case "goals-overview":
         return null;
       case "ad-hoc":
@@ -565,6 +579,10 @@ export class StatsWindowsController {
       this.renderGoalLabelsOverview(statsWindow);
       return;
     }
+    if (statsWindow.kind === "kickoff-overview") {
+      this.renderKickoffOverview(statsWindow, frameIndex);
+      return;
+    }
 
     const allowedScope = this.getStatsWindowAllowedScope(statsWindow.kind);
     const entries = statsWindow.entries
@@ -708,6 +726,298 @@ export class StatsWindowsController {
       list.append(item);
     }
     statsWindow.body.append(list);
+  }
+
+  private renderKickoffOverview(statsWindow: StatsWindowState, frameIndex: number): void {
+    const timeline = this.options.getStatsTimeline();
+    const replay = this.options.getReplayPlayer()?.replay ?? null;
+    if (!timeline || !replay) {
+      this.appendStatsWindowEmpty(statsWindow, "Load a replay to show kickoff details.");
+      return;
+    }
+
+    const kickoffEnvelope = this.getLatestKickoffEvent(timeline, frameIndex);
+    if (!kickoffEnvelope) {
+      this.appendStatsWindowEmpty(statsWindow, "No completed kickoff yet.");
+      return;
+    }
+    const kickoff = kickoffEnvelope.payload.payload;
+
+    const section = document.createElement("section");
+    section.className = "kickoff-overview";
+
+    const hero = document.createElement("header");
+    hero.className = "kickoff-overview-hero";
+    const titleGroup = document.createElement("div");
+    const title = document.createElement("h3");
+    title.textContent = this.formatKickoffTitle(kickoffEnvelope);
+    const subtitle = document.createElement("span");
+    subtitle.textContent = `Resolved at ${formatTime(kickoff.end_time)}`;
+    titleGroup.append(title, subtitle);
+
+    const victor = document.createElement("strong");
+    const victorTeamClass = this.teamClassFromNullable(kickoff.winning_team_is_team_0);
+    victor.className = "kickoff-overview-victor";
+    if (victorTeamClass) {
+      victor.classList.add(victorTeamClass);
+    }
+    victor.textContent = this.formatOutcome(kickoff);
+    hero.append(titleGroup, victor);
+
+    const summary = document.createElement("div");
+    summary.className = "kickoff-overview-summary";
+    summary.append(
+      this.renderKickoffMetric(
+        "Win strength",
+        `${this.formatNullableNumber(kickoff.win_strength, 2)} · ${this.formatKickoffLabelValue(
+          "kickoff_win_strength",
+          kickoff.win_strength_band,
+        )}`,
+      ),
+      this.renderKickoffMetric("First touch", this.formatFirstTouch(kickoff)),
+      this.renderKickoffMetric("Advantage", this.formatAdvantage(kickoff)),
+      this.renderKickoffMetric("Contested", this.formatContested(kickoff)),
+    );
+
+    const times = document.createElement("div");
+    times.className = "kickoff-detail-grid";
+    times.append(
+      this.renderKickoffDetail("Kickoff start", formatTime(kickoff.start_time)),
+      this.renderKickoffDetail("Movement start", formatTime(kickoff.movement_start_time)),
+      this.renderKickoffDetail(
+        "Live action",
+        kickoff.live_action_start_time === null ? "--" : formatTime(kickoff.live_action_start_time),
+      ),
+      this.renderKickoffDetail(
+        "First touch",
+        kickoff.first_touch_time === null ? "--" : formatTime(kickoff.first_touch_time),
+      ),
+      this.renderKickoffDetail("Resolution", formatTime(kickoff.end_time)),
+      this.renderKickoffDetail(
+        "After first touch",
+        this.formatSeconds(kickoff.advantage_seconds_after_first_touch),
+      ),
+    );
+
+    const strategy = document.createElement("div");
+    strategy.className = "kickoff-strategy-list";
+    strategy.append(
+      this.renderKickoffTeamStrategy("Blue", kickoff.team_zero_taker, kickoff.team_zero_non_takers),
+      this.renderKickoffTeamStrategy("Orange", kickoff.team_one_taker, kickoff.team_one_non_takers),
+    );
+
+    section.append(hero, summary, times, strategy);
+    statsWindow.body.append(section);
+  }
+
+  private getLatestKickoffEvent(
+    timeline: StatsTimeline,
+    frameIndex: number,
+  ): KickoffEnvelope | null {
+    const completed = statsEventEnvelopes(timeline)
+      .filter(
+        (event): event is KickoffEnvelope =>
+          event.payload.kind === "kickoff" && event.payload.payload.end_frame <= frameIndex,
+      )
+      .sort((left, right) => {
+        if (left.payload.payload.end_frame !== right.payload.payload.end_frame) {
+          return right.payload.payload.end_frame - left.payload.payload.end_frame;
+        }
+        return right.payload.payload.end_time - left.payload.payload.end_time;
+      });
+    return completed[0] ?? null;
+  }
+
+  private renderKickoffMetric(labelText: string, valueText: string): HTMLElement {
+    const metric = document.createElement("div");
+    metric.className = "kickoff-metric";
+    const label = document.createElement("span");
+    label.textContent = labelText;
+    const value = document.createElement("strong");
+    value.textContent = valueText;
+    metric.append(label, value);
+    return metric;
+  }
+
+  private renderKickoffDetail(labelText: string, valueText: string): HTMLElement {
+    const row = document.createElement("div");
+    row.className = "kickoff-detail-row";
+    const label = document.createElement("span");
+    label.textContent = labelText;
+    const value = document.createElement("strong");
+    value.textContent = valueText;
+    row.append(label, value);
+    return row;
+  }
+
+  private renderKickoffTeamStrategy(
+    teamLabel: string,
+    taker: KickoffTakerEvent | null,
+    supports: readonly KickoffSupportEvent[],
+  ): HTMLElement {
+    const section = document.createElement("section");
+    section.className = `kickoff-strategy-team ${teamLabel === "Blue" ? "team-blue" : "team-orange"}`;
+
+    const heading = document.createElement("h4");
+    heading.textContent = teamLabel;
+    section.append(heading);
+
+    const takerRow = document.createElement("p");
+    takerRow.className = "kickoff-strategy-line";
+    takerRow.textContent = taker
+      ? `${this.getPlayerName(taker.player)}: ${this.formatKickoffLabelValue(
+          "kickoff_approach",
+          taker.approach,
+        )} from ${this.formatKickoffLabelValue("kickoff_spawn", taker.spawn_position)} (${this.formatKickoffLabelValue(
+          "taker_outcome",
+          taker.outcome,
+        )}, ${this.formatSeconds(taker.time_to_ball)})`
+      : "No taker detected";
+    section.append(takerRow);
+
+    if (supports.length > 0) {
+      const supportList = document.createElement("ul");
+      supportList.className = "kickoff-support-list";
+      for (const support of supports) {
+        const item = document.createElement("li");
+        item.textContent = `${this.getPlayerName(support.player)}: ${this.formatKickoffLabelValue(
+          "support_behavior",
+          support.support_behavior,
+        )} from ${this.formatKickoffLabelValue("kickoff_spawn", support.spawn_position)}`;
+        supportList.append(item);
+      }
+      section.append(supportList);
+    }
+
+    return section;
+  }
+
+  private formatOutcome(kickoff: KickoffEvent): string {
+    if (kickoff.winning_team_is_team_0 === true) {
+      return "Blue wins";
+    }
+    if (kickoff.winning_team_is_team_0 === false) {
+      return "Orange wins";
+    }
+    if (kickoff.outcome === "neutral") {
+      return "Neutral";
+    }
+    return "Unknown";
+  }
+
+  private formatFirstTouch(kickoff: KickoffEvent): string {
+    if (!kickoff.first_touch_player) {
+      return "--";
+    }
+    const team =
+      kickoff.first_touch_team_is_team_0 === true
+        ? "Blue"
+        : kickoff.first_touch_team_is_team_0 === false
+          ? "Orange"
+          : "Unknown";
+    const time = kickoff.first_touch_time === null ? "--" : formatTime(kickoff.first_touch_time);
+    return `${team} · ${this.getPlayerName(kickoff.first_touch_player)} · ${time}`;
+  }
+
+  private formatAdvantage(kickoff: KickoffEvent): string {
+    if (kickoff.advantage === "no_advantage") {
+      return "No advantage";
+    }
+    const team =
+      kickoff.advantage_team_is_team_0 === true
+        ? "Blue"
+        : kickoff.advantage_team_is_team_0 === false
+          ? "Orange"
+          : "Unknown";
+    const kind = kickoff.advantage.replace(/^team_(zero|one)_/, "");
+    const player = kickoff.advantage_player
+      ? ` · ${this.getPlayerName(kickoff.advantage_player)}`
+      : "";
+    const time = kickoff.advantage_time === null ? "" : ` · ${formatTime(kickoff.advantage_time)}`;
+    return `${team} ${this.formatKickoffLabelValue("kickoff_advantage", kind)}${player}${time}`;
+  }
+
+  private formatContested(kickoff: KickoffEvent): string {
+    if (kickoff.kickoff_possession_outcome === "contested") {
+      return "Yes";
+    }
+    if (kickoff.kickoff_possession_team_is_team_0 === true) {
+      return `No · Blue ${this.formatPossessionOutcome(kickoff.kickoff_possession_outcome)}`;
+    }
+    if (kickoff.kickoff_possession_team_is_team_0 === false) {
+      return `No · Orange ${this.formatPossessionOutcome(kickoff.kickoff_possession_outcome)}`;
+    }
+    return `No · ${this.formatPossessionOutcome(kickoff.kickoff_possession_outcome)}`;
+  }
+
+  private formatPossessionOutcome(outcome: KickoffEvent["kickoff_possession_outcome"]): string {
+    if (outcome.endsWith("_advantage")) {
+      return "advantage";
+    }
+    if (outcome.endsWith("_possession")) {
+      return "possession";
+    }
+    return this.formatKickoffLabelValue("kickoff_possession_outcome", outcome);
+  }
+
+  private formatKickoffType(value: string): string {
+    return this.formatKickoffLabelValue("kickoff_type", value);
+  }
+
+  private formatKickoffTitle(kickoffEnvelope: KickoffEnvelope): string {
+    const kickoff = kickoffEnvelope.payload.payload;
+    const direction = this.formatKickoffDirection(kickoff.kickoff_direction);
+    const detail = [this.formatKickoffType(kickoff.kickoff_type), direction]
+      .filter(Boolean)
+      .join(" ");
+    return [kickoffEnvelope.meta.label, detail].filter(Boolean).join(" · ");
+  }
+
+  private formatKickoffDirection(value: string): string {
+    return value === "unknown"
+      ? ""
+      : `(${this.formatKickoffLabelValue("kickoff_direction", value)})`;
+  }
+
+  private formatNullableNumber(value: number | null, digits: number): string {
+    return value === null || !Number.isFinite(value) ? "--" : value.toFixed(digits);
+  }
+
+  private formatSeconds(value: number | null): string {
+    return value === null || !Number.isFinite(value) ? "--" : `${value.toFixed(2)}s`;
+  }
+
+  private formatLabel(value: string): string {
+    return value
+      .replace(/^team_zero_/, "blue_")
+      .replace(/^team_one_/, "orange_")
+      .replaceAll("_", " ")
+      .replace(/\b\w/g, (letter) => letter.toUpperCase());
+  }
+
+  private formatKickoffLabelValue(labelKey: string, value: string): string {
+    const normalizedValue = value.replace(/^team_zero_/, "blue_").replace(/^team_one_/, "orange_");
+    if (labelKey === "kickoff_advantage") {
+      return this.formatLabel(normalizedValue.replace(/^blue_/, "").replace(/^orange_/, ""));
+    }
+    if (labelKey === "kickoff_possession_outcome") {
+      return this.formatLabel(
+        normalizedValue.replace(/^blue_/, "Blue ").replace(/^orange_/, "Orange "),
+      );
+    }
+    return this.formatLabel(normalizedValue);
+  }
+
+  private teamClassFromNullable(isTeamZero: boolean | null): string | null {
+    return isTeamZero === null ? null : getTeamClass(isTeamZero);
+  }
+
+  private getPlayerName(playerId: Record<string, unknown>): string {
+    const playerIdString = playerIdToString(playerId);
+    return (
+      this.options.getReplayPlayer()?.replay.players.find((player) => player.id === playerIdString)
+        ?.name ?? playerIdString
+    );
   }
 
   private appendStatsWindowEmpty(statsWindow: StatsWindowState, message: string): void {

--- a/js/stat-evaluation-player/src/statsWindows.ts
+++ b/js/stat-evaluation-player/src/statsWindows.ts
@@ -736,9 +736,9 @@ export class StatsWindowsController {
       return;
     }
 
-    const kickoffEnvelope = this.getLatestKickoffEvent(timeline, frameIndex);
+    const kickoffEnvelope = this.getClosestKickoffEvent(timeline, frameIndex);
     if (!kickoffEnvelope) {
-      this.appendStatsWindowEmpty(statsWindow, "No completed kickoff yet.");
+      this.appendStatsWindowEmpty(statsWindow, "No kickoff events loaded.");
       return;
     }
     const kickoff = kickoffEnvelope.payload.payload;
@@ -752,7 +752,7 @@ export class StatsWindowsController {
     const title = document.createElement("h3");
     title.textContent = this.formatKickoffTitle(kickoffEnvelope);
     const subtitle = document.createElement("span");
-    subtitle.textContent = `Resolved at ${formatTime(kickoff.end_time)}`;
+    subtitle.textContent = `Nearest kickoff · resolved at ${formatTime(kickoff.end_time)}`;
     titleGroup.append(title, subtitle);
 
     const victor = document.createElement("strong");
@@ -810,22 +810,31 @@ export class StatsWindowsController {
     statsWindow.body.append(section);
   }
 
-  private getLatestKickoffEvent(
+  private getClosestKickoffEvent(
     timeline: StatsTimeline,
     frameIndex: number,
   ): KickoffEnvelope | null {
-    const completed = statsEventEnvelopes(timeline)
-      .filter(
-        (event): event is KickoffEnvelope =>
-          event.payload.kind === "kickoff" && event.payload.payload.end_frame <= frameIndex,
-      )
+    const kickoffs = statsEventEnvelopes(timeline)
+      .filter((event): event is KickoffEnvelope => event.payload.kind === "kickoff")
       .sort((left, right) => {
-        if (left.payload.payload.end_frame !== right.payload.payload.end_frame) {
-          return right.payload.payload.end_frame - left.payload.payload.end_frame;
+        const leftDistance = this.kickoffFrameDistance(left.payload.payload, frameIndex);
+        const rightDistance = this.kickoffFrameDistance(right.payload.payload, frameIndex);
+        if (leftDistance !== rightDistance) {
+          return leftDistance - rightDistance;
         }
-        return right.payload.payload.end_time - left.payload.payload.end_time;
+        return left.payload.payload.start_frame - right.payload.payload.start_frame;
       });
-    return completed[0] ?? null;
+    return kickoffs[0] ?? null;
+  }
+
+  private kickoffFrameDistance(kickoff: KickoffEvent, frameIndex: number): number {
+    if (frameIndex >= kickoff.start_frame && frameIndex <= kickoff.end_frame) {
+      return 0;
+    }
+    return Math.min(
+      Math.abs(frameIndex - kickoff.start_frame),
+      Math.abs(frameIndex - kickoff.end_frame),
+    );
   }
 
   private renderKickoffMetric(labelText: string, valueText: string): HTMLElement {

--- a/js/stat-evaluation-player/src/styles/stats-windows.css
+++ b/js/stat-evaluation-player/src/styles/stats-windows.css
@@ -477,3 +477,164 @@
   background: rgba(101, 214, 173, 0.18);
   color: #d7ffef;
 }
+
+.kickoff-overview {
+  display: grid;
+  gap: var(--ui-gap-md);
+  min-width: min(38rem, 84vw);
+}
+
+.kickoff-overview-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--ui-gap-md);
+  align-items: start;
+  padding-bottom: 0.52rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.kickoff-overview-hero h3 {
+  margin: 0;
+  color: #edf5fa;
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+
+.kickoff-overview-hero span {
+  display: block;
+  margin-top: 0.12rem;
+  color: #9eb4c6;
+  font-size: 0.72rem;
+}
+
+.kickoff-overview-victor {
+  max-width: 9rem;
+  padding: 0.2rem 0.46rem;
+  border-radius: var(--ui-radius-sm);
+  background: rgba(132, 149, 168, 0.18);
+  color: #d8e5ee;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.kickoff-overview-victor.team-blue,
+.kickoff-overview-victor.team-orange {
+  background: var(--team-soft);
+  color: color-mix(in srgb, var(--team-accent) 72%, #ffffff);
+}
+
+.kickoff-overview-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ui-gap-sm);
+}
+
+.kickoff-metric {
+  display: grid;
+  gap: 0.12rem;
+  min-width: 0;
+  padding: 0.46rem 0.52rem;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.kickoff-metric span,
+.kickoff-detail-row span {
+  color: #89a4ba;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.kickoff-metric strong {
+  min-width: 0;
+  color: #edf5fa;
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.kickoff-detail-grid {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.kickoff-detail-row {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 1fr) auto;
+  gap: var(--ui-gap-sm);
+  align-items: baseline;
+  min-height: 1.38rem;
+  font-size: 0.78rem;
+}
+
+.kickoff-detail-row strong {
+  color: #edf5fa;
+  font-variant-numeric: tabular-nums;
+}
+
+.kickoff-strategy-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(15rem, 1fr));
+  gap: var(--ui-gap-sm);
+}
+
+.kickoff-strategy-team {
+  display: grid;
+  gap: 0.34rem;
+  min-width: 0;
+  padding: 0.54rem 0.58rem;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid color-mix(in srgb, var(--team-accent) 26%, transparent);
+  background:
+    linear-gradient(180deg, var(--team-soft), rgba(255, 255, 255, 0.025)), rgba(255, 255, 255, 0.03);
+}
+
+.kickoff-strategy-team h4 {
+  margin: 0;
+  color: color-mix(in srgb, var(--team-accent) 62%, #edf5fa);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.kickoff-strategy-line {
+  margin: 0;
+  color: #edf5fa;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.kickoff-support-list {
+  display: grid;
+  gap: 0.22rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.kickoff-support-list li {
+  color: #afc4d4;
+  font-size: 0.74rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 720px) {
+  .kickoff-overview-summary,
+  .kickoff-strategy-list {
+    grid-template-columns: 1fr;
+  }
+
+  .kickoff-overview-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .kickoff-overview-victor {
+    justify-self: start;
+  }
+}

--- a/js/stat-evaluation-player/src/styles/stats-windows.css
+++ b/js/stat-evaluation-player/src/styles/stats-windows.css
@@ -478,10 +478,15 @@
   color: #d7ffef;
 }
 
+.stats-window:has(.kickoff-overview) {
+  width: min(34rem, calc(100vw - 1.6rem));
+}
+
 .kickoff-overview {
   display: grid;
   gap: var(--ui-gap-md);
-  min-width: min(38rem, 84vw);
+  width: 100%;
+  min-width: 0;
 }
 
 .kickoff-overview-hero {
@@ -526,7 +531,7 @@
 
 .kickoff-overview-summary {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: var(--ui-gap-sm);
 }
 
@@ -577,7 +582,7 @@
 
 .kickoff-strategy-list {
   display: grid;
-  grid-template-columns: repeat(2, minmax(15rem, 1fr));
+  grid-template-columns: 1fr;
   gap: var(--ui-gap-sm);
 }
 
@@ -624,8 +629,15 @@
   overflow-wrap: anywhere;
 }
 
+@media (min-width: 46rem) {
+  .kickoff-overview-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 720px) {
   .kickoff-overview-summary,
+  .kickoff-detail-grid,
   .kickoff-strategy-list {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary

- Add a dedicated kickoff details stats window to the stats evaluation player
- Show the nearest kickoff to the playhead, including victor, win strength, first touch, advantage, contested result, timings, and team strategy context
- Add launcher/config support and responsive styling for the new window

## Validation

- `node --run=check:tsc` from `js/stat-evaluation-player`
- `npx tsx --tsconfig tsconfig.test.json --test src/playerConfig.test.ts` from `js/stat-evaluation-player`
- `npm run format:check` from `js`
- `npm run lint` from `js`
- pre-commit `cargo clippy --all-targets --all-features -- -D warnings`
