### PR TITLE
Preserve goal explosions when skipping resets

### DIFF
--- a/js/player/src/player-internals/timeline.ts
+++ b/js/player/src/player-internals/timeline.ts
@@ -7,6 +7,8 @@ import type {
   ReplayPlayerTimelineSegment,
 } from "../types";
 
+export const GOAL_EXPLOSION_PROTECTED_SECONDS = 2;
+
 export function clampFrameIndex(replay: ReplayModel, frameIndex: number): number {
   if (replay.frames.length === 0) {
     return 0;
@@ -97,6 +99,18 @@ function isRenderableKickoffFrame(
   return isKickoffFrame(frame, kickoffGameState) && hasRenderableSamples(replay, frameIndex);
 }
 
+function isGoalExplosionProtectedFrame(
+  replay: ReplayModel,
+  frame: ReplayModel["frames"][number],
+): boolean {
+  return replay.timelineEvents.some(
+    (event) =>
+      event.kind === "goal" &&
+      frame.time >= event.time &&
+      frame.time < event.time + GOAL_EXPLOSION_PROTECTED_SECONDS,
+  );
+}
+
 export function isPostGoalTransitionFrame(
   replay: ReplayModel,
   frame: ReplayModel["frames"][number],
@@ -105,6 +119,7 @@ export function isPostGoalTransitionFrame(
   kickoffGameState: number | null,
 ): boolean {
   return (
+    !isGoalExplosionProtectedFrame(replay, frame) &&
     !isLiveGameplayFrame(frame, liveGameState) &&
     !isRenderableKickoffFrame(replay, frame, frameIndex, kickoffGameState)
   );

--- a/js/player/test/timeline.test.ts
+++ b/js/player/test/timeline.test.ts
@@ -7,9 +7,13 @@ import {
   projectReplayTimeToTimeline,
   projectTimelineTimeToReplay,
 } from "../src/player-internals/timeline";
+import { getPostGoalTransitionSkipTargetTime } from "../src/player-helpers";
 import type { ReplayModel } from "../src/types";
 
-function replayWithGameStates(gameStates: number[]): ReplayModel {
+function replayWithGameStates(
+  gameStates: number[],
+  timelineEvents: ReplayModel["timelineEvents"] = [],
+): ReplayModel {
   return {
     frameCount: gameStates.length,
     duration: Math.max(0, gameStates.length - 1),
@@ -28,7 +32,7 @@ function replayWithGameStates(gameStates: number[]): ReplayModel {
     boostPads: [],
     players: [],
     tickMarks: [],
-    timelineEvents: [],
+    timelineEvents,
     teamZeroNames: [],
     teamOneNames: [],
   };
@@ -70,4 +74,27 @@ test("timeline projection identifies skipped ranges without compacting them", ()
     seekTime: 4,
     hiddenBySkip: true,
   });
+});
+
+test("post-goal skip preserves the goal explosion window", () => {
+  const replay = replayWithGameStates(
+    [0, 0, 1, 1, 1, 1, 0, 0],
+    [
+      {
+        kind: "goal",
+        time: 2,
+        frame: 2,
+        playerId: null,
+        playerName: null,
+        isTeamZero: true,
+      },
+    ],
+  );
+
+  assert.deepEqual(computeTimelineSegments(replay, true, false, 0, null), [
+    { startTime: 4, endTime: 6 },
+  ]);
+  assert.equal(getPostGoalTransitionSkipTargetTime(replay, 2, 0, null), null);
+  assert.equal(getPostGoalTransitionSkipTargetTime(replay, 3, 0, null), null);
+  assert.equal(getPostGoalTransitionSkipTargetTime(replay, 4, 0, null), 6);
 });


### PR DESCRIPTION
## Summary
- preserve the first two seconds after each goal as renderable time even when post-goal reset skipping is enabled
- add a regression test proving post-goal skipping does not remove the goal explosion window

## Root Cause
The player classified the entire non-live post-goal reset interval as skippable. With skip-post-goal-resets enabled, playback could jump past the goal before the explosion scan observed the goal crossing, so the explosion never fired.

## Validation
- `npx tsx --tsconfig tsconfig.test.json --test test/timeline.test.ts`
- `npm run build:types` in `js/player`
- `npm run check:style` in `js`
