### PR TITLE
Account for gravity in shot/save goal-mouth projection

### DIFF
--- a/src/stats/calculators/touch_intention.rs
+++ b/src/stats/calculators/touch_intention.rs
@@ -468,11 +468,16 @@ fn opponent_goal_line_y(is_team_0: bool) -> f32 {
     -own_goal_line_y(is_team_0)
 }
 
-/// Returns true when a straight-line projection of the trajectory crosses the
-/// goal line at `target_goal_y` inside the goal mouth (with a ball-radius
-/// margin) within `max_seconds`. Gravity, bounces, and later touches are
-/// deliberately ignored, matching the other goal-mouth projections in this
-/// crate.
+/// Returns true when a ballistic projection of the trajectory crosses the goal
+/// line at `target_goal_y` inside the goal mouth (with a ball-radius margin)
+/// within `max_seconds`.
+///
+/// The horizontal (x/y) path is a straight line — gravity is purely vertical,
+/// so it does not change when the ball reaches the goal line nor its lateral
+/// position there. The vertical (z) path applies constant gravity, so a shot
+/// hit upward that arcs back down into the net is read correctly instead of
+/// being projected straight over the crossbar. Wall bounces and later touches
+/// are still deliberately ignored.
 fn trajectory_crosses_goal_mouth(
     position: glam::Vec3,
     velocity: glam::Vec3,
@@ -486,10 +491,17 @@ fn trajectory_crosses_goal_mouth(
     if !time_to_goal_line.is_finite() || !(0.0..=max_seconds).contains(&time_to_goal_line) {
         return false;
     }
-    let projected = position + velocity * time_to_goal_line;
-    projected.x.abs() <= BACK_WALL_GOAL_MOUTH_HALF_WIDTH_X + GOAL_MOUTH_TRAJECTORY_MARGIN
-        && projected.z >= BALL_RADIUS_Z - GOAL_MOUTH_TRAJECTORY_MARGIN
-        && projected.z <= GOAL_MOUTH_HEIGHT_Z + GOAL_MOUTH_TRAJECTORY_MARGIN
+    let projected_x = position.x + velocity.x * time_to_goal_line;
+    let projected_z = position.z
+        + velocity.z * time_to_goal_line
+        + 0.5
+            * crate::util::ballistics::STANDARD_BALL_GRAVITY_Z
+            * time_to_goal_line
+            * time_to_goal_line;
+    projected_x.abs() <= BACK_WALL_GOAL_MOUTH_HALF_WIDTH_X + GOAL_MOUTH_TRAJECTORY_MARGIN
+        && (BALL_RADIUS_Z - GOAL_MOUTH_TRAJECTORY_MARGIN
+            ..=GOAL_MOUTH_HEIGHT_Z + GOAL_MOUTH_TRAJECTORY_MARGIN)
+            .contains(&projected_z)
 }
 
 #[cfg(test)]

--- a/src/stats/calculators/touch_intention_tests.rs
+++ b/src/stats/calculators/touch_intention_tests.rs
@@ -142,6 +142,48 @@ fn fast_touch_toward_goal_mouth_classifies_as_shot() {
 }
 
 #[test]
+fn upward_arced_shot_into_net_classifies_as_shot() {
+    // A shot hit hard with significant upward velocity: a straight-line
+    // projection sails it well over the crossbar (z ~1500), but gravity arcs it
+    // back down into the goal mouth (z ~160). This mirrors a dribble-flick that
+    // scores along an obvious arc, which used to read as Neutral.
+    let player_id = player(1);
+    let mut classifier = TouchIntentionClassifier::default();
+
+    let resolution = classifier.classify(
+        &touch_at(&player_id, 1.0),
+        &player_id,
+        &TouchIntentionFrameContext {
+            ball_position: Some(glam::Vec3::new(0.0, 0.0, BALL_RADIUS_Z)),
+            ball_velocity: Some(glam::Vec3::new(0.0, 2500.0, 700.0)),
+            ..neutral_ctx()
+        },
+    );
+
+    assert_eq!(resolution.intention, TouchIntention::Shot);
+}
+
+#[test]
+fn shot_sailing_over_the_crossbar_is_not_a_shot() {
+    // Even with gravity, a ball rocketing upward is still well above the
+    // crossbar when it reaches the goal line, so it must not read as a shot.
+    let player_id = player(1);
+    let mut classifier = TouchIntentionClassifier::default();
+
+    let resolution = classifier.classify(
+        &touch_at(&player_id, 1.0),
+        &player_id,
+        &TouchIntentionFrameContext {
+            ball_position: Some(glam::Vec3::new(0.0, 4000.0, BALL_RADIUS_Z)),
+            ball_velocity: Some(glam::Vec3::new(0.0, 2500.0, 2000.0)),
+            ..neutral_ctx()
+        },
+    );
+
+    assert_eq!(resolution.intention, TouchIntention::Neutral);
+}
+
+#[test]
 fn touch_wide_of_goal_mouth_is_not_a_shot() {
     let player_id = player(1);
     let mut classifier = TouchIntentionClassifier::default();


### PR DESCRIPTION
## Problem

Obvious goals were being classified as `neutral` instead of `shot`. For example, the dribble-flick that scores the **first goal** of `assets/problematic-private-duel-2026-03-20.replay` read as `neutral`.

The geometric shot/save check, `trajectory_crosses_goal_mouth`, projected the post-touch ball trajectory onto the goal mouth with a **pure straight line**. Any shot hit with upward velocity was therefore extrapolated *over* the crossbar (the z-upper-bound check) and rejected — even balls that visibly arc back down into the net.

Concretely, that flick had ball velocity ≈ `(1222, -1570, 506)` (speed 2053, well over threshold):
- straight-line z at the goal line ≈ **1123** → "sails over the bar" → rejected
- gravity-aware z ≈ **127** → squarely in the goal mouth (matches the real flight, z ≈ 133)

## Fix

Apply constant gravity to the **z term only** (`z = z0 + vz*t + 0.5*g*t²`) using `STANDARD_BALL_GRAVITY_Z` (-650). The x/y path stays linear: gravity is purely vertical, so it changes neither the time-to-goal-line (computed from y) nor the lateral landing point. The helper is shared by `is_geometric_shot` and `is_geometric_save`, so both reads benefit.

## Tests

Two regression tests guard both directions:
- `upward_arced_shot_into_net_classifies_as_shot` — an arced shot that scores now reads as `shot` (was `neutral`).
- `shot_sailing_over_the_crossbar_is_not_a_shot` — a ball genuinely rocketing over the bar is still rejected, so the change isn't a blanket accept of upward shots.

All 23 touch-intention tests and 75 touch tests pass; `just check-rust` (fmt + clippy `-D warnings` + metadata + rdme) is clean.

## Notes

- Orthogonal to #229 (the touch tag-set refactor): that PR leaves `trajectory_crosses_goal_mouth` untouched and would not have fixed this goal. This fix survives unchanged if #229 lands later.
- Two related latent issues are **not** addressed here: (1) the replay-confirmed `Shot` stat event fires ~0.7s *after* the causing touch, and backward-only matching misses it; (2) `double_tap.rs::followup_touch_projects_on_goal_mouth` has the same gravity-ignoring projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)