### PR TITLE
Count wide back-wall rebounds as backboard bounces

### DIFF
--- a/src/stats/calculators/backboard_bounce.rs
+++ b/src/stats/calculators/backboard_bounce.rs
@@ -46,7 +46,10 @@ impl BackboardBounceCalculator {
         const BACKBOARD_MIN_BALL_Z: f32 = 500.0;
         const BACKBOARD_MIN_NORMALIZED_Y: f32 = 4700.0;
         const BACKBOARD_SIMULTANEOUS_TOUCH_MIN_NORMALIZED_Y: f32 = 5000.0;
-        const BACKBOARD_MAX_ABS_X: f32 = 1600.0;
+        // Count the full opponent back wall, including wide corner reads. The
+        // y-position and y-velocity reversal checks below still keep pure
+        // side-wall touches from arming backboard plays.
+        const BACKBOARD_MAX_ABS_X: f32 = 4096.0;
         const BACKBOARD_MIN_APPROACH_SPEED_Y: f32 = 350.0;
         const BACKBOARD_MIN_REBOUND_SPEED_Y: f32 = 250.0;
         const BACKBOARD_TOUCH_ATTRIBUTION_MAX_SECONDS: f32 = 2.5;

--- a/src/stats/calculators/backboard_bounce_tests.rs
+++ b/src/stats/calculators/backboard_bounce_tests.rs
@@ -113,6 +113,47 @@ fn backboard_bounce_uses_primary_touch_not_last_contested_candidate() {
 }
 
 #[test]
+fn wide_back_wall_rebound_counts_as_backboard_bounce() {
+    let shooter = boxcars::RemoteId::Steam(1);
+    let touch_state = TouchState {
+        touch_events: vec![touch(shooter.clone(), true, 0.0)],
+        last_touch: None,
+        last_touch_player: None,
+        last_touch_team_is_team_0: None,
+    };
+    let mut calculator = BackboardBounceCalculator::new();
+
+    calculator.update(
+        &frame(1),
+        &ball(
+            // Mirrors wide back-wall reads that are visually double taps even
+            // though they are outside the old central-backboard gate.
+            glam::Vec3::new(2746.0, 4840.0, 1400.0),
+            glam::Vec3::new(0.0, 500.0, 0.0),
+        ),
+        &PlayerFrameState::default(),
+        &touch_state,
+        &LivePlayState::active_play(),
+    );
+    let state = calculator.update(
+        &frame(2),
+        &ball(
+            glam::Vec3::new(2746.0, 4800.0, 1400.0),
+            glam::Vec3::new(0.0, -300.0, 0.0),
+        ),
+        &PlayerFrameState::default(),
+        &TouchState::default(),
+        &LivePlayState::active_play(),
+    );
+
+    let [bounce] = state.bounce_events.as_slice() else {
+        panic!("expected exactly one wide back-wall bounce");
+    };
+    assert_eq!(bounce.player, shooter);
+    assert!(bounce.is_team_0);
+}
+
+#[test]
 fn backboard_bounce_can_emit_on_simultaneous_touch_frame() {
     let shooter = boxcars::RemoteId::Steam(1);
     let initial_touch = touch(shooter.clone(), true, 0.0);


### PR DESCRIPTION
## Summary
- widen backboard-bounce detection to include full back-wall/corner reads instead of only central backboard bounces
- add a regression test for a wide high back-wall rebound that should arm double-tap detection

## Root cause
The backboard-bounce detector capped rebounds at `abs(x) <= 1600`, so wide back-wall reads could never produce the upstream `backboard` event needed by the `double_tap` and `double_tap_goal` paths.

## Validation
- `cargo fmt --check`
- `cargo test -p subtr-actor backboard_bounce::tests`
- `cargo test -p subtr-actor double_tap::tests`
- `cargo test -p subtr-actor --test clip_double_tap_test`
- `just check`