### PR TITLE
Keep explosion pools bound to active scene

### DIFF
--- a/js/player/src/player/managers/EffectsManager.js
+++ b/js/player/src/player/managers/EffectsManager.js
@@ -801,6 +801,10 @@ class SimplifiedExplosionPool {
 
 // Helper to get/create simplified explosion pool
 function getSimplifiedExplosionPool(scene, renderer = null, camera = null) {
+  if (_simplifiedExplosionPool && _simplifiedExplosionPool.scene !== scene) {
+    _simplifiedExplosionPool.dispose?.();
+    _simplifiedExplosionPool = null;
+  }
   if (!_simplifiedExplosionPool) {
     _simplifiedExplosionPool = new SimplifiedExplosionPool(scene, renderer, camera);
   }
@@ -1395,6 +1399,10 @@ class GoalExplosionPool {
 }
 
 function getGoalExplosionPool(scene, renderer = null, camera = null) {
+  if (_goalExplosionPool && _goalExplosionPool.scene !== scene) {
+    _goalExplosionPool.dispose?.();
+    _goalExplosionPool = null;
+  }
   if (!_goalExplosionPool) {
     _goalExplosionPool = new GoalExplosionPool(scene, renderer, camera);
   }


### PR DESCRIPTION
Fixes hidden preview-player warmup stealing the module-level explosion pools. When a visible player uses a different Three.js scene, the pool is now recreated for that scene instead of triggering goal explosions into the warmed hidden scene.\n\nValidation:\n- npm run build:types (js/player)\n- npm run check:style (js)