### PR TITLE
Detect speed flips by nose-pitch rotation, not jump-to-dodge timing

### DIFF
--- a/src/stats/calculators/kickoff.rs
+++ b/src/stats/calculators/kickoff.rs
@@ -25,6 +25,16 @@ const KICKOFF_APPROACH_MIN_FAKE_MOVE_DISTANCE: f32 = 350.0;
 const KICKOFF_APPROACH_FLIP_MIN_SECONDS_BEFORE_TOUCH: f32 = 0.5;
 const KICKOFF_APPROACH_FRONT_FLIP_FORWARD_COMPONENT: f32 = 0.45;
 const KICKOFF_APPROACH_DIAGONAL_FLIP_SIDE_COMPONENT: f32 = 0.35;
+/// The dodge/flip impulse is delivered over several frames (the car drags
+/// through the dodge), and boxcars often does not re-send the car velocity on
+/// the exact frame the dodge becomes active, so a single-frame velocity delta at
+/// dodge onset is unreliable (it is frequently exactly zero). Decompose the
+/// *peak* velocity change across this short window after the dodge instead.
+const KICKOFF_APPROACH_DODGE_DIRECTION_WINDOW_SECONDS: f32 = 0.20;
+/// Forward acceleration contributed by boost, subtracted across the dodge window
+/// so the recovered dodge direction reflects the flip impulse rather than the
+/// boost the taker is holding through it. Mirrors the speed-flip detector.
+const KICKOFF_APPROACH_BOOST_ACCELERATION_UU_PER_SECOND_SQUARED: f32 = 991.6667;
 const KICKOFF_SUPPORT_CHEAT_MIN_CENTER_PROGRESS: f32 = 400.0;
 const KICKOFF_ADVANTAGE_POSSESSION_MIN_RUN_SECONDS: f32 = 1.25;
 const KICKOFF_PRESSURE_NEUTRAL_ZONE_HALF_WIDTH_Y: f32 = 200.0;
@@ -55,6 +65,15 @@ struct KickoffApproachTrace {
     first_dodge_frame: Option<usize>,
     first_dodge_forward_component: Option<f32>,
     first_dodge_side_component: Option<f32>,
+    /// State for the windowed dodge-direction recovery (see
+    /// `KICKOFF_APPROACH_DODGE_DIRECTION_WINDOW_SECONDS`). Captured at dodge
+    /// onset and consumed for a short window afterward.
+    dodge_direction_baseline_velocity: Option<glam::Vec3>,
+    dodge_onset_forward: Option<glam::Vec3>,
+    dodge_onset_right: Option<glam::Vec3>,
+    dodge_direction_window_deadline: Option<f32>,
+    dodge_direction_boost_compensation: glam::Vec3,
+    best_dodge_direction_delta: f32,
     max_speed: f32,
     min_boost: Option<f32>,
     previous_boost: Option<f32>,
@@ -782,23 +801,63 @@ impl KickoffCalculator {
             trace.max_speed = trace.max_speed.max(speed);
         }
 
-        if player.dodge_active && !trace.previous_dodge_active && trace.first_dodge_time.is_none() {
+        let dodge_rising = player.dodge_active && !trace.previous_dodge_active;
+        let had_first_dodge = trace.first_dodge_time.is_some();
+        if dodge_rising && !had_first_dodge {
             trace.first_dodge_time = Some(frame.time);
             trace.first_dodge_frame = Some(frame.frame_number);
-            if let (Some(previous_velocity), Some(velocity), Some(rigid_body)) = (
-                trace.previous_velocity,
-                player.velocity(),
-                player.rigid_body.as_ref(),
-            ) {
-                let velocity_delta = velocity - previous_velocity;
-                if velocity_delta.length_squared() > f32::EPSILON {
-                    let dodge_direction = velocity_delta.normalize();
-                    let rotation = quat_to_glam(&rigid_body.rotation);
-                    let forward = rotation * glam::Vec3::X;
-                    let right = rotation * glam::Vec3::Y;
-                    trace.first_dodge_forward_component = Some(dodge_direction.dot(forward));
-                    trace.first_dodge_side_component = Some(dodge_direction.dot(right));
+            if let Some(rigid_body) = player.rigid_body.as_ref() {
+                let rotation = quat_to_glam(&rigid_body.rotation);
+                trace.dodge_onset_forward = Some(rotation * glam::Vec3::X);
+                trace.dodge_onset_right = Some(rotation * glam::Vec3::Y);
+                // Baseline is the velocity just before the flip impulse lands.
+                // Prefer the previous frame's velocity; the onset frame itself
+                // often repeats it (boxcars did not re-send it), which is exactly
+                // why the old single-frame delta read zero.
+                trace.dodge_direction_baseline_velocity =
+                    trace.previous_velocity.or_else(|| player.velocity());
+                trace.dodge_direction_window_deadline =
+                    Some(frame.time + KICKOFF_APPROACH_DODGE_DIRECTION_WINDOW_SECONDS);
+            }
+        }
+
+        // A later, separate dodge (e.g. flipping forward into the ball at first
+        // touch) must not overwrite the first dodge's recovered direction, so
+        // close the window as soon as a new dodge begins.
+        if dodge_rising && had_first_dodge {
+            trace.dodge_direction_window_deadline = None;
+        }
+
+        // Recover the dodge direction from the peak velocity change over the
+        // window after onset, decomposed in the car's onset frame, with the
+        // forward boost contribution removed so a boosting taker's flip still
+        // reads as diagonal rather than straight-forward.
+        if let (Some(deadline), Some(baseline), Some(forward), Some(right)) = (
+            trace.dodge_direction_window_deadline,
+            trace.dodge_direction_baseline_velocity,
+            trace.dodge_onset_forward,
+            trace.dodge_onset_right,
+        ) {
+            if frame.time <= deadline {
+                if player.boost_active {
+                    trace.dodge_direction_boost_compensation += forward
+                        * KICKOFF_APPROACH_BOOST_ACCELERATION_UU_PER_SECOND_SQUARED
+                        * frame.dt;
                 }
+                if let Some(velocity) = player.velocity() {
+                    let delta = velocity - baseline - trace.dodge_direction_boost_compensation;
+                    let horizontal = delta.truncate().length();
+                    if horizontal > trace.best_dodge_direction_delta
+                        && delta.length_squared() > f32::EPSILON
+                    {
+                        trace.best_dodge_direction_delta = horizontal;
+                        let direction = delta.normalize();
+                        trace.first_dodge_forward_component = Some(direction.dot(forward));
+                        trace.first_dodge_side_component = Some(direction.dot(right));
+                    }
+                }
+            } else {
+                trace.dodge_direction_window_deadline = None;
             }
         }
 

--- a/src/stats/calculators/speed_flip.rs
+++ b/src/stats/calculators/speed_flip.rs
@@ -6,7 +6,6 @@ const SPEED_FLIP_MAX_CANDIDATE_SECONDS: f32 = 0.55;
 const SPEED_FLIP_MAX_GROUND_Z: f32 = 80.0;
 const SPEED_FLIP_KICKOFF_MOTION_SPEED: f32 = 100.0;
 const SPEED_FLIP_MIN_ALIGNMENT: f32 = 0.72;
-const SPEED_FLIP_MAX_DODGE_DELAY_AFTER_GROUND_LEAVE_SECONDS: f32 = 0.20;
 const SPEED_FLIP_DODGE_ACCELERATION_SAMPLE_SECONDS: f32 = 0.18;
 const SPEED_FLIP_MIN_FORWARD_DODGE_DELTA: f32 = 80.0;
 const SPEED_FLIP_MIN_FORWARD_DODGE_DELTA_ALIGNMENT: f32 = 0.35;
@@ -18,7 +17,6 @@ const SPEED_FLIP_MIN_ESTIMATED_DODGE_SIDE_COMPONENT: f32 = 0.88;
 const SPEED_FLIP_MAX_ESTIMATED_DODGE_SIDE_COMPONENT: f32 = 0.95;
 const SPEED_FLIP_MAX_ESTIMATED_DODGE_UP_COMPONENT: f32 = 0.82;
 const SPEED_FLIP_MIN_DIAGONAL_SCORE: f32 = 0.35;
-const SPEED_FLIP_MIN_STRONG_DIAGONAL_SCORE: f32 = 0.75;
 const SPEED_FLIP_MIN_UP_ROTATION_DEGREES: f32 = 90.0;
 const SPEED_FLIP_MAX_CANCELLED_FORWARD_ROTATION_DEGREES: f32 = 45.0;
 const SPEED_FLIP_MIN_BOOST_ALIGNMENT: f32 = 0.80;
@@ -123,6 +121,7 @@ pub struct SpeedFlipCalculator {
     previous_dodge_active: HashMap<PlayerId, bool>,
     last_ground_contacts: HashMap<PlayerId, f32>,
     kickoff_approach_active_last_frame: bool,
+    kickoff_window_open: bool,
     current_kickoff_start_time: Option<f32>,
 }
 
@@ -139,8 +138,28 @@ impl SpeedFlipCalculator {
         self.events.new_events()
     }
 
-    fn kickoff_approach_active(gameplay: &GameplayState) -> bool {
-        gameplay.ball_has_been_hit == Some(false)
+    /// Whether we are inside a kickoff approach window.
+    ///
+    /// The opening kickoff of a match reports `ball_has_been_hit == None` (not
+    /// `Some(false)`) between the countdown ending and the first touch, so a gate
+    /// of `== Some(false)` alone never fires on it — the speed flip was simply
+    /// never evaluated as a kickoff. (The kickoff stats machinery works around
+    /// the same engine quirk; see `kickoff.rs::observe_movement_start`.) Track
+    /// the approach as an explicit window instead: open it on the countdown (or
+    /// the `Some(false)` signal used by every subsequent kickoff) and hold it
+    /// open through the `None` go→touch window until the ball is actually hit.
+    fn update_kickoff_window(&mut self, gameplay: &GameplayState) -> bool {
+        self.kickoff_window_open =
+            if gameplay.kickoff_countdown_active() || gameplay.ball_has_been_hit == Some(false) {
+                true
+            } else if gameplay.ball_has_been_hit == Some(true) {
+                false
+            } else {
+                // `None` with no countdown: either the opening go→touch window (keep
+                // whatever the countdown opened) or pre-match idle (stays closed).
+                self.kickoff_window_open
+            };
+        self.kickoff_window_open
     }
 
     fn player_by_id<'a>(
@@ -272,7 +291,7 @@ impl SpeedFlipCalculator {
     fn maybe_start_candidate(
         &mut self,
         frame: &FrameInfo,
-        gameplay: &GameplayState,
+        kickoff_approach_active: bool,
         ball: &BallFrameState,
         player: &PlayerSample,
         _live_play_state: &LivePlayState,
@@ -285,7 +304,7 @@ impl SpeedFlipCalculator {
             return;
         }
 
-        let is_kickoff = Self::kickoff_approach_active(gameplay);
+        let is_kickoff = kickoff_approach_active;
         let kickoff_start_time = if is_kickoff {
             let Some(kickoff_start_time) = self.current_kickoff_start_time else {
                 return;
@@ -505,11 +524,18 @@ impl SpeedFlipCalculator {
         if candidate.boost_alignment_sample_count == 0 {
             return None;
         }
-        if candidate.dodge_delay_after_ground_leave_seconds
-            > SPEED_FLIP_MAX_DODGE_DELAY_AFTER_GROUND_LEAVE_SECONDS
-        {
-            return None;
-        }
+        // The defining trait of a speed flip is the *cancel*: the dodge is a
+        // diagonal flip whose nose is levelled back out instead of pitching all
+        // the way over (`max_forward_rotation` stays small). This is what
+        // separates a real speed flip from an ordinary full diagonal flip, which
+        // can score just as high on raw diagonal angular velocity. We do NOT gate
+        // on how long after the jump the dodge fires: real speed flips vary a lot
+        // there (two pros on the same kickoff flipped 0.07s vs 0.22s after
+        // leaving the ground), so a timing ceiling only produces false negatives.
+        // `dodge_delay_after_ground_leave_seconds` is still reported for review.
+        let has_cancelled_diagonal_dodge = candidate.max_forward_rotation_degrees
+            <= SPEED_FLIP_MAX_CANCELLED_FORWARD_ROTATION_DEGREES
+            && candidate.best_diagonal_score >= SPEED_FLIP_MIN_DIAGONAL_SCORE;
         if candidate.dodge_acceleration_sample_count == 0
             || candidate.best_dodge_forward_delta < SPEED_FLIP_MIN_FORWARD_DODGE_DELTA
             || candidate.best_dodge_delta_alignment < SPEED_FLIP_MIN_FORWARD_DODGE_DELTA_ALIGNMENT
@@ -533,15 +559,6 @@ impl SpeedFlipCalculator {
         if has_incompatible_meaningful_impulse {
             return None;
         }
-        let weak_impulse_direction_is_usable = candidate.best_estimated_dodge_impulse_magnitude
-            < SPEED_FLIP_MIN_DIRECTIONAL_WEAK_IMPULSE_MAGNITUDE
-            || (candidate.best_estimated_dodge_impulse_forward_component >= 0.0
-                && estimated_dodge_side_component >= SPEED_FLIP_MIN_WEAK_IMPULSE_SIDE_COMPONENT);
-        if !weak_impulse_direction_is_usable {
-            return None;
-        }
-        let has_strong_diagonal_rotation =
-            candidate.best_diagonal_score >= SPEED_FLIP_MIN_STRONG_DIAGONAL_SCORE;
         let has_diagonal_impulse = has_meaningful_impulse
             && candidate.best_estimated_dodge_impulse_forward_component
                 >= SPEED_FLIP_MIN_ESTIMATED_DODGE_FORWARD_COMPONENT
@@ -550,15 +567,25 @@ impl SpeedFlipCalculator {
                 .contains(&estimated_dodge_side_component)
             && estimated_dodge_up_component <= SPEED_FLIP_MAX_ESTIMATED_DODGE_UP_COMPONENT
             && candidate.best_diagonal_score >= SPEED_FLIP_MIN_DIAGONAL_SCORE;
-        // Boost-through speed flips suppress the estimated dodge impulse (the
-        // boost compensation swallows it) and sloppier flips land below the
-        // strong-rotation score, but the flip cancel itself leaves a crisp
-        // signature: the car's up vector sweeps through the dodge rotation
-        // while the nose barely pitches because the cancel levels it out.
-        let has_cancelled_diagonal_dodge = candidate.max_forward_rotation_degrees
-            <= SPEED_FLIP_MAX_CANCELLED_FORWARD_ROTATION_DEGREES
-            && candidate.best_diagonal_score >= SPEED_FLIP_MIN_DIAGONAL_SCORE;
-        if !(has_strong_diagonal_rotation || has_diagonal_impulse || has_cancelled_diagonal_dodge) {
+        // A weak (sub-`MEANINGFUL`, super-`WEAK`) estimated impulse pointing the
+        // wrong way normally disqualifies a candidate, but on a boost-through
+        // speed flip the boost-compensation overshoot can flip the residual
+        // estimate backward even though the dodge is unmistakably a cancelled
+        // diagonal flip. Only the *cancelled* signature (the nose stays level —
+        // `max_forward_rotation` small) is specific enough to trust over a bad
+        // impulse estimate: a merely high diagonal *score* also fires on an
+        // ordinary forward flip whose nose pitches all the way over, so it is not
+        // sufficient on its own. The meaningful-impulse incompatibility check
+        // above still rejects genuinely wrong strong impulses.
+        let weak_impulse_direction_is_usable = has_cancelled_diagonal_dodge
+            || candidate.best_estimated_dodge_impulse_magnitude
+                < SPEED_FLIP_MIN_DIRECTIONAL_WEAK_IMPULSE_MAGNITUDE
+            || (candidate.best_estimated_dodge_impulse_forward_component >= 0.0
+                && estimated_dodge_side_component >= SPEED_FLIP_MIN_WEAK_IMPULSE_SIDE_COMPONENT);
+        if !weak_impulse_direction_is_usable {
+            return None;
+        }
+        if !(has_diagonal_impulse || has_cancelled_diagonal_dodge) {
             return None;
         }
         let boost_alignment_score =
@@ -658,7 +685,7 @@ impl SpeedFlipCalculator {
         live_play_state: &LivePlayState,
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
-        let kickoff_approach_active = Self::kickoff_approach_active(gameplay);
+        let kickoff_approach_active = self.update_kickoff_window(gameplay);
         if !live_play_state.is_live_play && !kickoff_approach_active {
             self.active_candidates
                 .apply_boundary(Boundary::LivePlayEnded);
@@ -676,7 +703,13 @@ impl SpeedFlipCalculator {
         self.update_ground_contacts(frame, players);
 
         for player in &players.players {
-            self.maybe_start_candidate(frame, gameplay, ball, player, live_play_state);
+            self.maybe_start_candidate(
+                frame,
+                kickoff_approach_active,
+                ball,
+                player,
+                live_play_state,
+            );
         }
 
         for (player_id, candidate) in self.active_candidates.iter_mut() {

--- a/src/stats/calculators/speed_flip_tests.rs
+++ b/src/stats/calculators/speed_flip_tests.rs
@@ -126,12 +126,32 @@ fn candidate_event_rejects_sideways_dodge_acceleration() {
 }
 
 #[test]
-fn candidate_event_rejects_late_airborne_dodge() {
+fn candidate_event_accepts_speed_flip_regardless_of_dodge_delay_after_ground_leave() {
+    // There is intentionally no ceiling on how long after leaving the ground the
+    // dodge fires: real speed flips vary widely there. A clean cancelled flip is
+    // accepted even with a long ground-leave-to-dodge delay.
     let player_id = boxcars::RemoteId::Steam(1);
-    let mut late_airborne_candidate = strong_candidate(2);
-    late_airborne_candidate.dodge_delay_after_ground_leave_seconds = 0.216;
+    let mut late_dodge_candidate = strong_candidate(2);
+    late_dodge_candidate.dodge_delay_after_ground_leave_seconds = 0.50;
 
-    assert!(SpeedFlipCalculator::candidate_event(&player_id, late_airborne_candidate).is_none());
+    assert!(SpeedFlipCalculator::candidate_event(&player_id, late_dodge_candidate).is_some());
+}
+
+#[test]
+fn candidate_event_rejects_noncancelled_full_diagonal_flip() {
+    // A full diagonal flip (the nose pitches all the way over) can score just as
+    // high on raw diagonal angular velocity as a speed flip, but it is not one.
+    // Without the cancel (small `max_forward_rotation`) and without a clean
+    // diagonal impulse, it must be rejected.
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut full_flip_candidate = strong_candidate(2);
+    full_flip_candidate.best_diagonal_score = 0.93;
+    full_flip_candidate.max_forward_rotation_degrees = 115.0;
+    // Impulse direction is diagonal-ish but not in the tight `has_diagonal_impulse`
+    // side-component band, so the cancel is the only thing that could accept it.
+    full_flip_candidate.best_estimated_dodge_impulse_side_component = 0.70;
+
+    assert!(SpeedFlipCalculator::candidate_event(&player_id, full_flip_candidate).is_none());
 }
 
 #[test]
@@ -169,15 +189,38 @@ fn candidate_event_rejects_vertical_dominant_wavedash_like_impulse() {
 }
 
 #[test]
-fn candidate_event_rejects_directional_weak_impulse_without_forward_or_side_component() {
+fn candidate_event_rejects_directional_weak_impulse_without_diagonal_rotation() {
     let player_id = boxcars::RemoteId::Steam(1);
     let mut weak_backward_candidate = strong_candidate(2);
     weak_backward_candidate.best_estimated_dodge_impulse_magnitude = 43.0;
     weak_backward_candidate.best_estimated_dodge_impulse_forward_component = -0.48;
     weak_backward_candidate.best_estimated_dodge_impulse_side_component = 0.0;
     weak_backward_candidate.best_estimated_dodge_impulse_up_component = -0.88;
+    // No diagonal-rotation signature to fall back on, so the weak backward
+    // impulse has nothing to vouch for it and the candidate is rejected.
+    weak_backward_candidate.best_diagonal_score = 0.2;
+    weak_backward_candidate.max_forward_rotation_degrees = 60.0;
 
     assert!(SpeedFlipCalculator::candidate_event(&player_id, weak_backward_candidate).is_none());
+}
+
+#[test]
+fn candidate_event_accepts_cancelled_dodge_despite_corrupted_weak_impulse() {
+    // Boost-through speed flips have their estimated dodge impulse swallowed by
+    // the boost compensation, leaving a weak (sub-`MEANINGFUL`) residual that can
+    // even point backward. When the rotation signature is an unambiguous
+    // cancelled diagonal dodge, the impulse-direction heuristic must not veto it.
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut boost_through_candidate = strong_candidate(2);
+    boost_through_candidate.best_estimated_dodge_impulse_magnitude = 43.0;
+    boost_through_candidate.best_estimated_dodge_impulse_forward_component = -0.48;
+    boost_through_candidate.best_estimated_dodge_impulse_side_component = 0.0;
+    boost_through_candidate.best_estimated_dodge_impulse_up_component = -0.88;
+    // Crisp cancelled diagonal dodge: strong diagonal spin, nose barely pitches.
+    boost_through_candidate.best_diagonal_score = 1.0;
+    boost_through_candidate.max_forward_rotation_degrees = 12.0;
+
+    assert!(SpeedFlipCalculator::candidate_event(&player_id, boost_through_candidate).is_some());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

zen's opening kickoff in `019ee691…` was classified `boost_into_ball` with **no flip credited at all**, even though it's a clear speed flip. The opening kickoff was just where it surfaced — the core detection bug is general and affects every speed-flip candidate (all kickoffs and open play).

## Root causes

1. **The dodge-delay gate rejected real speed flips.** `candidate_event` (which runs for *every* speed-flip candidate) rejected the flip solely on `SPEED_FLIP_MAX_DODGE_DELAY_AFTER_GROUND_LEAVE_SECONDS` — the dodge fired 0.218s after the car left the ground, just over the 0.20s ceiling. A second pro's flip on the *same kickoff* fired at 0.073s, so the natural jump→dodge variance already exceeds the threshold. That gate only existed as a backstop because the `has_strong_diagonal_rotation` accept path admitted ordinary **full** diagonal flips (the nose pitches all the way over) that score just as high on raw diagonal angular velocity.

2. **The fallback flip classifier read a zero dodge direction.** It derived direction from a single-frame velocity delta at dodge onset, but boxcars frequently doesn't re-send velocity that frame (`previous_velocity == velocity` → delta `(0,0,0)`), so both components defaulted to `0.000` → neither Diagonal nor FrontFlip fired → `boost_into_ball`.

## Changes

**Detection (general — all speed flips, kickoff and open play):**
- Drop the dodge-delay timing gate and the `has_strong_diagonal_rotation` path. Accept is now `has_diagonal_impulse || has_cancelled_diagonal_dodge`. The latter keys on `max_forward_rotation ≤ 45°` — how far the car's nose swung from its onset orientation — which is the observable **rotational signature** of a cancelled flip: a full flip rotates the nose all the way over, a speed flip doesn't. (We can't see the stick cancel input itself; this is the proxy for it, not a direct measurement.) `dodge_delay_after_ground_leave_seconds` is still computed and reported as review metadata.
- Let the cancelled-dodge signature override the weak-impulse direction veto, so a boost-through flip whose boost-compensated impulse estimate is corrupted is still recognized.

**Opening-kickoff specific:**
- Recover the approach-trace dodge direction from a windowed, boost-compensated peak velocity delta instead of a single frame; close the window when a new dodge begins so a flip-into-ball at first touch can't overwrite the first dodge. (Fixes the "no flip credited at all" fallback.)
- Recognize the opening kickoff in the speed-flip kickoff window (it reports `ball_has_been_hit == None` until first touch), giving opening-kickoff speed flips correct `is_kickoff` / `time_since_kickoff_start` metadata consumed by the JS overlays. Metadata only — not a detection change.

## Validation

- All reviewed-ground-truth clip fixtures pass: `clip_speed_flip_test` (confirmed flips kept; the human-rejected Adamboi04/colonelpanic candidates still rejected — now by nose-pitch rotation, e.g. Adamboi04's full flip at `max_fwd_rot=115°`), plus the kickoff-approach-flip, worldcup-kickoff, and contested-kickoff clip tests.
- 799 lib tests pass; `just check-rust` clean (fmt, clippy `--all-targets --all-features -D warnings`, metadata `--locked`, rdme).
- On the reported replay, zen's opening kickoff now reads `speed_flip`; no exported struct (`SpeedFlipEvent`) fields changed, so no ts-rs / BakkesMod ABI drift.

**Caveats / honest notes:**
- Removing the timing gate is a corpus-wide detection change; ground truth here is the clip-fixture set plus the reported replay. Low-risk (the cancel-rotation plus the existing strict gates — up-rotation ≥ 90°, alignment, boost-alignment, cancel-score, confidence — remain), but a broader batch of reviewed replays would confirm no open-play regression.
- The `max_forward_rotation ≤ 45°` test is a proxy for the cancel, measured within the ~0.32s evaluation window — it infers "the nose never pitched over," not the stick reversal itself. A full flip whose rotation hadn't completed within the window, or a very-late cancel, could blur the boundary; in the current corpus the full flips reach 100°+ and are cleanly rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)