### PR TITLE
Remove half flip start height filter

### DIFF
--- a/src/stats/calculators/half_flip.rs
+++ b/src/stats/calculators/half_flip.rs
@@ -2,7 +2,6 @@ use super::*;
 
 const HALF_FLIP_EVALUATION_SECONDS: f32 = 0.65;
 const HALF_FLIP_MAX_CANDIDATE_SECONDS: f32 = 1.0;
-const HALF_FLIP_MAX_START_Z: f32 = 90.0;
 const HALF_FLIP_MIN_FORWARD_REVERSAL: f32 = 0.75;
 const HALF_FLIP_MIN_POST_REVERSAL_RETAINED_REVERSAL: f32 = 0.45;
 const HALF_FLIP_MIN_FINAL_FORWARD_HORIZONTAL: f32 = 0.55;
@@ -112,9 +111,6 @@ impl HalfFlipCalculator {
         let Some(position) = player.position() else {
             return;
         };
-        if position.z > HALF_FLIP_MAX_START_Z {
-            return;
-        }
 
         let velocity_xy = Self::horizontal_velocity(player).unwrap_or(glam::Vec2::ZERO);
         let start_speed = velocity_xy.length();

--- a/src/stats/calculators/half_flip_tests.rs
+++ b/src/stats/calculators/half_flip_tests.rs
@@ -287,6 +287,74 @@ fn counts_forward_travel_when_facing_reverses() {
 }
 
 #[test]
+fn counts_backward_dodge_without_start_height_filter() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = HalfFlipCalculator::new();
+
+    calculator
+        .update(
+            &frame(1, 1.00),
+            &players(player(
+                1,
+                glam::Vec3::new(-450.0, 0.0, 0.0),
+                0.0,
+                0.0,
+                false,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(2, 1.05),
+            &players(player_at_z(
+                1,
+                PLAYER_GROUND_Z_THRESHOLD + 250.0,
+                glam::Vec3::new(-450.0, 0.0, 0.0),
+                0.0,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(9, 1.40),
+            &players(player_at_z(
+                1,
+                PLAYER_GROUND_Z_THRESHOLD + 320.0,
+                glam::Vec3::new(-450.0, 0.0, 0.0),
+                0.0,
+                std::f32::consts::FRAC_PI_2,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+    calculator
+        .update(
+            &frame(16, 1.75),
+            &players(player_at_z(
+                1,
+                PLAYER_GROUND_Z_THRESHOLD + 280.0,
+                glam::Vec3::new(-450.0, 0.0, 0.0),
+                std::f32::consts::PI,
+                0.0,
+                true,
+            )),
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+
+    let stats = calculator.player_stats().get(&player_id).unwrap();
+    assert_eq!(stats.count, 1);
+    assert_eq!(calculator.events().len(), 1);
+    assert_eq!(calculator.events()[0].frame, 16);
+    assert!(calculator.events()[0].confidence >= HALF_FLIP_MIN_CONFIDENCE);
+}
+
+#[test]
 fn rejects_dodge_without_facing_reversal() {
     let player_id = boxcars::RemoteId::Steam(1);
     let mut calculator = HalfFlipCalculator::new();


### PR DESCRIPTION
## Summary
- Remove the half-flip candidate start-height rejection so otherwise valid candidates are not filtered out solely for starting above a ground-adjacent threshold.
- Add a regression test that starts a backward dodge hundreds of units above ground and verifies it still emits a half-flip event when the orientation/reorientation evidence is strong.

## Root cause
The detector previously rejected candidates whose dodge began above `PLAYER_GROUND_Z_THRESHOLD + 45`. The reported replay had a valid half flip whose dodge began above that cap, so the event was suppressed before the confidence checks could evaluate it.

## Validation
- `cargo test stats::calculators::half_flip`
- `just check`