### PR TITLE
Gate flip reset fallback on counter availability

### DIFF
--- a/bakkesmod/rust/src/lib_tests/live_processor_view.rs
+++ b/bakkesmod/rust/src/lib_tests/live_processor_view.rs
@@ -214,6 +214,7 @@ fn live_processor_view_satisfies_processor_surface_from_live_frame() {
         demo_events,
         boost_pad_events,
         touch_events,
+        dodge_refreshed_counter_available: false,
         dodge_refreshed_events,
         player_stat_events,
         goal_events,

--- a/bakkesmod/rust/src/live_processor.rs
+++ b/bakkesmod/rust/src/live_processor.rs
@@ -482,6 +482,10 @@ impl ProcessorView for SaLiveProcessorView<'_> {
         &self.event_history.dodge_refreshed_events
     }
 
+    fn dodge_refreshed_counter_available(&self) -> bool {
+        false
+    }
+
     // The live BakkesMod path does not derive coalesced camera-toggle changes.
     fn player_camera_events(&self) -> &[(PlayerId, PlayerCameraStateChange)] {
         &[]

--- a/src/processor/view.rs
+++ b/src/processor/view.rs
@@ -82,6 +82,7 @@ pub trait ProcessorView {
     fn boost_pad_events(&self) -> &[BoostPadEvent];
     fn touch_events(&self) -> &[TouchEvent];
     fn dodge_refreshed_events(&self) -> &[DodgeRefreshedEvent];
+    fn dodge_refreshed_counter_available(&self) -> bool;
     fn player_camera_events(&self) -> &[(PlayerId, PlayerCameraStateChange)];
     fn player_stat_events(&self) -> &[PlayerStatEvent];
     fn goal_events(&self) -> &[GoalEvent];
@@ -317,6 +318,10 @@ impl ProcessorView for ReplayProcessor<'_> {
 
     fn dodge_refreshed_events(&self) -> &[DodgeRefreshedEvent] {
         &self.dodge_refreshed_events
+    }
+
+    fn dodge_refreshed_counter_available(&self) -> bool {
+        self.cached_object_ids.dodges_refreshed_counter.is_some()
     }
 
     fn player_camera_events(&self) -> &[(PlayerId, PlayerCameraStateChange)] {

--- a/src/stats/calculators/dodge_reset.rs
+++ b/src/stats/calculators/dodge_reset.rs
@@ -606,7 +606,9 @@ impl DodgeResetCalculator {
         }
         self.update_pending_reset_dodges(players, frame.time);
         for touch_event in chronological_touch_events(&touch_state.touch_events) {
-            self.arm_fallback_on_ball_reset(touch_event);
+            if !events.dodge_refreshed_counter_available {
+                self.arm_fallback_on_ball_reset(touch_event);
+            }
             self.process_touch_for_flip_reset(players, touch_event);
         }
         Ok(())

--- a/src/stats/calculators/dodge_reset_tests.rs
+++ b/src/stats/calculators/dodge_reset_tests.rs
@@ -270,6 +270,52 @@ fn underside_touch_can_seed_flip_reset_when_counter_is_absent() {
 }
 
 #[test]
+fn underside_touch_does_not_seed_flip_reset_when_counter_is_available() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let mut calculator = DodgeResetCalculator::new();
+
+    update_live(
+        &mut calculator,
+        &frame_info(1.0, 10),
+        &players(player_id.clone(), false),
+        &FrameEventsState {
+            dodge_refreshed_counter_available: true,
+            ..FrameEventsState::default()
+        },
+        &touch_state(vec![underside_touch_event(player_id.clone(), 1.0, 10)]),
+    );
+    update_live(
+        &mut calculator,
+        &frame_info(1.5, 15),
+        &players(player_id.clone(), true),
+        &FrameEventsState {
+            dodge_refreshed_counter_available: true,
+            ..FrameEventsState::default()
+        },
+        &TouchState::default(),
+    );
+    update_live(
+        &mut calculator,
+        &frame_info(1.6, 16),
+        &players(player_id, true),
+        &FrameEventsState {
+            dodge_refreshed_counter_available: true,
+            ..FrameEventsState::default()
+        },
+        &touch_state(vec![touch_event(boxcars::RemoteId::Steam(1), 1.6, 16)]),
+    );
+
+    assert!(
+        calculator.confirmed_flip_reset_events().is_empty(),
+        "authoritative counter-capable replays should not use geometry fallback"
+    );
+    assert!(
+        calculator.events().is_empty(),
+        "no fallback dodge-reset event should be emitted when counter signal exists"
+    );
+}
+
+#[test]
 fn raw_replay_touch_after_reset_does_not_confirm_without_attributed_touch_state() {
     let player_id = boxcars::RemoteId::Steam(1);
     let mut calculator = DodgeResetCalculator::new();

--- a/src/stats/calculators/frame_components.rs
+++ b/src/stats/calculators/frame_components.rs
@@ -123,6 +123,11 @@ pub struct FrameEventsState {
     pub demo_events: Vec<DemolishInfo>,
     pub boost_pad_events: Vec<BoostPadEvent>,
     pub touch_events: Vec<TouchEvent>,
+    /// Whether the replay exposes the authoritative refreshed-dodge counter.
+    ///
+    /// When this is present, flip-reset detection should prefer counter-derived
+    /// dodge refreshes and avoid geometry fallback candidates.
+    pub dodge_refreshed_counter_available: bool,
     pub dodge_refreshed_events: Vec<DodgeRefreshedEvent>,
     pub player_stat_events: Vec<PlayerStatEvent>,
     pub goal_events: Vec<GoalEvent>,

--- a/src/stats/calculators/frame_input.rs
+++ b/src/stats/calculators/frame_input.rs
@@ -293,6 +293,7 @@ impl FrameInput {
             demo_events: processor.current_frame_demolish_events().to_vec(),
             boost_pad_events: processor.current_frame_boost_pad_events().to_vec(),
             touch_events: processor.current_frame_touch_events().to_vec(),
+            dodge_refreshed_counter_available: processor.dodge_refreshed_counter_available(),
             dodge_refreshed_events: processor.current_frame_dodge_refreshed_events().to_vec(),
             player_stat_events: processor.current_frame_player_stat_events().to_vec(),
             goal_events: processor.current_frame_goal_events().to_vec(),
@@ -309,6 +310,7 @@ impl FrameInput {
             boost_pad_events: processor.boost_pad_events()[event_cursors.boost_pad_event_count..]
                 .to_vec(),
             touch_events: processor.touch_events()[event_cursors.touch_event_count..].to_vec(),
+            dodge_refreshed_counter_available: processor.dodge_refreshed_counter_available(),
             dodge_refreshed_events: processor.dodge_refreshed_events()
                 [event_cursors.dodge_refreshed_event_count..]
                 .to_vec(),


### PR DESCRIPTION
## Summary

- expose whether a replay contains the authoritative `DodgesRefreshedCounter` signal through `ProcessorView` and `FrameEventsState`
- gate the geometry-based flip-reset fallback so it only arms when that replay counter signal is unavailable
- add a unit test proving underside-touch fallback is suppressed when the counter exists

## Context

The Squishy replay fixed in the previous commit has no `TAGame.Car_TA:DodgesRefreshedCounter` object, so the geometry fallback is needed there. Replays that do expose the counter should rely on the counter-derived dodge reset events instead of the fallback.

## Validation

- `cargo test stats::calculators::dodge_reset::tests:: --lib`
- `cargo test --test clip_flip_reset_test`
- `cargo test -p subtr-actor-bakkesmod --no-run`
- `just check`
