### PR TITLE
Classify shots/saves from outcome, not just the touch-frame projection

### DIFF
--- a/src/stats/calculators/touch.rs
+++ b/src/stats/calculators/touch.rs
@@ -13,6 +13,16 @@ const AERIAL_TOUCH_MIN_PLAYER_Z: f32 = AIR_DRIBBLE_MIN_PLAYER_Z;
 /// such touches be recognized as dodge contacts after the fact.
 const DODGE_LAG_TOLERANCE_SECONDS: f32 = 0.12;
 
+/// How long after a touch a replay-reported shot/save stat event may land and
+/// still be attributed to that touch. The counter increment routinely
+/// replicates a fraction of a second after the touch that caused it.
+const STAT_EVENT_OUTCOME_WINDOW_SECONDS: f32 = 0.75;
+
+/// How long before a goal the scoring touch may have happened and still be
+/// attributed as the shot. Covers slow rollers and screened shots while
+/// rejecting a stale cross-play touch by the same player.
+const GOAL_SHOT_ATTRIBUTION_WINDOW_SECONDS: f32 = 10.0;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TouchKind {
     Control,
@@ -201,7 +211,27 @@ pub struct TouchCalculator {
     pending_dodge_upgrades: Vec<PendingDodgeUpgrade>,
     intention_classifier: TouchIntentionClassifier,
     control_follow: ControlFollowTracker,
+    shot_projection: ShotProjectionTracker,
 }
+
+/// Precedence of a touch intention in the single `intention` slot. Retroactive
+/// upgrades may only raise this rank, never lower it, so an outcome-confirmed
+/// shot/save is never clobbered by a later weaker read and vice versa. Mirrors
+/// the at-touch precedence ladder in [`TouchIntentionClassifier::classify`].
+fn intention_rank(value: &str) -> u8 {
+    match value {
+        "neutral" => 0,
+        "pass" => 1,
+        "control" => 2,
+        "clear" => 3,
+        "challenge" => 4,
+        "shot" => 5,
+        "save" => 6,
+        _ => 0,
+    }
+}
+
+const CHALLENGE_RANK: u8 = 4;
 
 impl TouchCalculator {
     pub fn new() -> Self {
@@ -229,6 +259,8 @@ impl TouchCalculator {
         self.write_finalized_ball_movement(finalized);
         let resolution = self.control_follow.flush();
         self.apply_control_resolution(resolution);
+        let shot_resolution = self.shot_projection.flush();
+        self.apply_shot_projection_resolution(shot_resolution);
     }
 
     fn finalize_ball_movement_at_boundary(&mut self, boundary: Boundary) {
@@ -408,6 +440,10 @@ impl TouchCalculator {
                 .control_follow
                 .observe_touch(player_id, touch_event.time);
             self.apply_control_resolution(control_resolution);
+            // This new touch ends the previous touch's free flight; resolve its
+            // shot projection from the settled trajectory just before now.
+            let shot_resolution = self.shot_projection.observe_touch();
+            self.apply_shot_projection_resolution(shot_resolution);
             let resolution = self.intention_classifier.classify(
                 touch_event,
                 player_id,
@@ -469,6 +505,11 @@ impl TouchCalculator {
                 self.control_follow
                     .open(touch_index, player_id, touch_event.time);
             }
+            // Every touch is a potential shot whose touch-frame trajectory was
+            // sampled before the impulse finished landing; watch its free flight
+            // and upgrade from the settled trajectory if it turns out goalward.
+            self.shot_projection
+                .open(touch_index, touch_event.team_is_team_0, touch_event.time);
         }
     }
 
@@ -481,8 +522,94 @@ impl TouchCalculator {
         if !resolution.control {
             return;
         }
+        self.raise_intention(resolution.touch_index, TouchIntention::Control);
+    }
+
+    /// Apply a closed shot-projection window: a settled free-flight trajectory
+    /// that crosses the opponent goal mouth upgrades the touch to a shot. Only
+    /// promotes open-play touches (below the contested rung), so it never
+    /// rewrites a contested challenge or an outcome-confirmed shot/save.
+    fn apply_shot_projection_resolution(&mut self, resolution: Option<ShotProjectionResolution>) {
+        let Some(resolution) = resolution else {
+            return;
+        };
+        if !resolution.is_shot {
+            return;
+        }
         if let Some(event) = self.events.get_mut(resolution.touch_index) {
-            event.intention = TouchIntention::Control.as_label_value().to_owned();
+            if intention_rank(&event.intention) < CHALLENGE_RANK {
+                event.intention = TouchIntention::Shot.as_label_value().to_owned();
+            }
+        }
+    }
+
+    /// Raise a touch's intention to `target` only when `target` outranks the
+    /// current label, so retroactive upgrades never downgrade a touch.
+    fn raise_intention(&mut self, touch_index: usize, target: TouchIntention) {
+        if let Some(event) = self.events.get_mut(touch_index) {
+            let target = target.as_label_value();
+            if intention_rank(target) > intention_rank(&event.intention) {
+                event.intention = target.to_owned();
+            }
+        }
+    }
+
+    /// Promote the toucher's most recent touch to `target` from an
+    /// outcome-authoritative signal (a replay shot/save stat event, or a scored
+    /// goal), matching by player within `window` of `signal_time`.
+    fn confirm_outcome_action(
+        &mut self,
+        player: &PlayerId,
+        signal_time: f32,
+        window: f32,
+        target: TouchIntention,
+    ) {
+        let Some(&touch_index) = self.active_touch_index_by_player.get(player) else {
+            return;
+        };
+        let Some(event) = self.events.get(touch_index) else {
+            return;
+        };
+        if signal_time < event.time || signal_time - event.time > window {
+            return;
+        }
+        self.raise_intention(touch_index, target);
+    }
+
+    /// Upgrade the scorer's most recent touch to a shot for each goal observed
+    /// this frame. The touch that scores is a shot regardless of what its
+    /// at-touch trajectory projection read.
+    fn confirm_goal_shots(&mut self, events_state: &FrameEventsState) {
+        for goal in &events_state.goal_events {
+            let Some(scorer) = goal.player.as_ref() else {
+                continue;
+            };
+            self.confirm_outcome_action(
+                scorer,
+                goal.time,
+                GOAL_SHOT_ATTRIBUTION_WINDOW_SECONDS,
+                TouchIntention::Shot,
+            );
+        }
+    }
+
+    /// Attach replay-reported shot/save stat events that land *after* the touch
+    /// they describe. The classifier matches stat events that precede the touch;
+    /// this covers the common case where the counter increment replicates a
+    /// fraction of a second after the touch (so the touch was already emitted).
+    fn confirm_stat_event_actions(&mut self, events_state: &FrameEventsState) {
+        for stat in &events_state.player_stat_events {
+            let target = match stat.kind {
+                PlayerStatEventKind::Shot => TouchIntention::Shot,
+                PlayerStatEventKind::Save => TouchIntention::Save,
+                PlayerStatEventKind::Assist => continue,
+            };
+            self.confirm_outcome_action(
+                &stat.player,
+                stat.time,
+                STAT_EVENT_OUTCOME_WINDOW_SECONDS,
+                target,
+            );
         }
     }
 
@@ -537,6 +664,15 @@ impl TouchCalculator {
             player_sample.and_then(PlayerSample::velocity),
         );
         self.apply_control_resolution(resolution);
+    }
+
+    /// Feed this frame's free-flight ball sample to any open shot-projection
+    /// window and apply its resolution once it ages out.
+    fn advance_shot_projection(&mut self, frame: &FrameInfo, ball: &BallFrameState) {
+        let resolution = self
+            .shot_projection
+            .advance(frame, ball.position(), ball.velocity());
+        self.apply_shot_projection_resolution(resolution);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -781,6 +917,10 @@ impl TouchCalculator {
         live_play_state: &LivePlayState,
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
+        // A scored goal makes the scorer's most recent touch a shot regardless
+        // of trajectory. Resolve it before any live-play boundary reset, since
+        // the goal frame is often the frame play stops.
+        self.confirm_goal_shots(events_state);
         if !live_play_state.is_live_play {
             self.finalize_ball_movement_at_boundary(Boundary::LivePlayEnded);
             self.previous_ball_velocity = ball.velocity();
@@ -790,6 +930,8 @@ impl TouchCalculator {
             self.intention_classifier.reset();
             let resolution = self.control_follow.flush();
             self.apply_control_resolution(resolution);
+            let shot_resolution = self.shot_projection.flush();
+            self.apply_shot_projection_resolution(shot_resolution);
             return Ok(());
         }
         self.intention_classifier
@@ -803,8 +945,12 @@ impl TouchCalculator {
             &touch_state.touch_events,
             fifty_fifty_state,
         );
+        // Replay shot/save stat events that land after their touch (the common
+        // case) are attached here; the classifier handles ones that precede it.
+        self.confirm_stat_event_actions(events_state);
         self.advance_dodge_upgrades(frame, players);
         self.advance_control_follow(frame, ball, players);
+        self.advance_shot_projection(frame, ball);
         self.credit_ball_movement(
             frame,
             ball,

--- a/src/stats/calculators/touch.rs
+++ b/src/stats/calculators/touch.rs
@@ -441,8 +441,8 @@ impl TouchCalculator {
                 .observe_touch(player_id, touch_event.time);
             self.apply_control_resolution(control_resolution);
             // This new touch ends the previous touch's free flight; resolve its
-            // shot projection from the settled trajectory just before now.
-            let shot_resolution = self.shot_projection.observe_touch();
+            // shot projection from the settled trajectory shortly before now.
+            let shot_resolution = self.shot_projection.observe_touch(touch_event.time);
             self.apply_shot_projection_resolution(shot_resolution);
             let resolution = self.intention_classifier.classify(
                 touch_event,

--- a/src/stats/calculators/touch_intention.rs
+++ b/src/stats/calculators/touch_intention.rs
@@ -468,11 +468,16 @@ fn opponent_goal_line_y(is_team_0: bool) -> f32 {
     -own_goal_line_y(is_team_0)
 }
 
-/// Returns true when a straight-line projection of the trajectory crosses the
-/// goal line at `target_goal_y` inside the goal mouth (with a ball-radius
-/// margin) within `max_seconds`. Gravity, bounces, and later touches are
-/// deliberately ignored, matching the other goal-mouth projections in this
-/// crate.
+/// Returns true when a ballistic projection of the trajectory crosses the goal
+/// line at `target_goal_y` inside the goal mouth (with a ball-radius margin)
+/// within `max_seconds`.
+///
+/// The horizontal (x/y) path is a straight line — gravity is purely vertical,
+/// so it does not change when the ball reaches the goal line nor its lateral
+/// position there. The vertical (z) path applies constant gravity, so a shot
+/// hit upward that arcs back down into the net is read correctly instead of
+/// being projected straight over the crossbar. Wall bounces and later touches
+/// are still deliberately ignored.
 fn trajectory_crosses_goal_mouth(
     position: glam::Vec3,
     velocity: glam::Vec3,
@@ -486,10 +491,17 @@ fn trajectory_crosses_goal_mouth(
     if !time_to_goal_line.is_finite() || !(0.0..=max_seconds).contains(&time_to_goal_line) {
         return false;
     }
-    let projected = position + velocity * time_to_goal_line;
-    projected.x.abs() <= BACK_WALL_GOAL_MOUTH_HALF_WIDTH_X + GOAL_MOUTH_TRAJECTORY_MARGIN
-        && projected.z >= BALL_RADIUS_Z - GOAL_MOUTH_TRAJECTORY_MARGIN
-        && projected.z <= GOAL_MOUTH_HEIGHT_Z + GOAL_MOUTH_TRAJECTORY_MARGIN
+    let projected_x = position.x + velocity.x * time_to_goal_line;
+    let projected_z = position.z
+        + velocity.z * time_to_goal_line
+        + 0.5
+            * crate::util::ballistics::STANDARD_BALL_GRAVITY_Z
+            * time_to_goal_line
+            * time_to_goal_line;
+    projected_x.abs() <= BACK_WALL_GOAL_MOUTH_HALF_WIDTH_X + GOAL_MOUTH_TRAJECTORY_MARGIN
+        && (BALL_RADIUS_Z - GOAL_MOUTH_TRAJECTORY_MARGIN
+            ..=GOAL_MOUTH_HEIGHT_Z + GOAL_MOUTH_TRAJECTORY_MARGIN)
+            .contains(&projected_z)
 }
 
 #[cfg(test)]

--- a/src/stats/calculators/touch_intention.rs
+++ b/src/stats/calculators/touch_intention.rs
@@ -452,6 +452,14 @@ impl ControlFollowTracker {
 /// the ball is actually headed; we wait for the trajectory to settle.
 const SHOT_PROJECTION_MIN_FREE_FLIGHT_SECONDS: f32 = 0.06;
 
+/// When a new touch ends free flight, samples within this many seconds of that
+/// touch are ignored. The incoming touch's impulse can start moving the ball a
+/// frame or two before its touch marker is detected (the same replication lag
+/// as the dodge byte), so the very last free-flight samples may already be
+/// contaminated by the next touch. Resolving from a few frames earlier keeps
+/// the read on the ball's own settled trajectory.
+const SHOT_PROJECTION_NEXT_TOUCH_GUARD_SECONDS: f32 = 0.12;
+
 /// Outcome of a closed shot-projection window. `touch_index` addresses the
 /// touch event to upgrade to a shot when `is_shot` is true.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -472,25 +480,62 @@ struct ShotProjectionWindow {
     touch_index: usize,
     is_team_0: bool,
     touch_time: f32,
-    last_sample: Option<ShotProjectionSample>,
+    /// Recent free-flight samples, oldest first. Bounded to the look-back the
+    /// next-touch guard needs, so it never grows with window length.
+    samples: VecDeque<ShotProjectionSample>,
 }
 
 impl ShotProjectionWindow {
-    /// Resolve from the most recent free-flight sample — i.e. the last moment
-    /// before the next touch ended the ball's free flight. That settled sample
-    /// is a far more reliable read of "was this headed in?" than the touch
-    /// frame, which is sampled before the impulse has finished landing.
-    fn resolution(&self) -> ShotProjectionResolution {
-        let is_shot = self.last_sample.is_some_and(|sample| {
-            sample.time - self.touch_time >= SHOT_PROJECTION_MIN_FREE_FLIGHT_SECONDS
-                && sample.velocity.length() >= SHOT_MIN_BALL_SPEED
-                && trajectory_crosses_goal_mouth(
-                    sample.position,
-                    sample.velocity,
-                    opponent_goal_line_y(self.is_team_0),
-                    SHOT_MAX_TIME_TO_GOAL_SECONDS,
-                )
-        });
+    fn record(&mut self, sample: ShotProjectionSample) {
+        // Retain enough history to look back past the next-touch guard, plus a
+        // small margin, and no more.
+        let cutoff = sample.time - (SHOT_PROJECTION_NEXT_TOUCH_GUARD_SECONDS + 0.1);
+        self.samples.push_back(sample);
+        while self
+            .samples
+            .front()
+            .is_some_and(|oldest| oldest.time < cutoff)
+        {
+            self.samples.pop_front();
+        }
+    }
+
+    fn is_shot_from(&self, sample: &ShotProjectionSample) -> bool {
+        sample.time - self.touch_time >= SHOT_PROJECTION_MIN_FREE_FLIGHT_SECONDS
+            && sample.velocity.length() >= SHOT_MIN_BALL_SPEED
+            && trajectory_crosses_goal_mouth(
+                sample.position,
+                sample.velocity,
+                opponent_goal_line_y(self.is_team_0),
+                SHOT_MAX_TIME_TO_GOAL_SECONDS,
+            )
+    }
+
+    /// Resolve from the most recent sample. Used when free flight ends at a
+    /// boundary (goal / stoppage / end of replay): nothing perturbs the ball, so
+    /// the last sample is the cleanest read of where it was headed.
+    fn resolution_latest(&self) -> ShotProjectionResolution {
+        let is_shot = self
+            .samples
+            .back()
+            .is_some_and(|sample| self.is_shot_from(sample));
+        ShotProjectionResolution {
+            touch_index: self.touch_index,
+            is_shot,
+        }
+    }
+
+    /// Resolve from the most recent sample at least the guard interval before
+    /// `close_time`. Used when a new touch ends free flight, so the read sits on
+    /// the ball's own trajectory rather than the next touch's incoming impulse.
+    fn resolution_before(&self, close_time: f32) -> ShotProjectionResolution {
+        let limit = close_time - SHOT_PROJECTION_NEXT_TOUCH_GUARD_SECONDS;
+        let is_shot = self
+            .samples
+            .iter()
+            .rev()
+            .find(|sample| sample.time <= limit)
+            .is_some_and(|sample| self.is_shot_from(sample));
         ShotProjectionResolution {
             touch_index: self.touch_index,
             is_shot,
@@ -499,10 +544,10 @@ impl ShotProjectionWindow {
 }
 
 /// Watches the ball's free flight after a touch and decides, from the settled
-/// trajectory just before the next touch, whether the touch sent the ball
-/// goalward — recovering shots whose touch-frame velocity had not yet finished
-/// updating. Resolutions are applied retroactively to the already-emitted touch
-/// event, mirroring [`ControlFollowTracker`].
+/// trajectory before the next touch, whether the touch sent the ball goalward —
+/// recovering shots whose touch-frame velocity had not yet finished updating.
+/// Resolutions are applied retroactively to the already-emitted touch event,
+/// mirroring [`ControlFollowTracker`].
 ///
 /// At most one window is open at a time: any new touch closes the previous
 /// window.
@@ -518,14 +563,17 @@ impl ShotProjectionTracker {
             touch_index,
             is_team_0,
             touch_time: time,
-            last_sample: None,
+            samples: VecDeque::new(),
         });
     }
 
-    /// Close the open window because a new touch ended free flight, resolving it
-    /// from the last sample observed before this touch.
-    pub fn observe_touch(&mut self) -> Option<ShotProjectionResolution> {
-        self.window.take().map(|window| window.resolution())
+    /// Close the open window because a new touch at `next_touch_time` ended free
+    /// flight, resolving it from a sample taken a guard interval before that
+    /// touch so the next touch's pre-detection impulse can't skew the read.
+    pub fn observe_touch(&mut self, next_touch_time: f32) -> Option<ShotProjectionResolution> {
+        self.window
+            .take()
+            .map(|window| window.resolution_before(next_touch_time))
     }
 
     /// Record this frame's free-flight ball sample, or resolve the window once
@@ -541,11 +589,11 @@ impl ShotProjectionTracker {
             .as_ref()
             .is_some_and(|window| frame.time - window.touch_time > SHOT_MAX_TIME_TO_GOAL_SECONDS)
         {
-            return self.flush();
+            return self.window.take().map(|window| window.resolution_latest());
         }
         let window = self.window.as_mut()?;
         if let (Some(position), Some(velocity)) = (ball_position, ball_velocity) {
-            window.last_sample = Some(ShotProjectionSample {
+            window.record(ShotProjectionSample {
                 position,
                 velocity,
                 time: frame.time,
@@ -556,7 +604,7 @@ impl ShotProjectionTracker {
 
     /// Close any open window immediately (live-play boundary or end of replay).
     pub fn flush(&mut self) -> Option<ShotProjectionResolution> {
-        self.window.take().map(|window| window.resolution())
+        self.window.take().map(|window| window.resolution_latest())
     }
 }
 

--- a/src/stats/calculators/touch_intention.rs
+++ b/src/stats/calculators/touch_intention.rs
@@ -446,6 +446,120 @@ impl ControlFollowTracker {
     }
 }
 
+/// A free-flight sample must be at least this far past the touch before its
+/// projection is trusted. The dodge/flick impulse is delivered over several
+/// frames, so the touch frame itself is the *least* reliable sample of where
+/// the ball is actually headed; we wait for the trajectory to settle.
+const SHOT_PROJECTION_MIN_FREE_FLIGHT_SECONDS: f32 = 0.06;
+
+/// Outcome of a closed shot-projection window. `touch_index` addresses the
+/// touch event to upgrade to a shot when `is_shot` is true.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShotProjectionResolution {
+    pub touch_index: usize,
+    pub is_shot: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ShotProjectionSample {
+    position: glam::Vec3,
+    velocity: glam::Vec3,
+    time: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ShotProjectionWindow {
+    touch_index: usize,
+    is_team_0: bool,
+    touch_time: f32,
+    last_sample: Option<ShotProjectionSample>,
+}
+
+impl ShotProjectionWindow {
+    /// Resolve from the most recent free-flight sample — i.e. the last moment
+    /// before the next touch ended the ball's free flight. That settled sample
+    /// is a far more reliable read of "was this headed in?" than the touch
+    /// frame, which is sampled before the impulse has finished landing.
+    fn resolution(&self) -> ShotProjectionResolution {
+        let is_shot = self.last_sample.is_some_and(|sample| {
+            sample.time - self.touch_time >= SHOT_PROJECTION_MIN_FREE_FLIGHT_SECONDS
+                && sample.velocity.length() >= SHOT_MIN_BALL_SPEED
+                && trajectory_crosses_goal_mouth(
+                    sample.position,
+                    sample.velocity,
+                    opponent_goal_line_y(self.is_team_0),
+                    SHOT_MAX_TIME_TO_GOAL_SECONDS,
+                )
+        });
+        ShotProjectionResolution {
+            touch_index: self.touch_index,
+            is_shot,
+        }
+    }
+}
+
+/// Watches the ball's free flight after a touch and decides, from the settled
+/// trajectory just before the next touch, whether the touch sent the ball
+/// goalward — recovering shots whose touch-frame velocity had not yet finished
+/// updating. Resolutions are applied retroactively to the already-emitted touch
+/// event, mirroring [`ControlFollowTracker`].
+///
+/// At most one window is open at a time: any new touch closes the previous
+/// window.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ShotProjectionTracker {
+    window: Option<ShotProjectionWindow>,
+}
+
+impl ShotProjectionTracker {
+    /// Open a projection window for a just-emitted touch event.
+    pub fn open(&mut self, touch_index: usize, is_team_0: bool, time: f32) {
+        self.window = Some(ShotProjectionWindow {
+            touch_index,
+            is_team_0,
+            touch_time: time,
+            last_sample: None,
+        });
+    }
+
+    /// Close the open window because a new touch ended free flight, resolving it
+    /// from the last sample observed before this touch.
+    pub fn observe_touch(&mut self) -> Option<ShotProjectionResolution> {
+        self.window.take().map(|window| window.resolution())
+    }
+
+    /// Record this frame's free-flight ball sample, or resolve the window once
+    /// it ages past the shot time-to-goal horizon.
+    pub fn advance(
+        &mut self,
+        frame: &FrameInfo,
+        ball_position: Option<glam::Vec3>,
+        ball_velocity: Option<glam::Vec3>,
+    ) -> Option<ShotProjectionResolution> {
+        if self
+            .window
+            .as_ref()
+            .is_some_and(|window| frame.time - window.touch_time > SHOT_MAX_TIME_TO_GOAL_SECONDS)
+        {
+            return self.flush();
+        }
+        let window = self.window.as_mut()?;
+        if let (Some(position), Some(velocity)) = (ball_position, ball_velocity) {
+            window.last_sample = Some(ShotProjectionSample {
+                position,
+                velocity,
+                time: frame.time,
+            });
+        }
+        None
+    }
+
+    /// Close any open window immediately (live-play boundary or end of replay).
+    pub fn flush(&mut self) -> Option<ShotProjectionResolution> {
+        self.window.take().map(|window| window.resolution())
+    }
+}
+
 /// True when an active 50/50 lists this player as one of its contestants.
 pub(crate) fn fifty_fifty_involves_player(
     active: &ActiveFiftyFifty,

--- a/src/stats/calculators/touch_intention_tests.rs
+++ b/src/stats/calculators/touch_intention_tests.rs
@@ -498,3 +498,58 @@ fn window_cut_short_does_not_confirm_control() {
     let resolution = tracker.flush().unwrap();
     assert!(!resolution.control);
 }
+
+#[test]
+fn shot_projection_confirms_shot_from_settled_goalward_sample() {
+    // is_team_0 touches default to attacking +y; a settled free-flight sample
+    // headed hard into the opponent mouth resolves as a shot.
+    let mut tracker = ShotProjectionTracker::default();
+    tracker.open(0, true, 1.0);
+
+    assert!(
+        tracker
+            .advance(
+                &frame_at(1.1),
+                Some(glam::Vec3::new(0.0, 4000.0, BALL_RADIUS_Z)),
+                Some(glam::Vec3::new(0.0, 2500.0, 0.0)),
+            )
+            .is_none()
+    );
+
+    let resolution = tracker.observe_touch().unwrap();
+    assert_eq!(resolution.touch_index, 0);
+    assert!(resolution.is_shot);
+}
+
+#[test]
+fn shot_projection_ignores_sample_too_soon_after_touch() {
+    // A sample within the settle window is the unreliable just-touched frame and
+    // must not by itself confirm a shot.
+    let mut tracker = ShotProjectionTracker::default();
+    tracker.open(0, true, 1.0);
+
+    tracker.advance(
+        &frame_at(1.02),
+        Some(glam::Vec3::new(0.0, 4000.0, BALL_RADIUS_Z)),
+        Some(glam::Vec3::new(0.0, 2500.0, 0.0)),
+    );
+
+    let resolution = tracker.observe_touch().unwrap();
+    assert!(!resolution.is_shot);
+}
+
+#[test]
+fn shot_projection_does_not_confirm_off_target_free_flight() {
+    let mut tracker = ShotProjectionTracker::default();
+    tracker.open(0, true, 1.0);
+
+    // Settled, fast, but sailing well over the crossbar.
+    tracker.advance(
+        &frame_at(1.1),
+        Some(glam::Vec3::new(0.0, 4000.0, BALL_RADIUS_Z)),
+        Some(glam::Vec3::new(0.0, 2500.0, 2000.0)),
+    );
+
+    let resolution = tracker.flush().unwrap();
+    assert!(!resolution.is_shot);
+}

--- a/src/stats/calculators/touch_intention_tests.rs
+++ b/src/stats/calculators/touch_intention_tests.rs
@@ -499,6 +499,13 @@ fn window_cut_short_does_not_confirm_control() {
     assert!(!resolution.control);
 }
 
+fn goalward_sample() -> (glam::Vec3, glam::Vec3) {
+    (
+        glam::Vec3::new(0.0, 4000.0, BALL_RADIUS_Z),
+        glam::Vec3::new(0.0, 2500.0, 0.0),
+    )
+}
+
 #[test]
 fn shot_projection_confirms_shot_from_settled_goalward_sample() {
     // is_team_0 touches default to attacking +y; a settled free-flight sample
@@ -506,18 +513,44 @@ fn shot_projection_confirms_shot_from_settled_goalward_sample() {
     let mut tracker = ShotProjectionTracker::default();
     tracker.open(0, true, 1.0);
 
-    assert!(
-        tracker
-            .advance(
-                &frame_at(1.1),
-                Some(glam::Vec3::new(0.0, 4000.0, BALL_RADIUS_Z)),
-                Some(glam::Vec3::new(0.0, 2500.0, 0.0)),
-            )
-            .is_none()
+    let (position, velocity) = goalward_sample();
+    for time in [1.1, 1.2, 1.3] {
+        assert!(
+            tracker
+                .advance(&frame_at(time), Some(position), Some(velocity))
+                .is_none()
+        );
+    }
+
+    // Next touch at 1.45; the guard ignores the last 0.12s, landing on the
+    // 1.3 sample, which is still cleanly goalward.
+    let resolution = tracker.observe_touch(1.45).unwrap();
+    assert_eq!(resolution.touch_index, 0);
+    assert!(resolution.is_shot);
+}
+
+#[test]
+fn shot_projection_guard_skips_next_touch_contaminated_samples() {
+    // Real free flight is goalward, but the frame right before the next touch is
+    // already being dragged off by that touch's incoming impulse. The guard must
+    // resolve from the earlier clean samples and still read a shot.
+    let mut tracker = ShotProjectionTracker::default();
+    tracker.open(0, true, 1.0);
+
+    let (position, velocity) = goalward_sample();
+    for time in [1.1, 1.2] {
+        tracker.advance(&frame_at(time), Some(position), Some(velocity));
+    }
+    // Contaminated last frame: ball yanked sideways/backward by the next touch.
+    tracker.advance(
+        &frame_at(1.3),
+        Some(glam::Vec3::new(0.0, 4200.0, BALL_RADIUS_Z)),
+        Some(glam::Vec3::new(3000.0, -1500.0, 0.0)),
     );
 
-    let resolution = tracker.observe_touch().unwrap();
-    assert_eq!(resolution.touch_index, 0);
+    // Next touch at 1.32: without the guard this would read the 1.3 sample and
+    // miss the shot; the guard falls back to the 1.2 sample.
+    let resolution = tracker.observe_touch(1.32).unwrap();
     assert!(resolution.is_shot);
 }
 
@@ -528,13 +561,10 @@ fn shot_projection_ignores_sample_too_soon_after_touch() {
     let mut tracker = ShotProjectionTracker::default();
     tracker.open(0, true, 1.0);
 
-    tracker.advance(
-        &frame_at(1.02),
-        Some(glam::Vec3::new(0.0, 4000.0, BALL_RADIUS_Z)),
-        Some(glam::Vec3::new(0.0, 2500.0, 0.0)),
-    );
+    let (position, velocity) = goalward_sample();
+    tracker.advance(&frame_at(1.02), Some(position), Some(velocity));
 
-    let resolution = tracker.observe_touch().unwrap();
+    let resolution = tracker.observe_touch(1.2).unwrap();
     assert!(!resolution.is_shot);
 }
 

--- a/src/stats/calculators/touch_intention_tests.rs
+++ b/src/stats/calculators/touch_intention_tests.rs
@@ -142,6 +142,48 @@ fn fast_touch_toward_goal_mouth_classifies_as_shot() {
 }
 
 #[test]
+fn upward_arced_shot_into_net_classifies_as_shot() {
+    // A shot hit hard with significant upward velocity: a straight-line
+    // projection sails it well over the crossbar (z ~1500), but gravity arcs it
+    // back down into the goal mouth (z ~160). This mirrors a dribble-flick that
+    // scores along an obvious arc, which used to read as Neutral.
+    let player_id = player(1);
+    let mut classifier = TouchIntentionClassifier::default();
+
+    let resolution = classifier.classify(
+        &touch_at(&player_id, 1.0),
+        &player_id,
+        &TouchIntentionFrameContext {
+            ball_position: Some(glam::Vec3::new(0.0, 0.0, BALL_RADIUS_Z)),
+            ball_velocity: Some(glam::Vec3::new(0.0, 2500.0, 700.0)),
+            ..neutral_ctx()
+        },
+    );
+
+    assert_eq!(resolution.intention, TouchIntention::Shot);
+}
+
+#[test]
+fn shot_sailing_over_the_crossbar_is_not_a_shot() {
+    // Even with gravity, a ball rocketing upward is still well above the
+    // crossbar when it reaches the goal line, so it must not read as a shot.
+    let player_id = player(1);
+    let mut classifier = TouchIntentionClassifier::default();
+
+    let resolution = classifier.classify(
+        &touch_at(&player_id, 1.0),
+        &player_id,
+        &TouchIntentionFrameContext {
+            ball_position: Some(glam::Vec3::new(0.0, 4000.0, BALL_RADIUS_Z)),
+            ball_velocity: Some(glam::Vec3::new(0.0, 2500.0, 2000.0)),
+            ..neutral_ctx()
+        },
+    );
+
+    assert_eq!(resolution.intention, TouchIntention::Neutral);
+}
+
+#[test]
 fn touch_wide_of_goal_mouth_is_not_a_shot() {
     let player_id = player(1);
     let mut classifier = TouchIntentionClassifier::default();

--- a/src/stats/calculators/touch_tests.rs
+++ b/src/stats/calculators/touch_tests.rs
@@ -1035,3 +1035,191 @@ fn touch_where_ball_leaves_the_player_stays_neutral() {
     assert_eq!(stats.intention_count("control"), 0);
     assert_eq!(stats.intention_count("neutral"), 1);
 }
+
+/// Drives one live-play frame through the calculator with the given ball,
+/// touch, and frame-events state, holding the toucher parked away from the ball.
+#[allow(clippy::too_many_arguments)]
+fn update_frame(
+    calculator: &mut TouchCalculator,
+    player_id: &PlayerId,
+    frame_number: usize,
+    ball: &BallFrameState,
+    touch_state: &TouchState,
+    events_state: &FrameEventsState,
+) {
+    calculator
+        .update(
+            &frame(frame_number),
+            ball,
+            &player_frame_state(player_id, glam::Vec3::new(0.0, -2000.0, 17.0)),
+            &vertical_state(player_id, 17.0),
+            &RotationCalculator::default(),
+            touch_state,
+            &possession(player_id, true),
+            &FiftyFiftyState::default(),
+            events_state,
+            &LivePlayState::active_play(),
+        )
+        .unwrap();
+}
+
+fn goal_events_state(player_id: &PlayerId, time: f32, frame_number: usize) -> FrameEventsState {
+    FrameEventsState {
+        goal_events: vec![GoalEvent {
+            time,
+            frame: frame_number,
+            scoring_team_is_team_0: true,
+            player: Some(player_id.clone()),
+            player_position: None,
+            team_zero_score: None,
+            team_one_score: None,
+        }],
+        ..FrameEventsState::default()
+    }
+}
+
+fn stat_events_state(
+    player_id: &PlayerId,
+    time: f32,
+    frame_number: usize,
+    kind: PlayerStatEventKind,
+) -> FrameEventsState {
+    FrameEventsState {
+        player_stat_events: vec![PlayerStatEvent {
+            time,
+            frame: frame_number,
+            player: player_id.clone(),
+            player_position: None,
+            is_team_0: true,
+            kind,
+            shot: None,
+        }],
+        ..FrameEventsState::default()
+    }
+}
+
+#[test]
+fn settled_free_flight_trajectory_upgrades_touch_to_shot() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = TouchCalculator::new();
+
+    // Touch frame: ball not yet moving goalward, so it reads as a non-shot.
+    update_frame(
+        &mut calculator,
+        &player_id,
+        1,
+        &ball(0.0, 0.0),
+        &touch_state(1, &player_id),
+        &FrameEventsState::default(),
+    );
+    assert_eq!(calculator.events()[0].intention, "neutral");
+
+    // Free flight: the settled trajectory is screaming into the opponent mouth.
+    let goalward = ball_with_position_and_velocity(
+        glam::Vec3::new(0.0, 4000.0, BALL_RADIUS_Z),
+        glam::Vec3::new(0.0, 2500.0, 0.0),
+    );
+    for frame_number in 2..=4 {
+        update_frame(
+            &mut calculator,
+            &player_id,
+            frame_number,
+            &goalward,
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        );
+    }
+    calculator.finish();
+
+    assert_eq!(calculator.events()[0].intention, "shot");
+}
+
+#[test]
+fn scored_goal_upgrades_scorers_last_touch_to_shot() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = TouchCalculator::new();
+
+    // A soft non-shot touch that nonetheless ends up in the net.
+    update_frame(
+        &mut calculator,
+        &player_id,
+        1,
+        &ball(0.0, 0.0),
+        &touch_state(1, &player_id),
+        &FrameEventsState::default(),
+    );
+    assert_eq!(calculator.events()[0].intention, "neutral");
+
+    update_frame(
+        &mut calculator,
+        &player_id,
+        5,
+        &ball(0.0, 0.0),
+        &TouchState::default(),
+        &goal_events_state(&player_id, 0.5, 5),
+    );
+
+    assert_eq!(calculator.events()[0].intention, "shot");
+}
+
+#[test]
+fn replay_shot_stat_after_touch_upgrades_touch_to_shot() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = TouchCalculator::new();
+
+    update_frame(
+        &mut calculator,
+        &player_id,
+        1,
+        &ball(0.0, 0.0),
+        &touch_state(1, &player_id),
+        &FrameEventsState::default(),
+    );
+    assert_eq!(calculator.events()[0].intention, "neutral");
+
+    // The replay shot counter increments a few frames after the touch.
+    update_frame(
+        &mut calculator,
+        &player_id,
+        5,
+        &ball(0.0, 0.0),
+        &TouchState::default(),
+        &stat_events_state(&player_id, 0.5, 5, PlayerStatEventKind::Shot),
+    );
+
+    assert_eq!(calculator.events()[0].intention, "shot");
+}
+
+#[test]
+fn off_target_free_flight_leaves_touch_unchanged() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = TouchCalculator::new();
+
+    update_frame(
+        &mut calculator,
+        &player_id,
+        1,
+        &ball(0.0, 0.0),
+        &touch_state(1, &player_id),
+        &FrameEventsState::default(),
+    );
+
+    // Fast and settled, but flying away from the opponent goal.
+    let away = ball_with_position_and_velocity(
+        glam::Vec3::new(0.0, 0.0, BALL_RADIUS_Z),
+        glam::Vec3::new(0.0, -2500.0, 0.0),
+    );
+    for frame_number in 2..=4 {
+        update_frame(
+            &mut calculator,
+            &player_id,
+            frame_number,
+            &away,
+            &TouchState::default(),
+            &FrameEventsState::default(),
+        );
+    }
+    calculator.finish();
+
+    assert_ne!(calculator.events()[0].intention, "shot");
+}


### PR DESCRIPTION
Follow-up to #247 (stacked on it — the gravity-aware projection is the fallback here). Base will move to `master` once #247 merges.

## Motivation

Obvious goals were being read as `neutral`. Two root causes beyond the gravity bug in #247:

- **We project from the touch frame, the *least* reliable sample.** The dodge/flick impulse is delivered over several frames, so at the touch frame the ball hasn't finished accelerating toward goal. The last settled frame before the next touch is a far better read.
- **We already have authoritative outcome signals and throw them away.** RL emits a `Shot`/`Save` stat event for the touch — but ~0.7s *later*, and our matching is backward-only, so the touch is already classified and emitted before the event arrives. And a `goal_event` names the scorer, whose last touch is by definition a shot.

## What this does

Three retroactive upgrades, layered on top of the existing at-touch classification (which stays as a provisional fast path). They mirror the calculator's existing retroactive patterns (`ControlFollowTracker`, the dodge-byte-lag upgrade) — emit provisional, then rewrite the already-emitted event once the outcome is known:

1. **Goal outcome → Shot.** The scorer's most recent touch before a `goal_event` becomes a shot, regardless of its at-touch projection (`GOAL_SHOT_ATTRIBUTION_WINDOW_SECONDS`).
2. **Late shot/save stat events.** A `Shot`/`Save` `PlayerStatEvent` that lands after its touch is attached to the most recent matching touch by that player (`STAT_EVENT_OUTCOME_WINDOW_SECONDS`). The classifier still handles stat events that *precede* the touch; this covers the after case.
3. **Settled-trajectory projection.** A new `ShotProjectionTracker` (mirroring `ControlFollowTracker`) watches each touch's free flight and, from the last settled sample before the next touch (or boundary), upgrades to a shot if that gravity-aware trajectory crosses the opponent goal mouth. This catches shots whose touch-frame velocity hadn't settled — **including shots that were saved and never reached the line.**

All upgrades pass through one `intention_rank` gate so they can only ever *raise* a touch's classification — never downgrade an outcome-confirmed shot/save, and (for the projection path) never overwrite a contested challenge.

## Result

On `problematic-private-duel-2026-03-20.replay`, **all 12 goals now have the scorer's last touch classified as `shot`** (the first goal was the original report). Shot count over the match went up correspondingly, with no goal left mislabeled.

## Tests

- `ShotProjectionTracker` unit tests: settled goalward sample confirms; sample too soon after the touch does not; off-target (over-the-bar) free flight does not.
- Calculator-level: settled free-flight upgrades a `neutral` touch to `shot`; a scored goal upgrades the scorer's last touch; a late `Shot` stat event upgrades the touch; off-target free flight leaves the touch unchanged.
- Full touch + stats suites pass; `clip_event_differential`, `clip_fidelity`, and `stats_timeline_collector` integration tests pass; `just check-rust` clean.

## Notes

- The `double_tap.rs` sibling gravity bug noted in #247 is still separate (flagged as a background task).
- This is the single-slot `intention` model on `master`; the tag-set refactor in #229 is orthogonal and these upgrades would map cleanly onto its `action` axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)