### PR TITLE
Ignore goal replay frames for kickoff phase

### DIFF
--- a/src/stats/calculators/frame_components.rs
+++ b/src/stats/calculators/frame_components.rs
@@ -41,7 +41,8 @@ impl GameplayState {
     }
 
     pub fn kickoff_phase_active(&self) -> bool {
-        self.kickoff_countdown_active() || self.ball_has_been_hit == Some(false)
+        self.game_state != Some(GAME_STATE_GOAL_SCORED_REPLAY)
+            && (self.kickoff_countdown_active() || self.ball_has_been_hit == Some(false))
     }
 
     pub fn current_in_game_team_player_count(&self, is_team_0: bool) -> usize {

--- a/src/stats/calculators/kickoff_tests.rs
+++ b/src/stats/calculators/kickoff_tests.rs
@@ -3386,6 +3386,53 @@ fn kickoff_goal_allows_deep_ball_in_conceding_half() {
 }
 
 #[test]
+fn goal_replay_frames_do_not_arm_phantom_missed_kickoffs() {
+    let blue_taker = PlayerId::Steam(64);
+    let orange_taker = PlayerId::Steam(65);
+    let players = PlayerFrameState {
+        players: vec![
+            player(
+                blue_taker,
+                true,
+                glam::Vec3::new(-256.0, -3840.0, 17.0),
+                85.0,
+            ),
+            player(
+                orange_taker,
+                false,
+                glam::Vec3::new(256.0, 3840.0, 17.0),
+                85.0,
+            ),
+        ],
+    };
+    let gameplay = GameplayState {
+        game_state: Some(GAME_STATE_GOAL_SCORED_REPLAY),
+        ball_has_been_hit: Some(false),
+        ..GameplayState::default()
+    };
+    let mut calculator = KickoffCalculator::new();
+
+    for frame_number in 0..20 {
+        calculator
+            .update(
+                &frame(frame_number, frame_number as f32 * 0.04),
+                &gameplay,
+                &ball(0.0),
+                &players,
+                &TouchState::default(),
+                &FrameEventsState::default(),
+            )
+            .unwrap();
+    }
+
+    calculator.finish();
+    assert!(
+        calculator.events().is_empty(),
+        "goal replay frames with ball_has_been_hit=false must not produce missed kickoff events"
+    );
+}
+
+#[test]
 fn next_kickoff_phase_flushes_kickoff_awaiting_attribution() {
     let blue_taker = PlayerId::Steam(66);
     let blue_support = PlayerId::Steam(67);

--- a/src/stats/calculators/live_play_tests.rs
+++ b/src/stats/calculators/live_play_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{GAME_STATE_KICKOFF_COUNTDOWN, GoalEvent};
+use crate::{GAME_STATE_GOAL_SCORED_REPLAY, GAME_STATE_KICKOFF_COUNTDOWN, GoalEvent};
 
 #[test]
 fn kickoff_waiting_for_first_touch_is_not_live_play() {
@@ -13,6 +13,20 @@ fn kickoff_waiting_for_first_touch_is_not_live_play() {
     assert_eq!(state.gameplay_phase, GameplayPhase::KickoffWaitingForTouch);
     assert!(!state.is_live_play);
     assert!(state.gameplay_phase.counts_toward_player_motion());
+}
+
+#[test]
+fn goal_replay_with_unhit_ball_is_post_goal_not_kickoff() {
+    let mut tracker = LivePlayTracker::default();
+    let gameplay = GameplayState {
+        game_state: Some(GAME_STATE_GOAL_SCORED_REPLAY),
+        ball_has_been_hit: Some(false),
+        ..Default::default()
+    };
+    let state = tracker.state_parts(&gameplay, &FrameEventsState::default());
+
+    assert_eq!(state.gameplay_phase, GameplayPhase::PostGoal);
+    assert!(!state.is_live_play);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Exclude goal replay frames from `GameplayState::kickoff_phase_active()` even when `ball_has_been_hit` is false.
- Add live-play coverage for goal replay frames with an unhit-ball flag.
- Add kickoff regression coverage proving repeated goal-replay frames do not arm phantom missed kickoff events.

## Root Cause
Some replay goal-replay frames report `game_state = GOAL_SCORED_REPLAY` while `ball_has_been_hit = false`. The kickoff detector treated those frames as kickoff phase, so every goal-replay frame could arm and immediately close a no-touch kickoff, inflating per-player kickoff counts.

## Validation
- `cargo fmt`
- `cargo test -p subtr-actor stats::calculators::kickoff::tests`
- `cargo test -p subtr-actor stats::calculators::live_play::tests`