### PR TITLE
Stop stale goal explosions after playback jumps

### DIFF
--- a/js/player/src/player/ReplayPlayer.ts
+++ b/js/player/src/player/ReplayPlayer.ts
@@ -977,6 +977,8 @@ export class ReplayPlayer extends EventTarget {
     // wheels would spin wildly from the position delta.
     this.actorManager.seekAnimations(this.currentTime);
     this.effectsManager.resetBallTrail();
+    this.effectsManager.clearGoalExplosions?.();
+    this.actorManager.resetGoalExplosionPlaybackState();
     this.actorManager.resetWheelTracking();
   }
 
@@ -1151,6 +1153,8 @@ export class ReplayPlayer extends EventTarget {
           // Wrapping is a seek: clear delta-based trackers (see seek()).
           this.actorManager.seekAnimations(0);
           this.effectsManager.resetBallTrail();
+          this.effectsManager.clearGoalExplosions?.();
+          this.actorManager.resetGoalExplosionPlaybackState();
           this.actorManager.resetWheelTracking();
         } else {
           next = end;

--- a/js/player/src/player/managers/ActorManager.js
+++ b/js/player/src/player/managers/ActorManager.js
@@ -255,6 +255,11 @@ export class ActorManager {
     this._ballModelReplaced = false;
   }
 
+  resetGoalExplosionPlaybackState() {
+    this._lastGoalScanTime = null;
+    this._firedGoalTimes.clear();
+  }
+
   setPlayerTeams(teams) {
     this.playerTeams = teams;
   }
@@ -3004,6 +3009,7 @@ export class ActorManager {
 
     const ball = this.actors[this.ballActorId];
     let ballHidden = false;
+    let inGoalExplosionWindow = false;
 
     for (const goal of goalEvents.values()) {
       const goalTime = goal.time;
@@ -3012,6 +3018,7 @@ export class ActorManager {
       // Hide the ball from the goal moment through the explosion lifetime.
       if (currentTime >= goalTime && currentTime <= goalTime + GOAL_BALL_HIDE_DURATION) {
         ballHidden = true;
+        inGoalExplosionWindow = true;
       }
 
       // Fire once, the first time we cross the goal moving forward. A baseline
@@ -3030,6 +3037,9 @@ export class ActorManager {
     if (ball) {
       ball.userData.isHiddenByGoal = ballHidden;
       if (ballHidden) ball.visible = false;
+    }
+    if (!inGoalExplosionWindow) {
+      this.effectsManager.clearGoalExplosions?.();
     }
 
     this._lastGoalScanTime = currentTime;

--- a/js/player/src/player/managers/EffectsManager.js
+++ b/js/player/src/player/managers/EffectsManager.js
@@ -1268,6 +1268,12 @@ class GoalExplosionPool {
     explosion.container.visible = false;
   }
 
+  clearActive() {
+    for (const explosion of this.explosions) {
+      this.resetExplosion(explosion);
+    }
+  }
+
   update(deltaTime) {
     for (const explosion of this.explosions) {
       if (!explosion.active) continue;
@@ -3499,6 +3505,7 @@ export class EffectsManager {
   reset() {
     this.explosions.active.forEach((explosion) => explosion.removeFromScene(this.scene));
     this.explosions.active = [];
+    this.clearGoalExplosions();
 
     // Clear boost trails
     this.boostTrails.forEach((trail) => {
@@ -3551,6 +3558,16 @@ export class EffectsManager {
     if (this.ballTrail) {
       this.ballTrail.reset();
     }
+  }
+
+  clearGoalExplosions() {
+    if (_goalExplosionPool) {
+      _goalExplosionPool.clearActive();
+    }
+    for (const explosion of this.explosions.active) {
+      explosion.removeFromScene(this.scene);
+    }
+    this.explosions.active = [];
   }
 
   createBoostTrail(carMesh, carActorId) {


### PR DESCRIPTION
## Summary
- Clear active goal explosion effects when playback seeks, loops, or leaves the goal explosion window.
- Reset goal-crossing bookkeeping on playback jumps so a seek cannot be interpreted as crossing a goal event.
- Add an explicit clear path for the pooled team-colored goal explosion instances.

## Root Cause
Goal explosions were triggered by crossing goal times, but active pooled effects were only allowed to age out by elapsed animation time. After a seek or skipped post-goal transition, the old explosion could continue rendering even though playback was no longer at the goal moment.

## Validation
- `just check`
- `npm run check` from `js/player`
