### PR TITLE
Gate player possession on real control (touch count + loose distance)

### DIFF
--- a/js/stat-evaluation-player/src/timelineRanges.test.ts
+++ b/js/stat-evaluation-player/src/timelineRanges.test.ts
@@ -14,7 +14,7 @@ import {
 } from "./timelineRanges.ts";
 import { createLegacyStatsTimeline, createStatsTimeline } from "./testStatsTimeline.ts";
 
-test("buildPossessionTimelineRanges derives merged team and neutral control spans", () => {
+test("buildPossessionTimelineRanges draws only active team spans, leaving gaps for neutral", () => {
   const timeline = {
     replay_meta: {},
     timeline_events: [],
@@ -122,16 +122,6 @@ test("buildPossessionTimelineRanges derives merged team and neutral control span
       isTeamZero: true,
     },
     {
-      id: "possession:neutral:2.000",
-      startTime: 2,
-      endTime: 3,
-      lane: "possession",
-      laneLabel: "Possession",
-      label: "Neutral possession",
-      color: "rgba(209, 217, 224, 0.7)",
-      isTeamZero: null,
-    },
-    {
       id: "possession:team_one:3.000",
       startTime: 3,
       endTime: 4,
@@ -181,16 +171,6 @@ test("buildPossessionTimelineRanges derives spans from compact event timelines",
       label: "Blue possession",
       color: "rgba(59, 130, 246, 0.88)",
       isTeamZero: true,
-    },
-    {
-      id: "possession:neutral:2.000",
-      startTime: 2,
-      endTime: 3,
-      lane: "possession",
-      laneLabel: "Possession",
-      label: "Neutral possession",
-      color: "rgba(209, 217, 224, 0.7)",
-      isTeamZero: null,
     },
   ]);
 });

--- a/js/stat-evaluation-player/src/timelineRanges.ts
+++ b/js/stat-evaluation-player/src/timelineRanges.ts
@@ -179,18 +179,9 @@ function buildPossessionTimelineRangesFromEvents(
         color: "rgba(245, 158, 11, 0.88)",
         isTeamZero: false,
       };
-    } else if (active && possessionState === "neutral") {
-      nextRange = {
-        id: `possession:neutral:${startTime.toFixed(3)}`,
-        startTime,
-        endTime,
-        lane: "possession",
-        laneLabel: "Possession",
-        label: "Neutral possession",
-        color: "rgba(209, 217, 224, 0.7)",
-        isTeamZero: null,
-      };
     }
+    // Neutral (and non-live / inactive) stretches draw nothing: the lane only
+    // shows spans where a team actively has possession, leaving gaps elsewhere.
 
     mergeRange(ranges, nextRange);
     previousFrame = frame;
@@ -264,18 +255,9 @@ export function buildPossessionTimelineRanges(
         color: "rgba(245, 158, 11, 0.88)",
         isTeamZero: false,
       };
-    } else if (deltaNeutral > DELTA_EPSILON) {
-      nextRange = {
-        id: `possession:neutral:${startTime.toFixed(3)}`,
-        startTime,
-        endTime,
-        lane: "possession",
-        laneLabel: "Possession",
-        label: "Neutral possession",
-        color: "rgba(209, 217, 224, 0.7)",
-        isTeamZero: null,
-      };
     }
+    // Neutral stretches draw nothing: only spans where a team actively has
+    // possession render, leaving gaps elsewhere.
 
     mergeRange(ranges, nextRange);
     previousFrame = frame;

--- a/src/stats/calculators/player_possession.rs
+++ b/src/stats/calculators/player_possession.rs
@@ -7,6 +7,20 @@ const PLAYER_POSSESSION_MERGE_GAP_SECONDS: f32 = 2.0;
 /// Minimum spacing between touches for them to count as distinct touches
 /// within a possession span (mirrors the controlled-play touch chaining).
 const DISTINCT_TOUCH_GAP_SECONDS: f32 = 0.12;
+/// Distinct touches a player must make for a span to count as possession at
+/// all. A single glancing contact — a kickoff poke the player never follows up
+/// on, say — is not possession, even though that player stayed the last to
+/// touch until an opponent took over. Consecutive touches are the primary
+/// possession signal; proximity is only a loose sanity bound (see
+/// `MAX_POSSESSION_BALL_DISTANCE`).
+const MIN_POSSESSION_TOUCHES: u32 = 2;
+/// A generous ceiling on how far the ball may drift from the holder before the
+/// span is treated as loose. Deliberately far looser than the controlled-play
+/// close radius (`controlled_play::CLOSE_DISTANCE_3D`, 700uu): proximity is not
+/// a primary signal, but once the ball is clearly gone the holder no longer
+/// has it, so the span suspends (and eventually expires) instead of riding the
+/// last touch until an opponent finally intervenes.
+const MAX_POSSESSION_BALL_DISTANCE: f32 = 2500.0;
 
 /// A contiguous single-player possession span, merged across field-third
 /// changes and brief contested interruptions, enriched with the touch, ball
@@ -262,6 +276,13 @@ impl PlayerPossessionCalculator {
     }
 
     fn finalize(&mut self, span: ActivePlayerPossession) {
+        // Possession requires the holder to have actually played the ball more
+        // than once. A span finalizes only when an opponent takes over or the
+        // ball is lost, so this is the retroactive "there was never really any
+        // possession here" check: a lone touch is dropped, never emitted.
+        if span.touch_count < MIN_POSSESSION_TOUCHES {
+            return;
+        }
         self.events.push(span.into_event());
     }
 
@@ -293,6 +314,31 @@ impl PlayerPossessionCalculator {
         })
     }
 
+    /// Demotes the touch-based holder to "no holder" when the ball has drifted
+    /// far from them. Possession is touch-led, so proximity is deliberately
+    /// loose — but once the ball is well out of reach the holder no longer has
+    /// it. Returning `None` makes the open span suspend (resumable if the same
+    /// player gets back to it within the merge gap) rather than ride the last
+    /// touch until an opponent finally intervenes.
+    fn holder_within_reach(
+        current_player: Option<PlayerId>,
+        ball: &BallFrameState,
+        players: &PlayerFrameState,
+    ) -> Option<PlayerId> {
+        let player_id = current_player?;
+        let within = match (
+            ball.position(),
+            players.player(&player_id).and_then(PlayerSample::position),
+        ) {
+            (Some(ball_position), Some(player_position)) => {
+                player_position.distance(ball_position) <= MAX_POSSESSION_BALL_DISTANCE
+            }
+            // Missing geometry: trust the touch-based holder rather than guess.
+            _ => true,
+        };
+        within.then_some(player_id)
+    }
+
     fn carry_sample_kind(
         player_id: &PlayerId,
         ball: &BallFrameState,
@@ -322,7 +368,8 @@ impl PlayerPossessionCalculator {
 
         self.expire_suspended(frame.time);
 
-        let current_player = possession_state.current_player.clone();
+        let current_player =
+            Self::holder_within_reach(possession_state.current_player.clone(), ball, players);
         let field_third = Self::field_third(ball);
 
         if let Some(active) = self.active.as_ref() {

--- a/src/stats/calculators/player_possession_tests.rs
+++ b/src/stats/calculators/player_possession_tests.rs
@@ -64,6 +64,15 @@ fn players_at(position: glam::Vec3) -> PlayerFrameState {
     }
 }
 
+fn players_with(team_zero: glam::Vec3, team_one: glam::Vec3) -> PlayerFrameState {
+    PlayerFrameState {
+        players: vec![
+            player_sample(1, true, team_zero),
+            player_sample(2, false, team_one),
+        ],
+    }
+}
+
 fn possession(player: Option<u64>, team_is_team_0: Option<bool>) -> PossessionState {
     PossessionState {
         active_team_before_sample: team_is_team_0,
@@ -131,7 +140,9 @@ fn emits_single_enriched_span_for_continuous_possession() {
     for step in 0..8 {
         let time = step as f32 * DT;
         let ball = ball_at(step as f32 * 100.0, 1000.0);
-        let touches = if step == 0 {
+        // Two distinct touches so the span qualifies as possession; they are
+        // grounded and well clear of the carry gap, so enrichment is unchanged.
+        let touches = if step == 0 || step == 4 {
             vec![touch(step, time, 1, glam::Vec3::new(0.0, 0.0, 17.0))]
         } else {
             vec![]
@@ -153,7 +164,7 @@ fn emits_single_enriched_span_for_continuous_possession() {
     let event = &events[0];
     assert_eq!(event.player_id, player_id(1));
     assert!(event.is_team_0);
-    assert_eq!(event.touch_count, 1);
+    assert_eq!(event.touch_count, 2);
     assert_eq!(event.aerial_touch_count, 0);
     assert_eq!(event.wall_touch_count, 0);
     assert!((event.duration - 8.0 * DT).abs() < 1e-4);
@@ -171,7 +182,19 @@ fn merges_spans_across_a_short_neutral_gap() {
     let owned = possession(Some(1), Some(true));
     let neutral = possession(None, None);
 
+    // One touch before the gap and one after: the merged span has the two
+    // distinct touches it needs to qualify as possession.
     for step in 0..4 {
+        let touches = if step == 0 {
+            vec![touch(
+                step,
+                step as f32 * DT,
+                1,
+                glam::Vec3::new(0.0, 0.0, 17.0),
+            )]
+        } else {
+            vec![]
+        };
         update(
             &mut calculator,
             step,
@@ -179,7 +202,7 @@ fn merges_spans_across_a_short_neutral_gap() {
             &ball,
             &players,
             &owned,
-            vec![],
+            touches,
         );
     }
     // Contested window shorter than the merge gap.
@@ -195,6 +218,16 @@ fn merges_spans_across_a_short_neutral_gap() {
         );
     }
     for step in 8..12 {
+        let touches = if step == 8 {
+            vec![touch(
+                step,
+                step as f32 * DT,
+                1,
+                glam::Vec3::new(0.0, 0.0, 17.0),
+            )]
+        } else {
+            vec![]
+        };
         update(
             &mut calculator,
             step,
@@ -202,7 +235,7 @@ fn merges_spans_across_a_short_neutral_gap() {
             &ball,
             &players,
             &owned,
-            vec![],
+            touches,
         );
     }
     calculator.finish();
@@ -219,10 +252,25 @@ fn merges_spans_across_a_short_neutral_gap() {
 #[test]
 fn turnover_to_another_player_splits_spans() {
     let mut calculator = PlayerPossessionCalculator::new();
-    let players = players_at(glam::Vec3::new(0.0, 0.0, 17.0));
+    // Both players sit next to the ball so the loose-distance bound never
+    // demotes whoever currently holds it.
+    let players = players_with(
+        glam::Vec3::new(0.0, 0.0, 17.0),
+        glam::Vec3::new(0.0, 0.0, 17.0),
+    );
     let ball = ball_at(0.0, 1000.0);
 
     for step in 0..4 {
+        let touches = if step == 0 || step == 2 {
+            vec![touch(
+                step,
+                step as f32 * DT,
+                1,
+                glam::Vec3::new(0.0, 0.0, 17.0),
+            )]
+        } else {
+            vec![]
+        };
         update(
             &mut calculator,
             step,
@@ -230,10 +278,20 @@ fn turnover_to_another_player_splits_spans() {
             &ball,
             &players,
             &possession(Some(1), Some(true)),
-            vec![],
+            touches,
         );
     }
     for step in 4..8 {
+        let touches = if step == 4 || step == 6 {
+            vec![touch(
+                step,
+                step as f32 * DT,
+                2,
+                glam::Vec3::new(0.0, 0.0, 17.0),
+            )]
+        } else {
+            vec![]
+        };
         update(
             &mut calculator,
             step,
@@ -241,7 +299,7 @@ fn turnover_to_another_player_splits_spans() {
             &ball,
             &players,
             &possession(Some(2), Some(false)),
-            vec![],
+            touches,
         );
     }
     calculator.finish();
@@ -263,6 +321,16 @@ fn expired_gap_finalizes_the_suspended_span() {
     let neutral = possession(None, None);
 
     for step in 0..4 {
+        let touches = if step == 0 || step == 2 {
+            vec![touch(
+                step,
+                step as f32 * DT,
+                1,
+                glam::Vec3::new(0.0, 0.0, 17.0),
+            )]
+        } else {
+            vec![]
+        };
         update(
             &mut calculator,
             step,
@@ -270,7 +338,7 @@ fn expired_gap_finalizes_the_suspended_span() {
             &ball,
             &players,
             &owned,
-            vec![],
+            touches,
         );
     }
     // Neutral stretch much longer than the merge gap.
@@ -286,6 +354,16 @@ fn expired_gap_finalizes_the_suspended_span() {
         );
     }
     for step in 20..24 {
+        let touches = if step == 20 || step == 22 {
+            vec![touch(
+                step,
+                step as f32 * DT,
+                1,
+                glam::Vec3::new(0.0, 0.0, 17.0),
+            )]
+        } else {
+            vec![]
+        };
         update(
             &mut calculator,
             step,
@@ -293,7 +371,7 @@ fn expired_gap_finalizes_the_suspended_span() {
             &ball,
             &players,
             &owned,
-            vec![],
+            touches,
         );
     }
     calculator.finish();
@@ -315,6 +393,16 @@ fn accumulates_carry_time_when_ball_rides_the_player() {
     let ball = ball_at(0.0, 120.0);
 
     for step in 0..8 {
+        let touches = if step == 0 || step == 4 {
+            vec![touch(
+                step,
+                step as f32 * DT,
+                1,
+                glam::Vec3::new(0.0, 0.0, 17.0),
+            )]
+        } else {
+            vec![]
+        };
         update(
             &mut calculator,
             step,
@@ -322,7 +410,7 @@ fn accumulates_carry_time_when_ball_rides_the_player() {
             &ball,
             &players,
             &state,
-            vec![],
+            touches,
         );
     }
     calculator.finish();
@@ -376,7 +464,10 @@ fn labels_sustained_control_using_controlled_play_criteria() {
 }
 
 #[test]
-fn single_touch_span_is_not_sustained_control() {
+fn single_touch_span_is_dropped() {
+    // A lone touch the player never follows up on — the canonical kickoff poke
+    // that stayed "possession" only because nobody else touched until the
+    // opponent did — is not possession and must not be emitted at all.
     let mut calculator = PlayerPossessionCalculator::new();
     let players = players_at(glam::Vec3::new(0.0, 0.0, 17.0));
     let ball = ball_at(0.0, 1000.0);
@@ -401,12 +492,56 @@ fn single_touch_span_is_not_sustained_control() {
     }
     calculator.finish();
 
+    assert!(
+        calculator.events().is_empty(),
+        "a single-touch span never qualifies as possession"
+    );
+}
+
+#[test]
+fn ball_drifting_far_ends_the_span_without_crediting_the_drift() {
+    // The holder makes two real touches, then the ball rockets away and they
+    // never play it again. The far frames must not be credited, and once the
+    // drift outlasts the merge gap the span finalizes on its own. `current_player`
+    // stays sticky on the holder throughout — only the loose-distance bound ends
+    // the span.
+    let mut calculator = PlayerPossessionCalculator::new();
+    let players = players_at(glam::Vec3::new(0.0, 0.0, 17.0));
+    let state = possession(Some(1), Some(true));
+
+    for step in 0..4 {
+        let time = step as f32 * DT;
+        let ball = ball_at(0.0, 200.0);
+        let touches = if step == 0 || step == 2 {
+            vec![touch(step, time, 1, glam::Vec3::new(0.0, 0.0, 17.0))]
+        } else {
+            vec![]
+        };
+        update(
+            &mut calculator,
+            step,
+            time,
+            &ball,
+            &players,
+            &state,
+            touches,
+        );
+    }
+    // Ball well beyond the loose-distance bound; the player stays put.
+    for step in 4..20 {
+        let time = step as f32 * DT;
+        let ball = ball_at(6000.0, 1000.0);
+        update(&mut calculator, step, time, &ball, &players, &state, vec![]);
+    }
+    calculator.finish();
+
     let events = calculator.events();
     assert_eq!(events.len(), 1);
-    assert!(
-        !events[0].sustained_control,
-        "a single touch never qualifies as controlled play"
-    );
+    let event = &events[0];
+    assert_eq!(event.touch_count, 2);
+    // Only the near frames (0..=3) are credited; the drift is excluded.
+    assert_eq!(event.end_frame, 3);
+    assert!((event.duration - 4.0 * DT).abs() < 1e-4);
 }
 
 #[test]

--- a/tests/player_possession_fixture_test.rs
+++ b/tests/player_possession_fixture_test.rs
@@ -34,8 +34,9 @@ fn player_possession_spans_are_sane_for_post_eac_doubles_replay() {
             "possessed duration cannot exceed the span's wall-clock window"
         );
         assert!(
-            span.touch_count >= 1,
-            "possession requires at least one touch by the owner"
+            span.touch_count >= 2,
+            "possession requires at least two distinct touches by the owner; a \
+             lone touch is not possession"
         );
         assert!(
             span.aerial_touch_count + span.wall_touch_count <= span.touch_count,


### PR DESCRIPTION
## Problem

Player possession was awarded to whoever **last touched** the ball until an opponent took over, with **no control requirement**. A glancing kickoff poke the player never followed up on therefore produced a long possession span — e.g. Mawkzy on the opening kickoff of [this replay](https://rocket-sense.duckdns.org/replays/019ee690-a31e-76b2-a2a5-c9543d5a111f). The span already computed `sustained_control = false`, but it was emitted anyway, and nothing retroactively undid it.

## Change

Require **actual control** before crediting a player-possession span (`src/stats/calculators/player_possession.rs`):

- **Touch-count gate (primary).** Drop spans with `touch_count < 2` at `finalize()`. Because a span only finalizes on opponent takeover or loss, this *is* the retroactive "there was never really any possession here" check — a lone touch is never emitted. Consecutive touches are the dominant signal.
- **Loose-distance bound.** New `holder_within_reach()` demotes the sticky last-toucher to "no holder" once the ball drifts past `MAX_POSSESSION_BALL_DISTANCE = 2500uu` (vs the 700uu strict-control radius). The span *suspends* rather than ends, so a dribbler who flicks-and-chases isn't chopped, but a true loss expires after the merge gap and the far-drift frames aren't credited.
- **Proximity stays loose.** `close_time` / `sustained_control` remain enrichment only — they don't gate emission or boundaries.

### Consequence (intended)
A clean **single-touch pass/clear** now awards no possession to that player — possession now means "played it ≥2 times," not "last to touch it."

## Tests

Updated the unit specs that relied on sub-two-touch spans, repurposed `single_touch_span_is_not_sustained_control` → `single_touch_span_is_dropped` (the kickoff-blip case), added `ball_drifting_far_ends_the_span_without_crediting_the_drift`, and tightened the replay fixture invariant from `touch_count >= 1` to `>= 2`.

No `PlayerPossessionEvent` struct/ABI/TS changes. Rust-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)