### PR TITLE
Backdate team possession loss to the loser's last touch

### DIFF
--- a/src/stats/analysis_graph/nodes/stats_projection.rs
+++ b/src/stats/analysis_graph/nodes/stats_projection.rs
@@ -161,8 +161,23 @@ pub struct StatsProjectionNode {
     boost_current_amount_consistency: BoostCurrentAmountConsistencyTracker,
     last_powerslide_sample_frame: Option<usize>,
     last_possession_sample_frame: Option<usize>,
+    /// Live frames awaiting a possession label. Backdated loss means a frame's
+    /// owning team is only known once a later touch (or timeout) resolves it, so
+    /// these are accumulated when the resolver finalizes the segment that covers
+    /// them — not eagerly on the live frame itself.
+    possession_frame_buffer: Vec<PossessionFrameSample>,
     territorial_pressure_tracked_time: f32,
     previous_live_play: Option<bool>,
+}
+
+/// A buffered live frame's possession-zone sample, held until the resolver
+/// decides which team (if any) owned the frame.
+#[derive(Debug, Clone, Default)]
+struct PossessionFrameSample {
+    frame: usize,
+    dt: f32,
+    field_third: Option<String>,
+    field_half: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -202,6 +217,42 @@ struct StatsProjectionCursors {
 impl StatsProjectionNode {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Fold buffered possession frames up to (and including) `end_frame` into the
+    /// stats under `label`, the team the resolver assigned them.
+    fn drain_possession_buffer_through(&mut self, end_frame: usize, label: &str) {
+        let mut drained = 0;
+        while drained < self.possession_frame_buffer.len() {
+            if self.possession_frame_buffer[drained].frame > end_frame {
+                break;
+            }
+            let (dt, field_third, field_half) = {
+                let sample = &self.possession_frame_buffer[drained];
+                (
+                    sample.dt,
+                    sample.field_third.clone(),
+                    sample.field_half.clone(),
+                )
+            };
+            self.state.possession.apply_frame(
+                label,
+                field_third.as_deref(),
+                field_half.as_deref(),
+                dt,
+            );
+            drained += 1;
+        }
+        self.possession_frame_buffer.drain(0..drained);
+    }
+
+    /// Flush any still-unresolved possession frames as neutral. The trailing
+    /// open segment never got a follow-up, so on the model its time is neutral.
+    fn flush_possession_buffer_as_neutral(&mut self) {
+        if self.possession_frame_buffer.is_empty() {
+            return;
+        }
+        self.drain_possession_buffer_through(usize::MAX, "neutral");
     }
 
     fn begin_sample(&mut self, frame: &FrameInfo, live_play: bool) {
@@ -387,29 +438,35 @@ impl StatsProjectionNode {
         // canonical ball_third / ball_half streams. The accumulator is
         // cumulative (not rebuilt each frame), so guard against finish()
         // re-processing the final frame.
+        //
+        // Backdated loss means a live frame's owning team is not known when the
+        // frame is processed: a possession's tail only becomes that team's credit
+        // once they re-touch, and goes neutral otherwise. So buffer each live
+        // frame's zone sample and only fold it into the stats when the resolver
+        // finalizes the segment that covers it.
         let possession = ctx.get::<PossessionCalculator>()?;
         let ball_third = ctx.get::<BallThirdCalculator>()?;
         let ball_half_calculator = ctx.get::<BallHalfCalculator>()?;
         if live_play && self.last_possession_sample_frame != Some(frame.frame_number) {
-            if let Some(possession_event) = possession.current_event().filter(|event| event.active)
-            {
-                let field_third = ball_third
-                    .current_event()
-                    .filter(|event| event.active)
-                    .map(|event| event.field_third.as_str());
-                let field_half = ball_half_calculator
-                    .current_event()
-                    .filter(|event| event.active)
-                    .map(|event| event.field_half.as_str());
-                self.state.possession.apply_frame(
-                    &possession_event.possession_state,
-                    field_third,
-                    field_half,
-                    frame.dt,
-                );
-            }
+            let field_third = ball_third
+                .current_event()
+                .filter(|event| event.active)
+                .map(|event| event.field_third.clone());
+            let field_half = ball_half_calculator
+                .current_event()
+                .filter(|event| event.active)
+                .map(|event| event.field_half.clone());
+            self.possession_frame_buffer.push(PossessionFrameSample {
+                frame: frame.frame_number,
+                dt: frame.dt,
+                field_third,
+                field_half,
+            });
         }
         self.last_possession_sample_frame = Some(frame.frame_number);
+        for segment in possession.new_resolved() {
+            self.drain_possession_buffer_through(segment.end_frame, segment.label.as_label_value());
+        }
         let ball_half = ctx.get::<BallHalfCalculator>()?;
         let projected_ball_half_events = ball_half.projected_events();
         self.state.ball_half = BallHalfStatsAccumulator::default();
@@ -643,6 +700,7 @@ impl AnalysisNode for StatsProjectionNode {
 
     fn finish(&mut self, ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
         self.project_frame(ctx)?;
+        self.flush_possession_buffer_as_neutral();
         self.warn_for_unresolved_boost_current_amount_drift();
         Ok(())
     }

--- a/src/stats/calculators/player_possession_tests.rs
+++ b/src/stats/calculators/player_possession_tests.rs
@@ -70,6 +70,7 @@ fn possession(player: Option<u64>, team_is_team_0: Option<bool>) -> PossessionSt
         current_team_is_team_0: team_is_team_0,
         active_player_before_sample: player.map(player_id),
         current_player: player.map(player_id),
+        ..Default::default()
     }
 }
 

--- a/src/stats/calculators/possession.rs
+++ b/src/stats/calculators/possession.rs
@@ -3,21 +3,605 @@ use super::*;
 const PENDING_TURNOVER_CONFIRMATION_WINDOW_SECONDS: f32 = 1.25;
 const LOOSE_BALL_TIMEOUT_SECONDS: f32 = 3.0;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-enum PossessionStateLabel {
+/// How long the resolver waits for a follow-up touch before deciding a
+/// possession's fate. A possession's credited span is backdated to its owner's
+/// last touch; the loose time after that touch stays provisional until either
+/// the same owner re-touches (kept), the opponent confirms a turnover (the gap
+/// goes neutral and the opponent is credited from their first touch), or this
+/// window elapses with no follow-up (the gap goes neutral). It unifies the old
+/// pending-turnover (1.25s) and loose-ball (3.0s) windows: with loss backdated
+/// to the last touch, the distinction no longer changes anyone's credited time,
+/// so a single resolution deadline suffices.
+const POSSESSION_RESOLUTION_WINDOW_SECONDS: f32 = 1.5;
+
+/// A team-or-neutral label for a resolved possession segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PossessionLabel {
     TeamZero,
     TeamOne,
-    #[default]
     Neutral,
 }
 
-impl PossessionStateLabel {
-    fn as_label_value(self) -> &'static str {
+impl PossessionLabel {
+    fn team(team_is_team_0: bool) -> Self {
+        if team_is_team_0 {
+            Self::TeamZero
+        } else {
+            Self::TeamOne
+        }
+    }
+
+    pub(crate) fn as_label_value(self) -> &'static str {
         match self {
             Self::TeamZero => "team_zero",
             Self::TeamOne => "team_one",
             Self::Neutral => "neutral",
         }
+    }
+}
+
+/// A finalized stretch of the possession timeline. The resolver emits these as
+/// soon as a touch or timeout decides who (if anyone) owned the stretch, so the
+/// loose time after a possession's last touch only becomes a team's credit once
+/// that team demonstrably keeps the ball.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ResolvedPossession {
+    pub start_time: f32,
+    pub start_frame: usize,
+    pub end_time: f32,
+    pub end_frame: usize,
+    pub label: PossessionLabel,
+    pub player: Option<PlayerId>,
+}
+
+/// The still-open (unresolved) trailing segment of the possession timeline. Its
+/// label is the current best guess; its true extent is only known once it is
+/// resolved, but display consumers can render it as the live possession.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct OpenPossession {
+    pub start_time: f32,
+    pub start_frame: usize,
+    pub label: PossessionLabel,
+    pub player: Option<PlayerId>,
+}
+
+/// The touch situation for a single frame, reduced to which team(s) contacted
+/// the ball and the latest contacting player per team.
+#[derive(Debug, Clone)]
+enum TouchInput {
+    None,
+    /// Exactly one team touched.
+    Single {
+        team_is_team_0: bool,
+        player: Option<PlayerId>,
+    },
+    /// Both teams touched the same frame (contested).
+    Contested {
+        team_zero_player: Option<PlayerId>,
+        team_one_player: Option<PlayerId>,
+    },
+}
+
+impl TouchInput {
+    fn opponent_player(&self, owner_team_is_team_0: bool) -> Option<PlayerId> {
+        match self {
+            TouchInput::Contested {
+                team_zero_player,
+                team_one_player,
+            } => {
+                if owner_team_is_team_0 {
+                    team_one_player.clone()
+                } else {
+                    team_zero_player.clone()
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn owner_player(&self, owner_team_is_team_0: bool) -> Option<PlayerId> {
+        match self {
+            TouchInput::Contested {
+                team_zero_player,
+                team_one_player,
+            } => {
+                if owner_team_is_team_0 {
+                    team_zero_player.clone()
+                } else {
+                    team_one_player.clone()
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+/// The resolver's phase: who (if anyone) currently holds the ball and what
+/// follow-up we are waiting on.
+#[derive(Debug, Clone, PartialEq, Default)]
+enum ResolverPhase {
+    /// No one is credited; the open segment is neutral.
+    #[default]
+    Neutral,
+    /// One team touched a loose/neutral ball once but has not confirmed control.
+    /// The open segment is still neutral — an unconfirmed touch grants nothing.
+    Acquiring {
+        team_is_team_0: bool,
+        first_touch_time: f32,
+        first_touch_frame: usize,
+        player: Option<PlayerId>,
+    },
+    /// A team holds the ball; the open segment is that team's. `last_touch` is
+    /// the trailing edge a loss would be backdated to.
+    Held {
+        team_is_team_0: bool,
+        player: Option<PlayerId>,
+        last_touch_time: f32,
+        last_touch_frame: usize,
+    },
+    /// The holder still owns it, but an opponent has touched once. The open
+    /// segment is still the holder's; the contest resolves on the next touch.
+    HeldChallenged {
+        team_is_team_0: bool,
+        player: Option<PlayerId>,
+        held_last_touch_time: f32,
+        held_last_touch_frame: usize,
+        challenger_first_time: f32,
+        challenger_first_frame: usize,
+        challenger_player: Option<PlayerId>,
+    },
+}
+
+/// Resolves a touch timeline into possession segments with loss backdated to
+/// the loser's last touch (see [`POSSESSION_RESOLUTION_WINDOW_SECONDS`]). This
+/// is the source of truth for team `PossessionEvent`s and `PossessionStats`;
+/// the legacy eager fields on [`PossessionTracker`] still drive per-player
+/// possession.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub(crate) struct PossessionResolver {
+    phase: ResolverPhase,
+    open_start_time: f32,
+    open_start_frame: usize,
+    newly_resolved: Vec<ResolvedPossession>,
+}
+
+impl PossessionResolver {
+    fn reset(&mut self) {
+        self.phase = ResolverPhase::Neutral;
+        self.open_start_time = 0.0;
+        self.open_start_frame = 0;
+        self.newly_resolved.clear();
+    }
+
+    /// Close the open segment at `(end_time, end_frame)` with `label`/`player`
+    /// and start a new open segment there.
+    fn finalize(
+        &mut self,
+        end_time: f32,
+        end_frame: usize,
+        label: PossessionLabel,
+        player: Option<PlayerId>,
+    ) {
+        if end_time > self.open_start_time {
+            self.newly_resolved.push(ResolvedPossession {
+                start_time: self.open_start_time,
+                start_frame: self.open_start_frame,
+                end_time,
+                end_frame,
+                label,
+                player,
+            });
+        }
+        self.open_start_time = end_time;
+        self.open_start_frame = end_frame;
+    }
+
+    fn within_window(now: f32, since: f32) -> bool {
+        now - since <= POSSESSION_RESOLUTION_WINDOW_SECONDS
+    }
+
+    fn touch_input(
+        touched_team_zero_player: &Option<PlayerId>,
+        touched_team_one_player: &Option<PlayerId>,
+        touched_team_zero: bool,
+        touched_team_one: bool,
+    ) -> TouchInput {
+        match (touched_team_zero, touched_team_one) {
+            (false, false) => TouchInput::None,
+            (true, false) => TouchInput::Single {
+                team_is_team_0: true,
+                player: touched_team_zero_player.clone(),
+            },
+            (false, true) => TouchInput::Single {
+                team_is_team_0: false,
+                player: touched_team_one_player.clone(),
+            },
+            (true, true) => TouchInput::Contested {
+                team_zero_player: touched_team_zero_player.clone(),
+                team_one_player: touched_team_one_player.clone(),
+            },
+        }
+    }
+
+    /// Advance the resolver one frame. Pushes any segments finalized this frame
+    /// onto `newly_resolved` (cleared at the start of every call).
+    fn update(
+        &mut self,
+        frame: &FrameInfo,
+        touched_team_zero_player: &Option<PlayerId>,
+        touched_team_one_player: &Option<PlayerId>,
+        touched_team_zero: bool,
+        touched_team_one: bool,
+    ) {
+        self.newly_resolved.clear();
+        let time = frame.time;
+        let fnum = frame.frame_number;
+        let input = Self::touch_input(
+            touched_team_zero_player,
+            touched_team_one_player,
+            touched_team_zero,
+            touched_team_one,
+        );
+
+        let phase = std::mem::take(&mut self.phase);
+        self.phase = match phase {
+            ResolverPhase::Neutral => self.step_neutral(time, fnum, input),
+            ResolverPhase::Acquiring {
+                team_is_team_0,
+                first_touch_time,
+                first_touch_frame,
+                player,
+            } => self.step_acquiring(
+                time,
+                fnum,
+                input,
+                team_is_team_0,
+                first_touch_time,
+                first_touch_frame,
+                player,
+            ),
+            ResolverPhase::Held {
+                team_is_team_0,
+                player,
+                last_touch_time,
+                last_touch_frame,
+            } => self.step_held(
+                time,
+                fnum,
+                input,
+                team_is_team_0,
+                player,
+                last_touch_time,
+                last_touch_frame,
+            ),
+            ResolverPhase::HeldChallenged {
+                team_is_team_0,
+                player,
+                held_last_touch_time,
+                held_last_touch_frame,
+                challenger_first_time,
+                challenger_first_frame,
+                challenger_player,
+            } => self.step_held_challenged(
+                time,
+                fnum,
+                input,
+                team_is_team_0,
+                player,
+                held_last_touch_time,
+                held_last_touch_frame,
+                challenger_first_time,
+                challenger_first_frame,
+                challenger_player,
+            ),
+        };
+    }
+
+    fn step_neutral(&mut self, time: f32, fnum: usize, input: TouchInput) -> ResolverPhase {
+        match input {
+            // A single touch on a neutral ball is provisional: it grants nothing
+            // until the same team confirms control with a follow-up.
+            TouchInput::Single {
+                team_is_team_0,
+                player,
+            } => ResolverPhase::Acquiring {
+                team_is_team_0,
+                first_touch_time: time,
+                first_touch_frame: fnum,
+                player,
+            },
+            // A contested neutral ball stays neutral until someone gets clear of it.
+            TouchInput::None | TouchInput::Contested { .. } => ResolverPhase::Neutral,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn step_acquiring(
+        &mut self,
+        time: f32,
+        fnum: usize,
+        input: TouchInput,
+        team_is_team_0: bool,
+        first_touch_time: f32,
+        first_touch_frame: usize,
+        player: Option<PlayerId>,
+    ) -> ResolverPhase {
+        let still_acquiring = ResolverPhase::Acquiring {
+            team_is_team_0,
+            first_touch_time,
+            first_touch_frame,
+            player: player.clone(),
+        };
+        match input {
+            TouchInput::None => {
+                if Self::within_window(time, first_touch_time) {
+                    still_acquiring
+                } else {
+                    // The lone touch was a deflection; the ball stays neutral.
+                    ResolverPhase::Neutral
+                }
+            }
+            TouchInput::Single {
+                team_is_team_0: touch_team,
+                player: touch_player,
+            } => {
+                if touch_team == team_is_team_0 {
+                    // Confirmed: credit the team from their first touch. The open
+                    // neutral segment ends there; a held segment opens.
+                    self.finalize(
+                        first_touch_time,
+                        first_touch_frame,
+                        PossessionLabel::Neutral,
+                        None,
+                    );
+                    ResolverPhase::Held {
+                        team_is_team_0,
+                        player: touch_player.or(player),
+                        last_touch_time: time,
+                        last_touch_frame: fnum,
+                    }
+                } else {
+                    // The other team got the latest single touch; track them now.
+                    ResolverPhase::Acquiring {
+                        team_is_team_0: touch_team,
+                        first_touch_time: time,
+                        first_touch_frame: fnum,
+                        player: touch_player,
+                    }
+                }
+            }
+            // Contested while acquiring: still nobody in clear control.
+            TouchInput::Contested { .. } => still_acquiring,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn step_held(
+        &mut self,
+        time: f32,
+        fnum: usize,
+        input: TouchInput,
+        team_is_team_0: bool,
+        player: Option<PlayerId>,
+        last_touch_time: f32,
+        last_touch_frame: usize,
+    ) -> ResolverPhase {
+        match input {
+            TouchInput::None => {
+                if Self::within_window(time, last_touch_time) {
+                    ResolverPhase::Held {
+                        team_is_team_0,
+                        player,
+                        last_touch_time,
+                        last_touch_frame,
+                    }
+                } else {
+                    // No follow-up came: possession ends at the last touch and the
+                    // loose tail is neutral.
+                    self.finalize(
+                        last_touch_time,
+                        last_touch_frame,
+                        PossessionLabel::team(team_is_team_0),
+                        player,
+                    );
+                    ResolverPhase::Neutral
+                }
+            }
+            TouchInput::Single {
+                team_is_team_0: touch_team,
+                player: touch_player,
+            } => {
+                if touch_team == team_is_team_0 {
+                    // Same team re-touches: the tail since the last touch is kept,
+                    // the trailing edge advances.
+                    ResolverPhase::Held {
+                        team_is_team_0,
+                        player: touch_player.or(player),
+                        last_touch_time: time,
+                        last_touch_frame: fnum,
+                    }
+                } else {
+                    ResolverPhase::HeldChallenged {
+                        team_is_team_0,
+                        player,
+                        held_last_touch_time: last_touch_time,
+                        held_last_touch_frame: last_touch_frame,
+                        challenger_first_time: time,
+                        challenger_first_frame: fnum,
+                        challenger_player: touch_player,
+                    }
+                }
+            }
+            TouchInput::Contested { .. } => {
+                // Owner and opponent both touched: treat as a fresh challenge,
+                // with the owner's trailing edge advanced to this frame.
+                ResolverPhase::HeldChallenged {
+                    team_is_team_0,
+                    player: input.owner_player(team_is_team_0).or(player),
+                    held_last_touch_time: time,
+                    held_last_touch_frame: fnum,
+                    challenger_first_time: time,
+                    challenger_first_frame: fnum,
+                    challenger_player: input.opponent_player(team_is_team_0),
+                }
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn step_held_challenged(
+        &mut self,
+        time: f32,
+        fnum: usize,
+        input: TouchInput,
+        team_is_team_0: bool,
+        player: Option<PlayerId>,
+        held_last_touch_time: f32,
+        held_last_touch_frame: usize,
+        challenger_first_time: f32,
+        challenger_first_frame: usize,
+        challenger_player: Option<PlayerId>,
+    ) -> ResolverPhase {
+        let confirm_turnover = |resolver: &mut Self, new_player: Option<PlayerId>| {
+            // The holder's credit ends at their last touch; the loose gap up to
+            // the challenger's first touch is neutral; the challenger is credited
+            // from that first touch.
+            resolver.finalize(
+                held_last_touch_time,
+                held_last_touch_frame,
+                PossessionLabel::team(team_is_team_0),
+                player.clone(),
+            );
+            resolver.finalize(
+                challenger_first_time,
+                challenger_first_frame,
+                PossessionLabel::Neutral,
+                None,
+            );
+            ResolverPhase::Held {
+                team_is_team_0: !team_is_team_0,
+                player: new_player.or_else(|| challenger_player.clone()),
+                last_touch_time: time,
+                last_touch_frame: fnum,
+            }
+        };
+
+        match input {
+            TouchInput::None => {
+                if Self::within_window(time, challenger_first_time) {
+                    ResolverPhase::HeldChallenged {
+                        team_is_team_0,
+                        player,
+                        held_last_touch_time,
+                        held_last_touch_frame,
+                        challenger_first_time,
+                        challenger_first_frame,
+                        challenger_player,
+                    }
+                } else {
+                    // Neither side followed up: the contested ball was loose.
+                    // Backdate the holder's loss to their last touch.
+                    self.finalize(
+                        held_last_touch_time,
+                        held_last_touch_frame,
+                        PossessionLabel::team(team_is_team_0),
+                        player,
+                    );
+                    ResolverPhase::Neutral
+                }
+            }
+            TouchInput::Single {
+                team_is_team_0: touch_team,
+                player: touch_player,
+            } => {
+                if touch_team == team_is_team_0 {
+                    // Holder repelled the challenge: the challenger's lone touch
+                    // never confirmed, so it grants nothing and does not break the
+                    // holder's possession. The hold stays continuous through the
+                    // poke (loss is only backdated when the holder is genuinely
+                    // dispossessed, i.e. the opponent confirms or no follow-up
+                    // comes).
+                    ResolverPhase::Held {
+                        team_is_team_0,
+                        player: touch_player.or(player),
+                        last_touch_time: time,
+                        last_touch_frame: fnum,
+                    }
+                } else {
+                    confirm_turnover(self, touch_player)
+                }
+            }
+            TouchInput::Contested { .. } => {
+                confirm_turnover(self, input.opponent_player(team_is_team_0))
+            }
+        }
+    }
+
+    /// The current open (unresolved) segment, or `None` when neutral with no
+    /// accumulated time.
+    fn open(&self) -> OpenPossession {
+        let (label, player) = match &self.phase {
+            ResolverPhase::Neutral | ResolverPhase::Acquiring { .. } => {
+                (PossessionLabel::Neutral, None)
+            }
+            ResolverPhase::Held {
+                team_is_team_0,
+                player,
+                ..
+            }
+            | ResolverPhase::HeldChallenged {
+                team_is_team_0,
+                player,
+                ..
+            } => (PossessionLabel::team(*team_is_team_0), player.clone()),
+        };
+        OpenPossession {
+            start_time: self.open_start_time,
+            start_frame: self.open_start_frame,
+            label,
+            player,
+        }
+    }
+
+    /// Flush the open segment as resolved, backdating any held tail to the last
+    /// touch (the follow-up never came). Used when live play ends.
+    fn flush(&mut self, end_time: f32, end_frame: usize) {
+        let phase = std::mem::take(&mut self.phase);
+        match phase {
+            ResolverPhase::Neutral | ResolverPhase::Acquiring { .. } => {
+                self.finalize(end_time, end_frame, PossessionLabel::Neutral, None);
+            }
+            ResolverPhase::Held {
+                team_is_team_0,
+                player,
+                last_touch_time,
+                last_touch_frame,
+            } => {
+                self.finalize(
+                    last_touch_time,
+                    last_touch_frame,
+                    PossessionLabel::team(team_is_team_0),
+                    player,
+                );
+                self.finalize(end_time, end_frame, PossessionLabel::Neutral, None);
+            }
+            ResolverPhase::HeldChallenged {
+                team_is_team_0,
+                player,
+                held_last_touch_time,
+                held_last_touch_frame,
+                ..
+            } => {
+                self.finalize(
+                    held_last_touch_time,
+                    held_last_touch_frame,
+                    PossessionLabel::team(team_is_team_0),
+                    player,
+                );
+                self.finalize(end_time, end_frame, PossessionLabel::Neutral, None);
+            }
+        }
+        self.phase = ResolverPhase::Neutral;
     }
 }
 
@@ -36,14 +620,6 @@ pub struct PossessionEvent {
     pub player_id: Option<PlayerId>,
 }
 
-impl PossessionEvent {
-    fn absorb_duration(&mut self, frame: &FrameInfo, duration: f32) {
-        self.end_time = frame.time;
-        self.end_frame = frame.frame_number;
-        self.duration += duration;
-    }
-}
-
 #[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct PossessionTracker {
     current_team_is_team_0: Option<bool>,
@@ -51,6 +627,9 @@ pub(crate) struct PossessionTracker {
     last_possession_touch_time: Option<f32>,
     pending_turnover_team_is_team_0: Option<bool>,
     pending_turnover_touch_time: Option<f32>,
+    /// Backdating resolver; source of truth for team possession segments. The
+    /// eager fields above remain the source for per-player possession.
+    resolver: PossessionResolver,
 }
 
 impl PossessionTracker {
@@ -64,6 +643,21 @@ impl PossessionTracker {
         self.current_player = None;
         self.last_possession_touch_time = None;
         self.clear_pending_turnover();
+    }
+
+    /// Begin a fresh resolver run at the start of a live-play stretch.
+    pub(crate) fn begin_resolver(&mut self, frame: &FrameInfo) {
+        self.resolver.reset();
+        self.resolver.open_start_time = frame.time;
+        self.resolver.open_start_frame = frame.frame_number;
+    }
+
+    /// Flush the resolver's open segment when live play ends, returning the
+    /// segments finalized by the flush.
+    pub(crate) fn flush_resolver(&mut self, frame: &FrameInfo) -> Vec<ResolvedPossession> {
+        self.resolver.newly_resolved.clear();
+        self.resolver.flush(frame.time, frame.frame_number);
+        std::mem::take(&mut self.resolver.newly_resolved)
     }
 
     fn expire_pending_turnover(&mut self, time: f32) {
@@ -174,7 +768,12 @@ impl PossessionTracker {
             .and_then(|touch| touch.player.clone())
     }
 
-    pub(crate) fn update(&mut self, time: f32, touch_events: &[TouchEvent]) -> PossessionState {
+    pub(crate) fn update(
+        &mut self,
+        frame: &FrameInfo,
+        touch_events: &[TouchEvent],
+    ) -> PossessionState {
+        let time = frame.time;
         self.expire_pending_turnover(time);
         self.expire_loose_ball(time);
 
@@ -197,11 +796,21 @@ impl PossessionTracker {
             touched_team_one_player.as_ref(),
         );
 
+        self.resolver.update(
+            frame,
+            &touched_team_zero_player,
+            &touched_team_one_player,
+            touched_team_zero,
+            touched_team_one,
+        );
+
         PossessionState {
             active_team_before_sample,
             current_team_is_team_0: self.current_team_is_team_0,
             active_player_before_sample,
             current_player: self.current_player.clone(),
+            newly_resolved: std::mem::take(&mut self.resolver.newly_resolved),
+            open_possession: Some(self.resolver.open()),
         }
     }
 }
@@ -210,26 +819,24 @@ impl PossessionTracker {
 #[path = "possession_tests.rs"]
 mod tests;
 
-/// Derives team possession from ball and touch state.
+/// Builds the team-possession event stream from the backdating resolver's
+/// finalized segments.
+///
+/// Finalized [`ResolvedPossession`] segments (active spans) are emitted as
+/// `PossessionEvent`s as soon as the resolver decides them; non-live stretches
+/// are emitted as coalesced inactive markers so the stream stays contiguous.
+/// The in-progress open segment is exposed via [`Self::current_event`] /
+/// [`Self::projected_events`] for display and goal tagging.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct PossessionCalculator {
-    tracker: PossessionTracker,
     events: EventStream<PossessionEvent>,
-    last_emitted_event_state: Option<PossessionEventState>,
-    pending_event: Option<PendingPossessionEvent>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-struct PossessionEventState {
-    active: bool,
-    possession_state: PossessionStateLabel,
-    player_id: Option<PlayerId>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct PendingPossessionEvent {
-    state: PossessionEventState,
-    event: PossessionEvent,
+    /// Segments finalized this frame, surfaced for the stats projection's
+    /// deferred per-frame accumulation.
+    new_resolved: Vec<ResolvedPossession>,
+    /// The current open (unresolved) segment rendered up to the latest frame.
+    open_event: Option<PossessionEvent>,
+    /// Coalesced inactive (non-live) marker awaiting flush.
+    inactive_pending: Option<PossessionEvent>,
 }
 
 impl PossessionCalculator {
@@ -245,83 +852,58 @@ impl PossessionCalculator {
         self.events.new_events()
     }
 
+    /// All committed events plus the in-progress open/inactive span. Used by
+    /// goal tagging to walk the possession that led to a goal.
     pub fn projected_events(&self) -> Vec<PossessionEvent> {
         let mut events = self.events.all().to_vec();
-        if let Some(pending) = &self.pending_event {
-            events.push(pending.event.clone());
+        if let Some(open) = &self.open_event {
+            events.push(open.clone());
+        }
+        if let Some(inactive) = &self.inactive_pending {
+            events.push(inactive.clone());
         }
         events
     }
 
-    pub fn flush_pending_event(&mut self) {
-        let Some(pending) = self.pending_event.take() else {
-            return;
-        };
-        self.events.push(pending.event);
+    /// Segments the resolver finalized on the most recent frame.
+    pub(crate) fn new_resolved(&self) -> &[ResolvedPossession] {
+        &self.new_resolved
     }
 
-    /// The event covering the most recently processed frame (the in-progress
-    /// pending span, or the last committed event once flushed). Used by the
-    /// projection to read the current possession state per frame without
-    /// rebuilding from the full event stream.
+    pub fn flush_pending_event(&mut self) {
+        if let Some(inactive) = self.inactive_pending.take() {
+            self.events.push(inactive);
+        }
+        if let Some(open) = self.open_event.take() {
+            self.events.push(open);
+        }
+    }
+
+    /// The span covering the most recently processed frame (the open segment if
+    /// live, else the last committed event).
     pub fn current_event(&self) -> Option<&PossessionEvent> {
-        self.pending_event
+        self.open_event
             .as_ref()
-            .map(|pending| &pending.event)
+            .or(self.inactive_pending.as_ref())
             .or_else(|| self.events.all().last())
     }
 
-    fn emit_event_if_changed(
-        &mut self,
-        frame: &FrameInfo,
-        active: bool,
-        duration: f32,
-        possession_state: PossessionStateLabel,
-        player_id: Option<PlayerId>,
-    ) {
-        let event_state = PossessionEventState {
-            active,
-            possession_state,
-            player_id: player_id.clone(),
-        };
-        if self.last_emitted_event_state.as_ref() == Some(&event_state) && duration == 0.0 {
-            return;
+    fn segment_event(segment: &ResolvedPossession) -> PossessionEvent {
+        PossessionEvent {
+            time: segment.start_time,
+            frame: segment.start_frame,
+            end_time: segment.end_time,
+            end_frame: segment.end_frame,
+            active: true,
+            duration: (segment.end_time - segment.start_time).max(0.0),
+            possession_state: segment.label.as_label_value().to_owned(),
+            player_id: segment.player.clone(),
         }
-        let event = PossessionEvent {
-            time: frame.time,
-            frame: frame.frame_number,
-            end_time: frame.time,
-            end_frame: frame.frame_number,
-            active,
-            duration,
-            possession_state: possession_state.as_label_value().to_owned(),
-            player_id,
-        };
-        self.record_event(event_state.clone(), frame, event);
-        self.last_emitted_event_state = Some(event_state);
     }
 
-    fn record_event(
-        &mut self,
-        state: PossessionEventState,
-        frame: &FrameInfo,
-        event: PossessionEvent,
-    ) {
-        let Some(pending) = self.pending_event.as_mut() else {
-            self.pending_event = Some(PendingPossessionEvent { state, event });
-            return;
-        };
-
-        if pending.state == state {
-            pending.event.absorb_duration(frame, event.duration);
-        } else {
-            let previous = self
-                .pending_event
-                .replace(PendingPossessionEvent { state, event });
-            let Some(previous) = previous else {
-                return;
-            };
-            self.events.push(previous.event);
+    fn flush_inactive(&mut self) {
+        if let Some(inactive) = self.inactive_pending.take() {
+            self.events.push(inactive);
         }
     }
 
@@ -332,28 +914,57 @@ impl PossessionCalculator {
         live_play_state: &LivePlayState,
     ) -> SubtrActorResult<()> {
         self.events.begin_update();
+        self.new_resolved.clear();
+
+        // Commit segments the resolver finalized this frame. On the live→non-live
+        // edge these are the flushed tail of the just-ended stretch, so they must
+        // precede any inactive marker for this frame.
+        if !possession_state.newly_resolved.is_empty() {
+            self.flush_inactive();
+            for segment in &possession_state.newly_resolved {
+                self.events.push(Self::segment_event(segment));
+                self.new_resolved.push(segment.clone());
+            }
+        }
+
         if !live_play_state.is_live_play {
-            self.emit_event_if_changed(frame, false, 0.0, PossessionStateLabel::Neutral, None);
+            self.open_event = None;
+            match self.inactive_pending.as_mut() {
+                Some(inactive) => {
+                    inactive.end_time = frame.time;
+                    inactive.end_frame = frame.frame_number;
+                    inactive.duration = (inactive.end_time - inactive.time).max(0.0);
+                }
+                None => {
+                    self.inactive_pending = Some(PossessionEvent {
+                        time: frame.time,
+                        frame: frame.frame_number,
+                        end_time: frame.time,
+                        end_frame: frame.frame_number,
+                        active: false,
+                        duration: 0.0,
+                        possession_state: PossessionLabel::Neutral.as_label_value().to_owned(),
+                        player_id: None,
+                    });
+                }
+            }
             return Ok(());
         }
 
-        let (state, player_id) =
-            if let Some(possession_team_is_team_0) = possession_state.active_team_before_sample {
-                if possession_team_is_team_0 {
-                    (
-                        PossessionStateLabel::TeamZero,
-                        possession_state.active_player_before_sample.clone(),
-                    )
-                } else {
-                    (
-                        PossessionStateLabel::TeamOne,
-                        possession_state.active_player_before_sample.clone(),
-                    )
-                }
-            } else {
-                (PossessionStateLabel::Neutral, None)
-            };
-        self.emit_event_if_changed(frame, true, frame.dt, state, player_id);
+        self.flush_inactive();
+        self.open_event = possession_state.open_possession.as_ref().map(|open| {
+            let label = open.label.as_label_value().to_owned();
+            PossessionEvent {
+                time: open.start_time,
+                frame: open.start_frame,
+                end_time: frame.time,
+                end_frame: frame.frame_number,
+                active: true,
+                duration: (frame.time - open.start_time).max(0.0),
+                possession_state: label,
+                player_id: open.player.clone(),
+            }
+        });
         Ok(())
     }
 }

--- a/src/stats/calculators/possession_state.rs
+++ b/src/stats/calculators/possession_state.rs
@@ -7,12 +7,17 @@ pub struct PossessionState {
     pub current_team_is_team_0: Option<bool>,
     pub active_player_before_sample: Option<PlayerId>,
     pub current_player: Option<PlayerId>,
+    /// Team-possession segments finalized by the backdating resolver this frame.
+    pub(crate) newly_resolved: Vec<ResolvedPossession>,
+    /// The resolver's current open (unresolved) segment, if live.
+    pub(crate) open_possession: Option<OpenPossession>,
 }
 
 /// Maintains shared ball-possession state from touches and live play.
 #[derive(Default)]
 pub struct PossessionStateCalculator {
     tracker: PossessionTracker,
+    was_live: bool,
 }
 
 impl PossessionStateCalculator {
@@ -27,10 +32,26 @@ impl PossessionStateCalculator {
         live_play_state: &LivePlayState,
     ) -> PossessionState {
         if !live_play_state.is_live_play {
+            // On the falling edge, flush the open segment so the just-ended live
+            // stretch is fully resolved (the trailing held tail goes neutral).
+            let newly_resolved = if self.was_live {
+                self.tracker.flush_resolver(frame)
+            } else {
+                Vec::new()
+            };
             self.tracker.reset();
-            return PossessionState::default();
+            self.was_live = false;
+            return PossessionState {
+                newly_resolved,
+                ..PossessionState::default()
+            };
         }
 
-        self.tracker.update(frame.time, &touch_state.touch_events)
+        if !self.was_live {
+            self.tracker.begin_resolver(frame);
+            self.was_live = true;
+        }
+
+        self.tracker.update(frame, &touch_state.touch_events)
     }
 }

--- a/src/stats/calculators/possession_tests.rs
+++ b/src/stats/calculators/possession_tests.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+fn frame_info(frame_number: usize, time: f32) -> FrameInfo {
+    FrameInfo {
+        frame_number,
+        time,
+        dt: 1.0 / 30.0,
+        seconds_remaining: None,
+    }
+}
+
 fn touch(frame: usize, time: f32, player: PlayerId, team_is_team_0: bool) -> TouchEvent {
     TouchEvent {
         touch_id: None,
@@ -16,6 +25,139 @@ fn touch(frame: usize, time: f32, player: PlayerId, team_is_team_0: bool) -> Tou
     }
 }
 
+/// Drives the backdating resolver through a sequence of frames and collects
+/// every finalized segment (live resolutions plus the end-of-stretch flush).
+struct ResolverSim {
+    tracker: PossessionTracker,
+    resolved: Vec<ResolvedPossession>,
+}
+
+impl ResolverSim {
+    fn new() -> Self {
+        let mut tracker = PossessionTracker::default();
+        tracker.begin_resolver(&frame_info(0, 0.0));
+        Self {
+            tracker,
+            resolved: Vec::new(),
+        }
+    }
+
+    fn step(&mut self, frame: usize, time: f32, touches: &[TouchEvent]) {
+        let state = self.tracker.update(&frame_info(frame, time), touches);
+        self.resolved.extend(state.newly_resolved);
+    }
+
+    fn finish(&mut self, frame: usize, time: f32) {
+        self.resolved
+            .extend(self.tracker.flush_resolver(&frame_info(frame, time)));
+    }
+
+    /// The credited (non-neutral) segments as `(team_is_team_0, start, end)`.
+    fn team_segments(&self) -> Vec<(bool, f32, f32)> {
+        self.resolved
+            .iter()
+            .filter_map(|segment| match segment.label {
+                PossessionLabel::TeamZero => Some((true, segment.start_time, segment.end_time)),
+                PossessionLabel::TeamOne => Some((false, segment.start_time, segment.end_time)),
+                PossessionLabel::Neutral => None,
+            })
+            .collect()
+    }
+}
+
+fn p(id: u64) -> PlayerId {
+    PlayerId::Steam(id)
+}
+
+#[test]
+fn single_kickoff_touch_then_lost_credits_no_possession_to_first_toucher() {
+    // Blue (team 0) gets one kickoff touch and hits it away; orange (team 1)
+    // recovers and controls. Blue's lone touch must grant nothing.
+    let mut sim = ResolverSim::new();
+    sim.step(10, 1.0, &[touch(10, 1.0, p(1), true)]); // blue, single → unconfirmed
+    sim.step(20, 2.0, &[touch(20, 2.0, p(2), false)]); // orange takes the loose ball
+    sim.step(25, 2.5, &[touch(25, 2.5, p(2), false)]); // orange confirms control
+    sim.finish(40, 4.0);
+
+    // Only orange is credited, and only from their first touch.
+    assert_eq!(sim.team_segments(), vec![(false, 2.0, 2.5)]);
+}
+
+#[test]
+fn brief_control_with_no_follow_up_is_backdated_to_last_touch() {
+    // Blue controls briefly (two touches) then loses it with no follow-up. The
+    // loose tail after the last touch is neutral, not blue's.
+    let mut sim = ResolverSim::new();
+    sim.step(10, 1.0, &[touch(10, 1.0, p(1), true)]);
+    sim.step(13, 1.3, &[touch(13, 1.3, p(1), true)]); // confirm
+    sim.step(90, 3.0, &[]); // 1.7s with no touch → loss, backdated to 1.3
+    sim.finish(120, 4.0);
+
+    assert_eq!(sim.team_segments(), vec![(true, 1.0, 1.3)]);
+}
+
+#[test]
+fn sustained_dribble_is_one_continuous_segment() {
+    let mut sim = ResolverSim::new();
+    for (frame, time) in [
+        (10, 1.0),
+        (13, 1.3),
+        (16, 1.6),
+        (19, 1.9),
+        (22, 2.2),
+        (25, 2.5),
+    ] {
+        sim.step(frame, time, &[touch(frame, time, p(1), true)]);
+    }
+    sim.finish(40, 4.0);
+
+    // One uninterrupted blue possession from the first touch to the last.
+    assert_eq!(sim.team_segments(), vec![(true, 1.0, 2.5)]);
+}
+
+#[test]
+fn unconfirmed_opponent_clear_grants_nothing_and_keeps_holder_continuous() {
+    // Blue holds; orange gets a single clearing touch; blue recovers before
+    // orange confirms. Orange's lone clear grants nothing and does not break
+    // blue's possession — the hold stays continuous through the repelled poke.
+    let mut sim = ResolverSim::new();
+    sim.step(10, 1.0, &[touch(10, 1.0, p(1), true)]);
+    sim.step(13, 1.3, &[touch(13, 1.3, p(1), true)]); // blue confirms
+    sim.step(18, 1.8, &[touch(18, 1.8, p(1), true)]); // blue extends
+    sim.step(20, 2.0, &[touch(20, 2.0, p(2), false)]); // orange single clear
+    sim.step(23, 2.3, &[touch(23, 2.3, p(1), true)]); // blue repels
+    sim.finish(40, 4.0);
+
+    // Orange credited nothing; blue's possession is one continuous span.
+    assert_eq!(sim.team_segments(), vec![(true, 1.0, 2.3)]);
+}
+
+#[test]
+fn confirmed_turnover_credits_winner_from_first_touch_with_neutral_gap() {
+    // Blue holds, orange wins it with two touches. Blue ends at its last touch,
+    // the loose gap is neutral, orange is credited from its first touch.
+    let mut sim = ResolverSim::new();
+    sim.step(10, 1.0, &[touch(10, 1.0, p(1), true)]);
+    sim.step(13, 1.3, &[touch(13, 1.3, p(1), true)]); // blue confirms, last touch 1.3
+    sim.step(20, 2.0, &[touch(20, 2.0, p(2), false)]); // orange challenges
+    sim.step(24, 2.4, &[touch(24, 2.4, p(2), false)]); // orange confirms turnover
+    sim.finish(40, 4.0);
+
+    assert_eq!(
+        sim.resolved
+            .iter()
+            .map(|s| (s.label, s.start_time, s.end_time))
+            .collect::<Vec<_>>(),
+        vec![
+            (PossessionLabel::Neutral, 0.0, 1.0),
+            (PossessionLabel::TeamZero, 1.0, 1.3),
+            (PossessionLabel::Neutral, 1.3, 2.0),
+            (PossessionLabel::TeamOne, 2.0, 2.4),
+            (PossessionLabel::Neutral, 2.4, 4.0),
+        ]
+    );
+}
+
 #[test]
 fn tracker_uses_latest_touch_player_for_team_independent_of_slice_order() {
     let earlier_player = PlayerId::Steam(1);
@@ -24,7 +166,7 @@ fn tracker_uses_latest_touch_player_for_team_independent_of_slice_order() {
     let later_touch = touch(20, 2.0, later_player.clone(), true);
     let earlier_touch = touch(10, 1.0, earlier_player, true);
 
-    let state = tracker.update(2.0, &[later_touch, earlier_touch]);
+    let state = tracker.update(&frame_info(20, 2.0), &[later_touch, earlier_touch]);
 
     assert_eq!(state.current_team_is_team_0, Some(true));
     assert_eq!(state.current_player, Some(later_player));

--- a/src/stats/calculators/territorial_pressure_tests.rs
+++ b/src/stats/calculators/territorial_pressure_tests.rs
@@ -43,6 +43,7 @@ fn possession(team_is_team_0: Option<bool>) -> PossessionState {
         current_team_is_team_0: team_is_team_0,
         active_player_before_sample: None,
         current_player: None,
+        ..Default::default()
     }
 }
 

--- a/src/stats/calculators/touch_tests.rs
+++ b/src/stats/calculators/touch_tests.rs
@@ -44,6 +44,7 @@ fn possession(player_id: &PlayerId, is_team_0: bool) -> PossessionState {
         current_team_is_team_0: Some(is_team_0),
         active_player_before_sample: Some(player_id.clone()),
         current_player: Some(player_id.clone()),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
## What

Team possession was credited eagerly: once a team touched the ball it held possession every frame until the opponent affirmatively took it (the 1.25s pending-turnover + 3.0s loose-ball windows). So a team that won a kickoff, hit the ball once, and immediately lost it still banked a slice of possession for all the loose-ball time until the opponent's confirming touch.

This replaces that with a **backdating resolver**. A possession's credited span ends at its owner's **last touch**; the loose time after it stays provisional until a follow-up resolves it:

- **same team re-touches** → kept; the span stays continuous (sustained dribbles/carries are unaffected)
- **opponent confirms** → turnover; the loser ends at its last touch, the loose gap is **neutral**, and the winner is credited from its **first** touch
- **no follow-up within ~1.5s** → the tail goes **neutral**

So an unconfirmed single touch (a kickoff whack-away, a lone clearing poke) grants nothing, and a repelled poke no longer fragments the holder. The single 1.5s resolution window unifies the old pending-turnover and loose-ball windows, which no longer change anyone's credited time once loss is backdated.

## Scope

- The resolver is the source of truth for the team `PossessionEvent` stream and `PossessionStats`.
- The eager **per-player** tracker is unchanged, so `PlayerPossessionEvent`s are unaffected.
- Because a frame's owning team is only known once a later touch resolves it, the stats projection now **buffers** each live frame's zone sample and folds it in when the resolver finalizes the covering segment (flushing any unresolved tail as neutral at `finish()`).

## Effect (on `assets/problematic-private-duel-2026-03-20.replay`)

- Off the first kickoff, blue is now credited **zero** — the opening reads neutral until orange establishes real control (~22.6s), instead of the old phantom slice.
- Whole-match split moves heavily toward neutral (this duel: team_zero ~3.6%, team_one ~6.3%, neutral ~90%). Clean multi-touch holds are still recognized; it's single-touch duel play that now reads neutral. This is the intended pure-touch-timing tradeoff.

## Deferred follow-ups (discussed)

- **Join** a holder's spans back together across a neutral gap left by a *failed* opponent clear.
- A **control-aware** loss trigger (hold while the ball stays with the player; neutral only when it's actually driven away) to temper how much loose duel play reads as neutral.

## Tests

New resolver unit tests cover: single-kickoff-touch → no credit, brief-control backdated to last touch, sustained dribble as one continuous span, repelled poke stays continuous, confirmed turnover with neutral gap. `just check`, `just check-types`, targeted possession/projection/goal-tags/fifty-fifty tests, and the bakkesmod ABI compile-check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)