### PR TITLE
Split air dribbles from ball carries

### DIFF
--- a/bakkesmod/rust/src/lib_tests/live_graph_basics.rs
+++ b/bakkesmod/rust/src/lib_tests/live_graph_basics.rs
@@ -772,9 +772,9 @@ fn exposes_live_graph_info_json() {
     assert!(builtin_names
         .iter()
         .any(|name| name == "continuous_ball_control"));
-    // `air_dribble` is a stats module, not an analysis node; its node is `ball_carry`.
+    // `air_dribble` is a standalone analysis node; `ball_carry` remains separate.
     assert!(builtin_names.iter().any(|name| name == "ball_carry"));
-    assert!(!builtin_names.iter().any(|name| name == "air_dribble"));
+    assert!(builtin_names.iter().any(|name| name == "air_dribble"));
     assert!(builtin_names.iter().any(|name| name == "frame_info"));
     assert!(builtin_names.iter().any(|name| name == "live_play"));
     assert!(builtin_names
@@ -794,12 +794,11 @@ fn exposes_live_graph_info_json() {
                 .to_owned()
         })
         .collect::<BTreeSet<_>>();
-    // `core` and `air_dribble` are stats-module names, not analysis nodes, so they
-    // are no longer callable as nodes; their providing nodes are.
+    // `core` is a stats-module name, not an analysis node, so its providing node is callable.
     assert!(callable_names.iter().any(|name| name == "match_stats"));
     assert!(callable_names.iter().any(|name| name == "ball_carry"));
     assert!(!callable_names.iter().any(|name| name == "core"));
-    assert!(!callable_names.iter().any(|name| name == "air_dribble"));
+    assert!(callable_names.iter().any(|name| name == "air_dribble"));
     assert!(callable_names
         .iter()
         .any(|name| name == "continuous_ball_control"));

--- a/crates/subtr-actor-tools/src/bin/flip_reset_goal_audit.rs
+++ b/crates/subtr-actor-tools/src/bin/flip_reset_goal_audit.rs
@@ -8,7 +8,9 @@ use std::collections::HashMap;
 
 use anyhow::Context;
 use clap::Parser;
-use subtr_actor::{EventPayload, GoalTag, PlayerId, ReplayMeta, StatsTimelineCollector};
+use subtr_actor::{
+    BallCarryKind, EventPayload, GoalTag, PlayerId, ReplayMeta, StatsTimelineCollector,
+};
 
 #[derive(Debug, Parser)]
 #[command(about = "Audit FlipResetGoal tagging for a replay.")]
@@ -58,7 +60,61 @@ fn main() -> anyhow::Result<()> {
                 .tags
                 .iter()
                 .any(|t| matches!(t, GoalTag::FlipResetGoal(_)));
+            let has_air_dribble = goal
+                .tags
+                .iter()
+                .any(|t| matches!(t, GoalTag::AirDribbleGoal(_)));
             println!("         FlipResetGoal: {has_flip}");
+            println!("         AirDribbleGoal: {has_air_dribble}");
+        }
+    }
+
+    println!("\n==== AIR DRIBBLE events ====");
+    for event in &timeline.events.events {
+        if let EventPayload::BallCarry(carry) = &event.payload {
+            if carry.kind != BallCarryKind::AirDribble {
+                continue;
+            }
+            println!(
+                "clk {} abs {:.3}-{:.3} frames {}-{} player={} team0={} touches={} air_touches={} origin={:?}",
+                clock(carry.start_time),
+                carry.start_time,
+                carry.end_time,
+                carry.start_frame,
+                carry.end_frame,
+                player_name(&names, &carry.player_id),
+                carry.is_team_0,
+                carry.touch_count,
+                carry.air_touch_count,
+                carry.air_dribble_origin,
+            );
+        }
+    }
+
+    println!("\n==== TOUCH events ====");
+    for event in &timeline.events.events {
+        if let EventPayload::Touch(touch) = &event.payload {
+            let kind = touch.tag("kind").unwrap_or("<none>");
+            let surface = touch.tag("surface").unwrap_or("<none>");
+            println!(
+                "clk {} abs {:.3} frame {} player={} team0={} kind={} surface={} player_z={} ball_z={} speed_change={:.1}",
+                clock(touch.time),
+                touch.time,
+                touch.frame,
+                player_name(&names, &touch.player),
+                touch.is_team_0,
+                kind,
+                surface,
+                touch
+                    .player_position
+                    .map(|position| format!("{:.0}", position[2]))
+                    .unwrap_or_else(|| "<none>".to_owned()),
+                touch
+                    .ball_position
+                    .map(|position| format!("{:.0}", position[2]))
+                    .unwrap_or_else(|| "<none>".to_owned()),
+                touch.ball_speed_change,
+            );
         }
     }
 

--- a/docs/event-definitions.html
+++ b/docs/event-definitions.html
@@ -464,6 +464,7 @@ ul.tight li { margin: .15rem 0; }
 <p class="muted">None documented.</p>
 <div class="section-label">Producers</div>
 <ul class="tight producers">
+<li><code>air_dribble</code> via <code>AirDribbleNode</code> / <code>AirDribbleCalculator</code></li>
 <li><code>ball_carry</code> via <code>BallCarryNode</code> / <code>BallCarryCalculator</code></li>
 </ul>
 </div>

--- a/docs/event-definitions.md
+++ b/docs/event-definitions.md
@@ -44,6 +44,7 @@ _None documented._
   - False negative evidence: `not_evaluated`
   - Testing: `untested`
 - Producers:
+  - `air_dribble` via `AirDribbleNode` / `AirDribbleCalculator`
   - `ball_carry` via `BallCarryNode` / `BallCarryCalculator`
 
 **Summary**

--- a/src/collector/stats/builtins.rs
+++ b/src/collector/stats/builtins.rs
@@ -79,14 +79,6 @@ struct TeamPlayerStatsWithEventsExport<'a, Team, Player, Event> {
 }
 
 #[derive(Serialize)]
-struct TeamPlayerStatsWithCollectedEventsExport<'a, Team, Player, Event> {
-    team_zero: &'a Team,
-    team_one: &'a Team,
-    player_stats: Vec<PlayerStatsEntry<'a, Player>>,
-    events: Vec<&'a Event>,
-}
-
-#[derive(Serialize)]
 struct StatsExport<'a, T> {
     stats: &'a T,
 }
@@ -834,20 +826,15 @@ pub(crate) fn builtin_module_json(
             })
         }
         "air_dribble" => {
-            let calculator = graph_state::<BallCarryCalculator>(graph, module_name)?;
+            let calculator = graph_state::<AirDribbleCalculator>(graph, module_name)?;
             let projection = projected_stats(graph, module_name)?;
-            let events = calculator
-                .carry_events()
-                .iter()
-                .filter(|event| event.kind == BallCarryKind::AirDribble)
-                .collect::<Vec<_>>();
-            serialize_to_json_value(&TeamPlayerStatsWithCollectedEventsExport {
+            serialize_to_json_value(&TeamPlayerStatsWithEventsExport {
                 team_zero: projection.ball_carry.team_zero_air_dribble_stats(),
                 team_one: projection.ball_carry.team_one_air_dribble_stats(),
                 player_stats: player_stats_entries(
                     projection.ball_carry.player_air_dribble_stats(),
                 ),
-                events,
+                events: calculator.events(),
             })
         }
         "boost" => {

--- a/src/collector/stats/collector.rs
+++ b/src/collector/stats/collector.rs
@@ -30,13 +30,12 @@ enum SampleMode {
 ///
 /// Most modules share their providing node's name. The exceptions are modules
 /// that are a second view onto another node's calculator: `core` is served by
-/// the `match_stats` node, and `air_dribble` by the `ball_carry` node. This is
+/// the `match_stats` node, and `flip_reset` is served by `dodge_reset`. This is
 /// the only place that translation lives — there is no global node-name alias
 /// table.
 fn stats_module_analysis_node_name(module_name: &str) -> &str {
     match module_name {
         "core" => "match_stats",
-        "air_dribble" => "ball_carry",
         "flip_reset" => "dodge_reset",
         other => other,
     }

--- a/src/collector/stats/collector_tests.rs
+++ b/src/collector/stats/collector_tests.rs
@@ -2,25 +2,34 @@ use super::*;
 
 #[test]
 fn maps_stats_modules_to_their_providing_nodes() {
-    // Most modules share their providing node's name; `core` and `air_dribble`
+    // Most modules share their providing node's name; `core` and `flip_reset`
     // are the only second-view exceptions.
     assert_eq!(stats_module_analysis_node_name("core"), "match_stats");
-    assert_eq!(stats_module_analysis_node_name("air_dribble"), "ball_carry");
+    assert_eq!(
+        stats_module_analysis_node_name("air_dribble"),
+        "air_dribble"
+    );
     assert_eq!(stats_module_analysis_node_name("boost"), "boost");
     assert_eq!(stats_module_analysis_node_name("ball_carry"), "ball_carry");
 }
 
 #[test]
-fn air_dribble_and_ball_carry_modules_share_one_node() {
+fn air_dribble_and_ball_carry_modules_use_separate_nodes() {
     let selection = BuiltinModuleSelection::from_names(["air_dribble", "ball_carry"])
         .expect("air_dribble and ball_carry are builtin stats modules");
     let mut graph = selection.graph().expect("selection should build a graph");
     graph.resolve().expect("graph should resolve");
 
+    let air_dribble_nodes = graph
+        .node_names()
+        .filter(|name| *name == "air_dribble")
+        .count();
     let ball_carry_nodes = graph
         .node_names()
         .filter(|name| *name == "ball_carry")
         .count();
+    assert_eq!(air_dribble_nodes, 1);
     assert_eq!(ball_carry_nodes, 1);
+    assert!(graph.state::<AirDribbleCalculator>().is_some());
     assert!(graph.state::<BallCarryCalculator>().is_some());
 }

--- a/src/stats/analysis_graph/mod.rs
+++ b/src/stats/analysis_graph/mod.rs
@@ -168,6 +168,7 @@ builtin_analysis_nodes! {
     PassNode,
     DodgeResetNode,
     BallCarryNode,
+    AirDribbleNode,
     BoostNode,
     BumpNode,
     MovementNode,

--- a/src/stats/analysis_graph/module_tests.rs
+++ b/src/stats/analysis_graph/module_tests.rs
@@ -1,15 +1,15 @@
 use super::*;
 use crate::{
-    AerialGoalCalculator, AirDribbleGoalCalculator, BackboardCalculator, BallCarryCalculator,
-    BumpCalculator, CenterCalculator, CounterAttackGoalCalculator, DoubleTapGoalCalculator,
-    EmptyNetGoalCalculator, FlickCalculator, FlickGoalCalculator, FlipIntoBallGoalCalculator,
-    FlipResetGoalCalculator, HalfVolleyCalculator, HalfVolleyGoalCalculator,
-    HighAerialGoalCalculator, LongDistanceGoalCalculator, MatchStatsCalculator, OneTimerCalculator,
-    OneTimerGoalCalculator, OwnHalfGoalCalculator, PassCalculator, PassingGoalCalculator,
-    PlayerVerticalState, PossessionState, RotationCalculator, StatsTimelineCollector,
-    SustainedPressureGoalCalculator, TerritorialPressureCalculator, TouchState,
-    WallAerialCalculator, WallAerialShotCalculator, builtin_analysis_node_json,
-    builtin_analysis_nodes_json, builtin_stats_module_names,
+    AerialGoalCalculator, AirDribbleCalculator, AirDribbleGoalCalculator, BackboardCalculator,
+    BallCarryCalculator, BumpCalculator, CenterCalculator, CounterAttackGoalCalculator,
+    DoubleTapGoalCalculator, EmptyNetGoalCalculator, FlickCalculator, FlickGoalCalculator,
+    FlipIntoBallGoalCalculator, FlipResetGoalCalculator, HalfVolleyCalculator,
+    HalfVolleyGoalCalculator, HighAerialGoalCalculator, LongDistanceGoalCalculator,
+    MatchStatsCalculator, OneTimerCalculator, OneTimerGoalCalculator, OwnHalfGoalCalculator,
+    PassCalculator, PassingGoalCalculator, PlayerVerticalState, PossessionState,
+    RotationCalculator, StatsTimelineCollector, SustainedPressureGoalCalculator,
+    TerritorialPressureCalculator, TouchState, WallAerialCalculator, WallAerialShotCalculator,
+    builtin_analysis_node_json, builtin_analysis_nodes_json, builtin_stats_module_names,
 };
 use std::any::TypeId;
 use std::collections::HashSet;
@@ -149,6 +149,27 @@ fn duplicate_node_requests_share_one_provider() {
         names.iter().filter(|name| **name == "ball_carry").count(),
         1
     );
+    assert!(graph.state::<BallCarryCalculator>().is_some());
+}
+
+#[test]
+fn air_dribble_and_ball_carry_resolve_as_separate_providers() {
+    let mut graph = graph_with_builtin_analysis_nodes(["air_dribble", "ball_carry"])
+        .expect("air dribble and ball carry requests should be accepted");
+    graph
+        .resolve()
+        .expect("air dribble and ball carry should resolve");
+
+    let names = graph.node_names().collect::<Vec<_>>();
+    assert_eq!(
+        names.iter().filter(|name| **name == "air_dribble").count(),
+        1
+    );
+    assert_eq!(
+        names.iter().filter(|name| **name == "ball_carry").count(),
+        1
+    );
+    assert!(graph.state::<AirDribbleCalculator>().is_some());
     assert!(graph.state::<BallCarryCalculator>().is_some());
 }
 

--- a/src/stats/analysis_graph/nodes/air_dribble.rs
+++ b/src/stats/analysis_graph/nodes/air_dribble.rs
@@ -1,0 +1,66 @@
+use super::*;
+use crate::stats::calculators::*;
+use crate::*;
+
+/// Detects air dribbles from continuous same-player non-ground touches.
+pub struct AirDribbleNode {
+    calculator: AirDribbleCalculator,
+}
+
+impl AirDribbleNode {
+    pub fn new() -> Self {
+        Self {
+            calculator: AirDribbleCalculator::new(),
+        }
+    }
+}
+
+impl Default for AirDribbleNode {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AnalysisNode for AirDribbleNode {
+    type State = AirDribbleCalculator;
+
+    fn name(&self) -> &'static str {
+        "air_dribble"
+    }
+
+    fn emitted_events(&self) -> &'static [crate::stats::calculators::EmittedEvent] {
+        crate::stats::calculators::AIR_DRIBBLE_EMITTED_EVENTS
+    }
+
+    fn dependencies(&self) -> Vec<AnalysisDependency> {
+        vec![
+            frame_info_dependency(),
+            ball_frame_state_dependency(),
+            player_frame_state_dependency(),
+            live_play_dependency(),
+            touch_dependency(),
+        ]
+    }
+
+    fn evaluate(&mut self, ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
+        self.calculator.update(
+            ctx.get::<FrameInfo>()?,
+            ctx.get::<BallFrameState>()?,
+            ctx.get::<PlayerFrameState>()?,
+            ctx.get::<LivePlayState>()?,
+            ctx.get::<TouchCalculator>()?,
+        )
+    }
+
+    fn finish(&mut self, _ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
+        self.calculator.finish()
+    }
+
+    fn state(&self) -> &Self::State {
+        &self.calculator
+    }
+}
+
+pub(crate) fn boxed_default() -> Box<dyn AnalysisNodeDyn> {
+    Box::new(AirDribbleNode::new())
+}

--- a/src/stats/analysis_graph/nodes/goal_tags.rs
+++ b/src/stats/analysis_graph/nodes/goal_tags.rs
@@ -153,8 +153,8 @@ mechanic_goal_tag_node!(
     AirDribbleGoalNode,
     AirDribbleGoalCalculator,
     "air_dribble_goal",
-    ball_carry_dependency,
-    BallCarryCalculator
+    air_dribble_dependency,
+    AirDribbleCalculator
 );
 mechanic_goal_tag_node!(
     FlipIntoBallGoalNode,

--- a/src/stats/analysis_graph/nodes/mod.rs
+++ b/src/stats/analysis_graph/nodes/mod.rs
@@ -1,14 +1,14 @@
 pub(crate) use super::graph::*;
 use crate::stats::calculators::{
-    AerialGoalCalculator, AirDribbleGoalCalculator, BackboardBounceState, BackboardCalculator,
-    BallCarryCalculator, BallFrameState, BallHalfCalculator, BallThirdCalculator, BoostCalculator,
-    BumpCalculator, BumpGoalCalculator, CeilingShotCalculator, CeilingShotGoalCalculator,
-    CenterCalculator, ContinuousBallControlState, ControlledPlayCalculator,
-    CounterAttackGoalCalculator, DemoCalculator, DemoGoalCalculator, DodgeResetCalculator,
-    DoubleTapCalculator, DoubleTapGoalCalculator, EmptyNetGoalCalculator, FiftyFiftyCalculator,
-    FiftyFiftyState, FlickCalculator, FlickGoalCalculator, FlipImpulseCalculator,
-    FlipIntoBallGoalCalculator, FlipResetGoalCalculator, FrameEventsState, FrameInfo,
-    GameplayState, HalfFlipCalculator, HalfVolleyCalculator, HalfVolleyGoalCalculator,
+    AerialGoalCalculator, AirDribbleCalculator, AirDribbleGoalCalculator, BackboardBounceState,
+    BackboardCalculator, BallCarryCalculator, BallFrameState, BallHalfCalculator,
+    BallThirdCalculator, BoostCalculator, BumpCalculator, BumpGoalCalculator,
+    CeilingShotCalculator, CeilingShotGoalCalculator, CenterCalculator, ContinuousBallControlState,
+    ControlledPlayCalculator, CounterAttackGoalCalculator, DemoCalculator, DemoGoalCalculator,
+    DodgeResetCalculator, DoubleTapCalculator, DoubleTapGoalCalculator, EmptyNetGoalCalculator,
+    FiftyFiftyCalculator, FiftyFiftyState, FlickCalculator, FlickGoalCalculator,
+    FlipImpulseCalculator, FlipIntoBallGoalCalculator, FlipResetGoalCalculator, FrameEventsState,
+    FrameInfo, GameplayState, HalfFlipCalculator, HalfVolleyCalculator, HalfVolleyGoalCalculator,
     HighAerialGoalCalculator, KickoffCalculator, KickoffGoalCalculator, LivePlayState,
     LongDistanceGoalCalculator, LoosePossessionCalculator, MatchStatsCalculator,
     MovementCalculator, OneTimerCalculator, OneTimerGoalCalculator, OwnHalfGoalCalculator,
@@ -19,6 +19,7 @@ use crate::stats::calculators::{
     WallAerialCalculator, WallAerialShotCalculator, WavedashCalculator, WhiffCalculator,
 };
 
+pub(crate) mod air_dribble;
 pub(crate) mod backboard;
 pub(crate) mod backboard_bounce;
 pub(crate) mod ball_carry;
@@ -73,6 +74,8 @@ pub(crate) mod wall_aerial_shot;
 pub(crate) mod wavedash;
 pub(crate) mod whiff;
 
+#[allow(unused_imports)]
+pub use air_dribble::AirDribbleNode;
 #[allow(unused_imports)]
 pub use backboard::BackboardNode;
 #[allow(unused_imports)]
@@ -446,6 +449,10 @@ pub(crate) fn dodge_reset_dependency() -> AnalysisDependency {
 
 pub(crate) fn ball_carry_dependency() -> AnalysisDependency {
     AnalysisDependency::with_default::<BallCarryCalculator>(ball_carry::boxed_default)
+}
+
+pub(crate) fn air_dribble_dependency() -> AnalysisDependency {
+    AnalysisDependency::with_default::<AirDribbleCalculator>(air_dribble::boxed_default)
 }
 
 pub(crate) fn boost_dependency() -> AnalysisDependency {

--- a/src/stats/analysis_graph/nodes/stats_projection.rs
+++ b/src/stats/analysis_graph/nodes/stats_projection.rs
@@ -206,6 +206,7 @@ struct StatsProjectionCursors {
     flip_reset: usize,
     dodge_reset_flip_reset_outcome: usize,
     ball_carry: usize,
+    air_dribble: usize,
     bump: usize,
     half_volley: usize,
     powerslide: usize,
@@ -566,6 +567,10 @@ impl StatsProjectionNode {
         for event in Self::events_since(&mut self.cursors.ball_carry, ball_carry.carry_events()) {
             self.state.ball_carry.apply_event(event);
         }
+        let air_dribble = ctx.get::<AirDribbleCalculator>()?;
+        for event in Self::events_since(&mut self.cursors.air_dribble, air_dribble.events()) {
+            self.state.ball_carry.apply_event(event);
+        }
         let boost = ctx.get::<BoostCalculator>()?;
         // The boost calculator now accumulates BoostStats directly as it processes frames, so we
         // mirror its accumulator instead of replaying projected ledger/state events.
@@ -682,6 +687,7 @@ impl AnalysisNode for StatsProjectionNode {
             flick_dependency(),
             dodge_reset_dependency(),
             ball_carry_dependency(),
+            air_dribble_dependency(),
             boost_dependency(),
             bump_dependency(),
             half_volley_dependency(),

--- a/src/stats/analysis_graph/nodes/stats_timeline_events.rs
+++ b/src/stats/analysis_graph/nodes/stats_timeline_events.rs
@@ -89,6 +89,7 @@ impl StatsTimelineEventsNode {
             flick_dependency(),
             dodge_reset_dependency(),
             ball_carry_dependency(),
+            air_dribble_dependency(),
             boost_dependency(),
             bump_dependency(),
             half_volley_dependency(),
@@ -133,6 +134,7 @@ impl StatsTimelineEventsNode {
         let demo = ctx.get::<DemoCalculator>()?;
         let backboard = ctx.get::<BackboardCalculator>()?;
         let ball_carry = ctx.get::<BallCarryCalculator>()?;
+        let air_dribble = ctx.get::<AirDribbleCalculator>()?;
         let ceiling_shot = ctx.get::<CeilingShotCalculator>()?;
         let wall_aerial = ctx.get::<WallAerialCalculator>()?;
         let wall_aerial_shot = ctx.get::<WallAerialShotCalculator>()?;
@@ -218,6 +220,7 @@ impl StatsTimelineEventsNode {
                 &goal_context,
                 backboard,
                 ball_carry,
+                air_dribble,
                 ceiling_shot,
                 wall_aerial,
                 wall_aerial_shot,
@@ -359,6 +362,7 @@ fn build_replay_events(
     goal_context: &[GoalContextEvent],
     backboard: &BackboardCalculator,
     ball_carry: &BallCarryCalculator,
+    air_dribble: &AirDribbleCalculator,
     ceiling_shot: &CeilingShotCalculator,
     wall_aerial: &WallAerialCalculator,
     wall_aerial_shot: &WallAerialShotCalculator,
@@ -700,10 +704,27 @@ fn build_replay_events(
 
     for (index, event) in ball_carry.carry_events().iter().enumerate() {
         events.push(make_event(
-            match event.kind {
-                BallCarryKind::Carry => MECHANIC_BALL_CARRY,
-                BallCarryKind::AirDribble => MECHANIC_AIR_DRIBBLE,
-            },
+            MECHANIC_BALL_CARRY,
+            index,
+            span(
+                event.start_frame,
+                event.end_frame,
+                event.start_time,
+                event.end_time,
+            ),
+            EventPayload::BallCarry(event.clone()),
+            Some(event.player_id.clone()),
+            None,
+            Some(event.is_team_0),
+            Some(event.end_position),
+            Some(event.end_position),
+            None,
+        ));
+    }
+
+    for (index, event) in air_dribble.events().iter().enumerate() {
+        events.push(make_event(
+            MECHANIC_AIR_DRIBBLE,
             index,
             span(
                 event.start_frame,

--- a/src/stats/calculators/air_dribble.rs
+++ b/src/stats/calculators/air_dribble.rs
@@ -2,12 +2,9 @@ use super::*;
 
 const AIR_DRIBBLE_MIN_BALL_Z: f32 = 300.0;
 pub(crate) const AIR_DRIBBLE_MIN_PLAYER_Z: f32 = 100.0;
-const AIR_DRIBBLE_MAX_HORIZONTAL_GAP: f32 = BALL_RADIUS_Z * 3.0;
-const AIR_DRIBBLE_MAX_ABOVE_CAR_GAP: f32 = 360.0;
-const AIR_DRIBBLE_MAX_BELOW_CAR_GAP: f32 = 100.0;
 pub(crate) const AIR_DRIBBLE_MIN_DURATION: f32 = 0.65;
 const AIR_DRIBBLE_MIN_TOUCHES: u32 = 3;
-const AIR_DRIBBLE_MIN_AIR_TOUCHES: u32 = 2;
+const AIR_DRIBBLE_TOUCH_MAX_GAP_SECONDS: f32 = 3.0;
 const WALL_TAKEOFF_MIN_Z: f32 = 120.0;
 const SIDE_WALL_START_ABS_X: f32 = 3200.0;
 const BACK_WALL_START_ABS_Y: f32 = 4600.0;
@@ -33,34 +30,8 @@ impl AirDribbleOrigin {
 pub(crate) struct AirDribblePolicy;
 
 impl AirDribblePolicy {
-    pub(crate) fn is_sample(
-        player_position: glam::Vec3,
-        ball_position: glam::Vec3,
-        horizontal_gap: f32,
-        vertical_gap: f32,
-    ) -> bool {
-        ball_position.z >= AIR_DRIBBLE_MIN_BALL_Z
-            && player_position.z >= AIR_DRIBBLE_MIN_PLAYER_Z
-            && !player_is_on_wall(player_position)
-            && horizontal_gap <= AIR_DRIBBLE_MAX_HORIZONTAL_GAP
-            && (-AIR_DRIBBLE_MAX_BELOW_CAR_GAP..=AIR_DRIBBLE_MAX_ABOVE_CAR_GAP)
-                .contains(&vertical_gap)
-    }
-
     pub(crate) fn is_air_touch_position(player_position: glam::Vec3) -> bool {
         player_position.z > PLAYER_GROUND_Z_THRESHOLD && !player_is_on_wall(player_position)
-    }
-
-    pub(crate) fn kind_requires_airborne(kind: BallCarryKind) -> bool {
-        kind == BallCarryKind::AirDribble
-    }
-
-    pub(crate) fn is_valid_sequence(
-        sequence: &CompletedBallControlSequence<BallCarryKind>,
-    ) -> bool {
-        sequence.kind != BallCarryKind::AirDribble
-            || (sequence.touch_count >= AIR_DRIBBLE_MIN_TOUCHES
-                && sequence.air_touch_count >= AIR_DRIBBLE_MIN_AIR_TOUCHES)
     }
 
     pub(crate) fn origin(start_position: glam::Vec3) -> AirDribbleOrigin {
@@ -72,6 +43,220 @@ impl AirDribblePolicy {
         } else {
             AirDribbleOrigin::GroundToAir
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ActiveAirDribble {
+    player_id: PlayerId,
+    is_team_0: bool,
+    start_frame: usize,
+    end_frame: usize,
+    start_time: f32,
+    end_time: f32,
+    start_position: glam::Vec3,
+    end_position: glam::Vec3,
+    path_distance: f32,
+    horizontal_gap_sum: f32,
+    vertical_gap_sum: f32,
+    touch_count: u32,
+}
+
+impl ActiveAirDribble {
+    fn from_touch(touch: &TouchClassificationEvent) -> Option<Self> {
+        let player_position = touch.player_position.map(glam::Vec3::from_array)?;
+        let ball_position = touch.ball_position.map(glam::Vec3::from_array)?;
+        let (horizontal_gap, vertical_gap) = touch_gaps(player_position, ball_position);
+        Some(Self {
+            player_id: touch.player.clone(),
+            is_team_0: touch.is_team_0,
+            start_frame: touch.frame,
+            end_frame: touch.frame,
+            start_time: touch.time,
+            end_time: touch.time,
+            start_position: player_position,
+            end_position: player_position,
+            path_distance: 0.0,
+            horizontal_gap_sum: horizontal_gap,
+            vertical_gap_sum: vertical_gap,
+            touch_count: 1,
+        })
+    }
+
+    fn extend(&mut self, touch: &TouchClassificationEvent) -> Option<()> {
+        let player_position = touch.player_position.map(glam::Vec3::from_array)?;
+        let ball_position = touch.ball_position.map(glam::Vec3::from_array)?;
+        let (horizontal_gap, vertical_gap) = touch_gaps(player_position, ball_position);
+        self.path_distance += player_position.distance(self.end_position);
+        self.end_position = player_position;
+        self.end_time = touch.time;
+        self.end_frame = touch.frame;
+        self.horizontal_gap_sum += horizontal_gap;
+        self.vertical_gap_sum += vertical_gap;
+        self.touch_count += 1;
+        Some(())
+    }
+
+    fn event(self) -> Option<BallCarryEvent> {
+        if self.touch_count < AIR_DRIBBLE_MIN_TOUCHES {
+            return None;
+        }
+        let duration = self.end_time - self.start_time;
+        if duration < AIR_DRIBBLE_MIN_DURATION {
+            return None;
+        }
+        let average_speed = if duration > 0.0 {
+            self.path_distance / duration
+        } else {
+            0.0
+        };
+        Some(BallCarryEvent {
+            player_id: self.player_id,
+            is_team_0: self.is_team_0,
+            kind: BallCarryKind::AirDribble,
+            start_position: self.start_position.to_array(),
+            end_position: self.end_position.to_array(),
+            start_frame: self.start_frame,
+            end_frame: self.end_frame,
+            start_time: self.start_time,
+            end_time: self.end_time,
+            duration,
+            straight_line_distance: self
+                .start_position
+                .truncate()
+                .distance(self.end_position.truncate()),
+            path_distance: self.path_distance,
+            average_horizontal_gap: self.horizontal_gap_sum / self.touch_count as f32,
+            average_vertical_gap: self.vertical_gap_sum / self.touch_count as f32,
+            average_speed,
+            touch_count: self.touch_count,
+            air_touch_count: self.touch_count,
+            air_dribble_origin: Some(AirDribblePolicy::origin(self.start_position)),
+        })
+    }
+}
+
+fn touch_gaps(player_position: glam::Vec3, ball_position: glam::Vec3) -> (f32, f32) {
+    (
+        player_position
+            .truncate()
+            .distance(ball_position.truncate()),
+        ball_position.z - player_position.z,
+    )
+}
+
+fn is_air_dribble_touch(touch: &TouchClassificationEvent) -> bool {
+    matches!(touch.tag("surface"), Some("air" | "wall"))
+        && touch
+            .ball_position
+            .is_some_and(|position| position[2] >= AIR_DRIBBLE_MIN_BALL_Z)
+}
+
+/// Detects air dribbles from continuous same-player non-ground touches.
+#[derive(Debug, Clone, Default)]
+pub struct AirDribbleCalculator {
+    events: EventStream<BallCarryEvent>,
+    active: Option<ActiveAirDribble>,
+    processed_touch_count: usize,
+}
+
+impl AirDribbleCalculator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn events(&self) -> &[BallCarryEvent] {
+        self.events.all()
+    }
+
+    pub fn new_events(&self) -> &[BallCarryEvent] {
+        self.events.new_events()
+    }
+
+    fn finish_active(&mut self) {
+        if let Some(event) = self.active.take().and_then(ActiveAirDribble::event) {
+            self.events.push(event);
+        }
+    }
+
+    fn observe_touch(&mut self, touch: &TouchClassificationEvent) {
+        if !is_air_dribble_touch(touch) {
+            self.finish_active();
+            return;
+        }
+
+        let same_sequence = self.active.as_ref().is_some_and(|active| {
+            active.player_id == touch.player
+                && active.is_team_0 == touch.is_team_0
+                && touch.time - active.end_time <= AIR_DRIBBLE_TOUCH_MAX_GAP_SECONDS
+        });
+        if same_sequence {
+            if self
+                .active
+                .as_mut()
+                .and_then(|active| active.extend(touch))
+                .is_none()
+            {
+                self.finish_active();
+            }
+            return;
+        }
+
+        self.finish_active();
+        self.active = ActiveAirDribble::from_touch(touch);
+    }
+
+    pub fn update(
+        &mut self,
+        frame: &FrameInfo,
+        ball: &BallFrameState,
+        players: &PlayerFrameState,
+        live_play: &LivePlayState,
+        touch: &TouchCalculator,
+    ) -> SubtrActorResult<()> {
+        self.update_with_touch_classification_events(
+            frame,
+            ball,
+            players,
+            live_play,
+            touch.events(),
+        )
+    }
+
+    pub(crate) fn update_with_touch_classification_events(
+        &mut self,
+        frame: &FrameInfo,
+        ball: &BallFrameState,
+        _players: &PlayerFrameState,
+        live_play: &LivePlayState,
+        touch_events: &[TouchClassificationEvent],
+    ) -> SubtrActorResult<()> {
+        self.events.begin_update();
+        if !live_play.is_live_play {
+            self.finish_active();
+            self.processed_touch_count = touch_events.len();
+            return Ok(());
+        }
+        if ball
+            .position()
+            .is_none_or(|position| position.z < AIR_DRIBBLE_MIN_BALL_Z)
+        {
+            self.finish_active();
+        }
+        for touch in &touch_events[self.processed_touch_count..] {
+            if touch.frame > frame.frame_number {
+                break;
+            }
+            self.observe_touch(touch);
+            self.processed_touch_count += 1;
+        }
+        Ok(())
+    }
+
+    pub fn finish(&mut self) -> SubtrActorResult<()> {
+        self.events.begin_update();
+        self.finish_active();
+        Ok(())
     }
 }
 

--- a/src/stats/calculators/air_dribble_tests.rs
+++ b/src/stats/calculators/air_dribble_tests.rs
@@ -1,384 +1,262 @@
 use super::*;
-use crate::stats::calculators::ball_control_test_support::*;
+use crate::stats::calculators::ball_control_test_support::{ball, frame, player, rigid_body};
+
+fn live_play() -> LivePlayState {
+    LivePlayState {
+        is_live_play: true,
+        ..LivePlayState::default()
+    }
+}
+
+fn player_with_id(
+    player_id: PlayerId,
+    is_team_0: bool,
+    position: glam::Vec3,
+    velocity: glam::Vec3,
+) -> PlayerSample {
+    PlayerSample {
+        player_id,
+        is_team_0,
+        hitbox: default_car_hitbox(),
+        rigid_body: Some(rigid_body(position, velocity)),
+        boost_amount: None,
+        last_boost_amount: None,
+        boost_active: false,
+        dodge_active: false,
+        dodge_torque: None,
+        powerslide_active: false,
+        match_goals: None,
+        match_assists: None,
+        match_saves: None,
+        match_shots: None,
+        match_score: None,
+    }
+}
+
+fn touch(
+    frame: usize,
+    time: f32,
+    player: (PlayerId, bool),
+    tags: (&str, &str),
+    positions: (glam::Vec3, glam::Vec3),
+) -> TouchClassificationEvent {
+    let (player_position, ball_position) = positions;
+    TouchClassificationEvent {
+        touch_id: None,
+        time,
+        frame,
+        sample_time: time,
+        sample_frame: frame,
+        player: player.0,
+        player_position: Some(player_position.to_array()),
+        ball_position: Some(ball_position.to_array()),
+        is_team_0: player.1,
+        tags: TouchClassificationEvent::classification_tags(
+            tags.0, "high", tags.1, "none", None, false, false,
+        ),
+        role: RoleState::Unknown,
+        play_depth: PlayDepthState::Unknown,
+        ball_speed_change: 120.0,
+        ball_movement: None,
+    }
+}
+
+fn update(
+    calculator: &mut AirDribbleCalculator,
+    frame_number: usize,
+    time: f32,
+    player_position: glam::Vec3,
+    ball_position: glam::Vec3,
+    touches: &[TouchClassificationEvent],
+) {
+    calculator
+        .update_with_touch_classification_events(
+            &frame(frame_number, time),
+            &ball(ball_position, glam::Vec3::new(200.0, 0.0, 0.0)),
+            &PlayerFrameState {
+                players: vec![player(player_position, glam::Vec3::new(200.0, 0.0, 0.0))],
+            },
+            &live_play(),
+            touches,
+        )
+        .unwrap();
+}
 
 #[test]
-fn counts_air_dribble_when_airborne_player_carries_airborne_ball() {
+fn counts_three_same_player_non_ground_touches_as_air_dribble() {
     let player_id = boxcars::RemoteId::Steam(1);
-    let mut harness = BallCarryHarness::default();
+    let mut calculator = AirDribbleCalculator::new();
+    let mut touches = Vec::new();
 
-    for i in 1..=5 {
-        let x = i as f32 * 50.0;
-        let touch_state = if matches!(i, 1 | 3 | 5) {
-            touch_state_with_touch(i, i as f32 * 0.2)
-        } else {
-            touch_state()
-        };
-        harness.update(
-            &frame(i, i as f32 * 0.2),
-            &ball(
-                glam::Vec3::new(x, 0.0, 520.0),
-                glam::Vec3::new(250.0, 0.0, 0.0),
-            ),
-            &PlayerFrameState {
-                players: vec![player(
-                    glam::Vec3::new(x, 0.0, 360.0),
-                    glam::Vec3::new(250.0, 0.0, 0.0),
-                )],
-            },
-            &touch_state,
-            &LivePlayState {
-                is_live_play: true,
-                ..LivePlayState::default()
-            },
+    for (frame_number, time, x, kind, surface) in [
+        (1, 0.0, 0.0, "hard_hit", "wall"),
+        (3, 0.4, 120.0, "medium_hit", "air"),
+        (5, 0.8, 260.0, "control", "air"),
+    ] {
+        let player_position = glam::Vec3::new(x, 0.0, 360.0);
+        let ball_position = glam::Vec3::new(x + 30.0, 0.0, 520.0);
+        touches.push(touch(
+            frame_number,
+            time,
+            (player_id.clone(), true),
+            (kind, surface),
+            (player_position, ball_position),
+        ));
+        update(
+            &mut calculator,
+            frame_number,
+            time,
+            player_position,
+            ball_position,
+            &touches,
         );
     }
 
-    harness.finish();
+    calculator.finish().unwrap();
 
-    assert!(harness.calculator.player_stats().get(&player_id).is_none());
-    let stats = harness
-        .calculator
-        .player_air_dribble_stats()
-        .get(&player_id)
-        .unwrap();
-    assert_eq!(stats.count, 1);
-    assert_eq!(stats.ground_to_air_count, 1);
-    assert_eq!(stats.wall_to_air_count, 0);
-    assert_eq!(stats.total_touch_count, 3);
-    assert!((stats.total_time - 1.0).abs() < f32::EPSILON);
+    assert_eq!(calculator.events().len(), 1);
+    let event = &calculator.events()[0];
+    assert_eq!(event.player_id, player_id);
+    assert_eq!(event.kind, BallCarryKind::AirDribble);
+    assert_eq!(event.touch_count, 3);
+    assert_eq!(event.air_touch_count, 3);
     assert_eq!(
-        harness.calculator.carry_events()[0].kind,
-        BallCarryKind::AirDribble
-    );
-    assert_eq!(
-        harness.calculator.carry_events()[0].air_dribble_origin,
+        event.air_dribble_origin,
         Some(AirDribbleOrigin::GroundToAir)
     );
 }
 
 #[test]
-fn counts_takeoff_touch_plus_two_air_touches_as_air_dribble() {
+fn grounded_ball_between_touches_breaks_the_air_dribble_sequence() {
     let player_id = boxcars::RemoteId::Steam(1);
-    let mut harness = BallCarryHarness::default();
+    let mut calculator = AirDribbleCalculator::new();
+    let mut touches = Vec::new();
 
-    harness.update(
-        &frame(1, 0.2),
-        &ball(
-            glam::Vec3::new(50.0, 0.0, 520.0),
-            glam::Vec3::new(250.0, 0.0, 0.0),
-        ),
-        &PlayerFrameState {
-            players: vec![player(
-                glam::Vec3::new(50.0, 0.0, 20.0),
-                glam::Vec3::new(250.0, 0.0, 0.0),
-            )],
-        },
-        &touch_state_with_touch(1, 0.2),
-        &LivePlayState {
-            is_live_play: true,
-            ..LivePlayState::default()
-        },
+    for (frame_number, time, x) in [(1, 0.0, 0.0), (3, 0.4, 120.0)] {
+        let player_position = glam::Vec3::new(x, 0.0, 360.0);
+        let ball_position = glam::Vec3::new(x + 30.0, 0.0, 520.0);
+        touches.push(touch(
+            frame_number,
+            time,
+            (player_id.clone(), true),
+            ("control", "air"),
+            (player_position, ball_position),
+        ));
+        update(
+            &mut calculator,
+            frame_number,
+            time,
+            player_position,
+            ball_position,
+            &touches,
+        );
+    }
+
+    update(
+        &mut calculator,
+        4,
+        0.6,
+        glam::Vec3::new(180.0, 0.0, 360.0),
+        glam::Vec3::new(180.0, 0.0, 120.0),
+        &touches,
     );
 
-    for i in 2..=6 {
-        let x = i as f32 * 50.0;
-        let touch_state = if matches!(i, 4 | 6) {
-            touch_state_with_touch(i, i as f32 * 0.2)
-        } else {
-            touch_state()
-        };
-        harness.update(
-            &frame(i, i as f32 * 0.2),
-            &ball(
-                glam::Vec3::new(x, 0.0, 520.0),
-                glam::Vec3::new(250.0, 0.0, 0.0),
-            ),
-            &PlayerFrameState {
-                players: vec![player(
-                    glam::Vec3::new(x, 0.0, 360.0),
-                    glam::Vec3::new(250.0, 0.0, 0.0),
-                )],
-            },
-            &touch_state,
-            &LivePlayState {
-                is_live_play: true,
-                ..LivePlayState::default()
-            },
-        );
-    }
-
-    harness.finish();
-
-    let stats = harness
-        .calculator
-        .player_air_dribble_stats()
-        .get(&player_id)
-        .unwrap();
-    assert_eq!(stats.count, 1);
-    assert_eq!(stats.total_touch_count, 3);
-    assert_eq!(harness.calculator.carry_events()[0].touch_count, 3);
-    assert_eq!(harness.calculator.carry_events()[0].air_touch_count, 2);
-}
-
-#[test]
-fn counts_air_dribble_that_finishes_inside_goal_mouth() {
-    let player_id = boxcars::RemoteId::Steam(1);
-    let mut harness = BallCarryHarness::default();
-
-    for i in 1..=5 {
-        let y = 4700.0 + i as f32 * 100.0;
-        let touch_state = if matches!(i, 1 | 3 | 5) {
-            touch_state_with_touch(i, i as f32 * 0.2)
-        } else {
-            touch_state()
-        };
-        harness.update(
-            &frame(i, i as f32 * 0.2),
-            &ball(
-                glam::Vec3::new(120.0, y, 520.0),
-                glam::Vec3::new(0.0, 250.0, 0.0),
-            ),
-            &PlayerFrameState {
-                players: vec![player(
-                    glam::Vec3::new(80.0, y, 360.0),
-                    glam::Vec3::new(0.0, 250.0, 0.0),
-                )],
-            },
-            &touch_state,
-            &LivePlayState {
-                is_live_play: true,
-                ..LivePlayState::default()
-            },
-        );
-    }
-
-    harness.finish();
-
-    let stats = harness
-        .calculator
-        .player_air_dribble_stats()
-        .get(&player_id)
-        .unwrap();
-    assert_eq!(stats.count, 1);
-    assert_eq!(stats.total_touch_count, 3);
-}
-
-#[test]
-fn rejects_air_dribble_when_player_lands_between_touches() {
-    let player_id = boxcars::RemoteId::Steam(1);
-    let mut harness = BallCarryHarness::default();
-
-    for i in 1..=7 {
-        let x = i as f32 * 50.0;
-        let player_z = if matches!(i, 1 | 4) { 20.0 } else { 360.0 };
-        let touch_state = if matches!(i, 1 | 3 | 7) {
-            touch_state_with_touch(i, i as f32 * 0.2)
-        } else {
-            touch_state()
-        };
-        harness.update(
-            &frame(i, i as f32 * 0.2),
-            &ball(
-                glam::Vec3::new(x, 0.0, 520.0),
-                glam::Vec3::new(250.0, 0.0, 0.0),
-            ),
-            &PlayerFrameState {
-                players: vec![player(
-                    glam::Vec3::new(x, 0.0, player_z),
-                    glam::Vec3::new(250.0, 0.0, 0.0),
-                )],
-            },
-            &touch_state,
-            &LivePlayState {
-                is_live_play: true,
-                ..LivePlayState::default()
-            },
-        );
-    }
-
-    harness.finish();
-
-    assert!(
-        harness
-            .calculator
-            .player_air_dribble_stats()
-            .get(&player_id)
-            .is_none()
+    let player_position = glam::Vec3::new(260.0, 0.0, 360.0);
+    let ball_position = glam::Vec3::new(290.0, 0.0, 520.0);
+    touches.push(touch(
+        5,
+        0.8,
+        (player_id, true),
+        ("control", "air"),
+        (player_position, ball_position),
+    ));
+    update(
+        &mut calculator,
+        5,
+        0.8,
+        player_position,
+        ball_position,
+        &touches,
     );
-    assert!(harness.calculator.carry_events().is_empty());
+
+    calculator.finish().unwrap();
+
+    assert!(calculator.events().is_empty());
 }
 
 #[test]
-fn rejects_air_dribble_with_fewer_than_three_successive_touches() {
+fn non_air_control_touch_breaks_the_air_dribble_sequence() {
     let player_id = boxcars::RemoteId::Steam(1);
-    let mut harness = BallCarryHarness::default();
+    let mut calculator = AirDribbleCalculator::new();
+    let mut touches = Vec::new();
 
-    for i in 1..=5 {
-        let x = i as f32 * 50.0;
-        let touch_state = if i == 3 {
-            touch_state_with_touch(i, i as f32 * 0.2)
-        } else {
-            touch_state()
-        };
-        harness.update(
-            &frame(i, i as f32 * 0.2),
-            &ball(
-                glam::Vec3::new(x, 0.0, 520.0),
-                glam::Vec3::new(250.0, 0.0, 0.0),
-            ),
-            &PlayerFrameState {
-                players: vec![player(
-                    glam::Vec3::new(x, 0.0, 360.0),
-                    glam::Vec3::new(250.0, 0.0, 0.0),
-                )],
-            },
-            &touch_state,
-            &LivePlayState {
-                is_live_play: true,
-                ..LivePlayState::default()
-            },
+    for (frame_number, time, surface) in [(1, 0.0, "air"), (3, 0.4, "ground"), (5, 0.8, "air")] {
+        let x = frame_number as f32 * 60.0;
+        let player_position = glam::Vec3::new(x, 0.0, 360.0);
+        let ball_position = glam::Vec3::new(x + 30.0, 0.0, 520.0);
+        touches.push(touch(
+            frame_number,
+            time,
+            (player_id.clone(), true),
+            ("control", surface),
+            (player_position, ball_position),
+        ));
+        update(
+            &mut calculator,
+            frame_number,
+            time,
+            player_position,
+            ball_position,
+            &touches,
         );
     }
 
-    harness.finish();
+    calculator.finish().unwrap();
 
-    assert!(
-        harness
-            .calculator
-            .player_air_dribble_stats()
-            .get(&player_id)
-            .is_none()
-    );
-    assert!(harness.calculator.carry_events().is_empty());
+    assert!(calculator.events().is_empty());
 }
 
 #[test]
-fn records_air_dribble_touch_count() {
-    let player_id = boxcars::RemoteId::Steam(1);
-    let mut harness = BallCarryHarness::default();
+fn different_player_touch_starts_a_new_sequence() {
+    let first_player = boxcars::RemoteId::Steam(1);
+    let second_player = boxcars::RemoteId::Steam(2);
+    let mut calculator = AirDribbleCalculator::new();
+    let mut touches = Vec::new();
 
-    for i in 1..=8 {
-        let x = i as f32 * 50.0;
-        let touch_state = if matches!(i, 1 | 4 | 7) {
-            touch_state_with_touch(i, i as f32 * 0.2)
-        } else {
-            touch_state()
-        };
-        harness.update(
-            &frame(i, i as f32 * 0.2),
-            &ball(
-                glam::Vec3::new(x, 0.0, 520.0),
-                glam::Vec3::new(250.0, 0.0, 0.0),
-            ),
-            &PlayerFrameState {
-                players: vec![player(
-                    glam::Vec3::new(x, 0.0, 360.0),
-                    glam::Vec3::new(250.0, 0.0, 0.0),
-                )],
-            },
-            &touch_state,
-            &LivePlayState {
-                is_live_play: true,
-                ..LivePlayState::default()
-            },
-        );
+    for (frame_number, time, player_id) in [
+        (1, 0.0, first_player.clone()),
+        (3, 0.4, first_player),
+        (5, 0.8, second_player),
+    ] {
+        let x = frame_number as f32 * 60.0;
+        let player_position = glam::Vec3::new(x, 0.0, 360.0);
+        let ball_position = glam::Vec3::new(x + 30.0, 0.0, 520.0);
+        touches.push(touch(
+            frame_number,
+            time,
+            (player_id.clone(), true),
+            ("control", "air"),
+            (player_position, ball_position),
+        ));
+        calculator
+            .update_with_touch_classification_events(
+                &frame(frame_number, time),
+                &ball(ball_position, glam::Vec3::new(200.0, 0.0, 0.0)),
+                &PlayerFrameState {
+                    players: vec![player_with_id(
+                        player_id,
+                        true,
+                        player_position,
+                        glam::Vec3::new(200.0, 0.0, 0.0),
+                    )],
+                },
+                &live_play(),
+                &touches,
+            )
+            .unwrap();
     }
 
-    harness.finish();
+    calculator.finish().unwrap();
 
-    let stats = harness
-        .calculator
-        .player_air_dribble_stats()
-        .get(&player_id)
-        .unwrap();
-    assert_eq!(stats.total_touch_count, 3);
-    assert_eq!(stats.max_touch_count, 3);
-    assert_eq!(stats.average_touch_count(), 3.0);
-    assert_eq!(harness.calculator.carry_events()[0].touch_count, 3);
-}
-
-#[test]
-fn records_wall_to_air_dribble_origin() {
-    let player_id = boxcars::RemoteId::Steam(1);
-    let mut harness = BallCarryHarness::default();
-
-    for i in 1..=5 {
-        let touch_state = if matches!(i, 1 | 3 | 5) {
-            touch_state_with_touch(i, i as f32 * 0.2)
-        } else {
-            touch_state()
-        };
-        harness.update(
-            &frame(i, i as f32 * 0.2),
-            &ball(
-                glam::Vec3::new(3420.0, i as f32 * 50.0, 520.0),
-                glam::Vec3::new(0.0, 250.0, 0.0),
-            ),
-            &PlayerFrameState {
-                players: vec![player(
-                    glam::Vec3::new(3300.0, i as f32 * 50.0, 360.0),
-                    glam::Vec3::new(0.0, 250.0, 0.0),
-                )],
-            },
-            &touch_state,
-            &LivePlayState {
-                is_live_play: true,
-                ..LivePlayState::default()
-            },
-        );
-    }
-
-    harness.finish();
-
-    let stats = harness
-        .calculator
-        .player_air_dribble_stats()
-        .get(&player_id)
-        .unwrap();
-    assert_eq!(stats.ground_to_air_count, 0);
-    assert_eq!(stats.wall_to_air_count, 1);
-    assert_eq!(
-        harness.calculator.carry_events()[0].air_dribble_origin,
-        Some(AirDribbleOrigin::WallToAir)
-    );
-}
-
-#[test]
-fn rejects_wall_control_as_air_dribble() {
-    let player_id = boxcars::RemoteId::Steam(1);
-    let mut harness = BallCarryHarness::default();
-
-    for i in 1..=5 {
-        let y = i as f32 * 50.0;
-        harness.update(
-            &frame(i, i as f32 * 0.2),
-            &ball(
-                glam::Vec3::new(3720.0, y, 520.0),
-                glam::Vec3::new(0.0, 250.0, 0.0),
-            ),
-            &PlayerFrameState {
-                players: vec![player(
-                    glam::Vec3::new(3650.0, y, 360.0),
-                    glam::Vec3::new(0.0, 250.0, 0.0),
-                )],
-            },
-            &touch_state(),
-            &LivePlayState {
-                is_live_play: true,
-                ..LivePlayState::default()
-            },
-        );
-    }
-
-    harness.finish();
-
-    assert!(harness.calculator.player_stats().get(&player_id).is_none());
-    assert!(
-        harness
-            .calculator
-            .player_air_dribble_stats()
-            .get(&player_id)
-            .is_none()
-    );
-    assert!(harness.calculator.carry_events().is_empty());
+    assert!(calculator.events().is_empty());
 }

--- a/src/stats/calculators/ball_carry.rs
+++ b/src/stats/calculators/ball_carry.rs
@@ -35,7 +35,7 @@ pub enum BallCarryKind {
     AirDribble,
 }
 
-/// Detects ball carries and air dribbles from continuous ball-control sequences.
+/// Detects ground ball carries from continuous ball-control sequences.
 #[derive(Debug, Clone, Default)]
 pub struct BallCarryCalculator {
     carry_events: EventStream<BallCarryEvent>,
@@ -66,17 +66,6 @@ impl BallCarryCalculator {
             .distance(ball_position.truncate());
         let vertical_gap = ball_position.z - player_position.z;
 
-        if AirDribblePolicy::is_sample(player_position, ball_position, horizontal_gap, vertical_gap)
-        {
-            return Some(ContinuousBallControlSample {
-                player_position,
-                kind: BallCarryKind::AirDribble,
-                horizontal_gap,
-                vertical_gap,
-                speed: player.speed().unwrap_or(0.0),
-            });
-        }
-
         if player_is_on_wall(player_position) {
             return None;
         }
@@ -102,8 +91,8 @@ impl BallCarryCalculator {
         })
     }
 
-    pub(crate) fn kind_requires_airborne(kind: BallCarryKind) -> bool {
-        AirDribblePolicy::kind_requires_airborne(kind)
+    pub(crate) fn kind_requires_airborne(_kind: BallCarryKind) -> bool {
+        false
     }
 
     pub(crate) fn control_player_statuses(
@@ -171,17 +160,11 @@ impl BallCarryCalculator {
             .find(|player| &player.player_id == player_id)
             .and_then(|player| {
                 Self::carry_frame_sample(player, ball).map(|sample| {
-                    let air_touch_count =
-                        if AirDribblePolicy::is_air_touch_position(sample.player_position) {
-                            touch_count
-                        } else {
-                            0
-                        };
                     ContinuousBallControlCandidate {
                         player_id: player.player_id.clone(),
                         is_team_0: player.is_team_0,
                         touch_count,
-                        air_touch_count,
+                        air_touch_count: 0,
                         sample,
                     }
                 })
@@ -191,8 +174,6 @@ impl BallCarryCalculator {
     fn event_from_sequence(
         sequence: CompletedBallControlSequence<BallCarryKind>,
     ) -> BallCarryEvent {
-        let air_dribble_origin = (sequence.kind == BallCarryKind::AirDribble)
-            .then(|| AirDribblePolicy::origin(sequence.start_position));
         BallCarryEvent {
             player_id: sequence.player_id,
             is_team_0: sequence.is_team_0,
@@ -211,7 +192,7 @@ impl BallCarryCalculator {
             average_speed: sequence.average_speed,
             touch_count: sequence.touch_count,
             air_touch_count: sequence.air_touch_count,
-            air_dribble_origin,
+            air_dribble_origin: None,
         }
     }
 
@@ -227,9 +208,6 @@ impl BallCarryCalculator {
             .skip(self.processed_control_sequence_count)
             .cloned()
         {
-            if !AirDribblePolicy::is_valid_sequence(&sequence) {
-                continue;
-            }
             self.record_carry_event(Self::event_from_sequence(sequence));
         }
         self.processed_control_sequence_count = control_state.completed_sequences.len();

--- a/src/stats/calculators/ball_control_test_support.rs
+++ b/src/stats/calculators/ball_control_test_support.rs
@@ -57,40 +57,6 @@ pub(crate) fn touch_state() -> TouchState {
     }
 }
 
-pub(crate) fn touch_state_with_touch(frame: usize, time: f32) -> TouchState {
-    let player_id = boxcars::RemoteId::Steam(1);
-    TouchState {
-        touch_events: vec![TouchEvent {
-            touch_id: None,
-            time,
-            frame,
-            team_is_team_0: true,
-            player: Some(player_id.clone()),
-            player_position: None,
-            closest_approach_distance: None,
-            contact_local_ball_position: None,
-            contact_local_hitbox_point: None,
-            contact_world_hitbox_point: None,
-            dodge_contact: false,
-        }],
-        last_touch: Some(TouchEvent {
-            touch_id: None,
-            time,
-            frame,
-            team_is_team_0: true,
-            player: Some(player_id.clone()),
-            player_position: None,
-            closest_approach_distance: None,
-            contact_local_ball_position: None,
-            contact_local_hitbox_point: None,
-            contact_world_hitbox_point: None,
-            dodge_contact: false,
-        }),
-        last_touch_player: Some(player_id),
-        last_touch_team_is_team_0: Some(true),
-    }
-}
-
 #[derive(Default)]
 pub(crate) struct BallCarryHarness {
     tracker: ContinuousBallControlTracker<BallCarryKind>,

--- a/src/stats/calculators/event_definition.rs
+++ b/src/stats/calculators/event_definition.rs
@@ -1195,6 +1195,13 @@ pub(crate) const BALL_CARRY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     "BallCarryCalculator",
 )];
 
+pub(crate) const AIR_DRIBBLE_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
+    &BALL_CARRY_EVENT_DEFINITION,
+    "air_dribble",
+    "AirDribbleNode",
+    "AirDribbleCalculator",
+)];
+
 pub(crate) const CONTROLLED_PLAY_EMITTED_EVENTS: &[EmittedEvent] = &[produced_event(
     &CONTROLLED_PLAY_EVENT_DEFINITION,
     "controlled_play",

--- a/src/stats/calculators/goal_tags.rs
+++ b/src/stats/calculators/goal_tags.rs
@@ -1397,10 +1397,10 @@ impl AirDribbleGoalCalculator {
     pub fn update(
         &mut self,
         match_stats: &MatchStatsCalculator,
-        ball_carry: &BallCarryCalculator,
+        air_dribble: &AirDribbleCalculator,
     ) -> SubtrActorResult<()> {
         self.events.replace_all_assuming_append_only(
-            self.tag_goals(match_stats.goal_context_events(), ball_carry.carry_events()),
+            self.tag_goals(match_stats.goal_context_events(), air_dribble.events()),
         );
         Ok(())
     }

--- a/src/stats/calculators/touch_state.rs
+++ b/src/stats/calculators/touch_state.rs
@@ -349,6 +349,48 @@ impl TouchStateCalculator {
             })
     }
 
+    /// Finds a concrete current-frame contact for a dodge refresh when no
+    /// trajectory-deviation candidate was cached. Flip-reset underside contacts
+    /// can refresh the dodge without producing a replay `BallHitTeamNum` marker
+    /// or enough ball deviation to enter the candidate cache.
+    fn current_frame_touch_candidate_for_dodge_refresh(
+        &self,
+        dodge_refresh: &DodgeRefreshedEvent,
+        ball: &BallFrameState,
+        players: &PlayerFrameState,
+    ) -> Option<TouchEvent> {
+        self.previous_ball_rigid_body?;
+        let ball = ball.sample()?;
+        let player = players
+            .players
+            .iter()
+            .find(|player| player.player_id == dodge_refresh.player)?;
+        let rigid_body = player.rigid_body.as_ref()?;
+        let (closest_contact_gap, _current_contact_gap) =
+            touch_candidate_contact_gap_rank_with_hitbox(
+                &ball.rigid_body,
+                rigid_body,
+                player.hitbox,
+            )?;
+        if closest_contact_gap > MARKER_CONTACT_ATTRIBUTION_MAX_GAP {
+            return None;
+        }
+        let contact_fields = touch_event_contact_fields(ball.position(), rigid_body, player.hitbox);
+        Some(TouchEvent {
+            touch_id: None,
+            time: dodge_refresh.time,
+            frame: dodge_refresh.frame,
+            team_is_team_0: dodge_refresh.is_team_0,
+            player: Some(dodge_refresh.player.clone()),
+            player_position: Some(rigid_body.location),
+            closest_approach_distance: Some(closest_contact_gap),
+            contact_local_ball_position: contact_fields.local_ball_position,
+            contact_local_hitbox_point: contact_fields.local_hitbox_point,
+            contact_world_hitbox_point: contact_fields.world_hitbox_point,
+            dodge_contact: player.dodge_active,
+        })
+    }
+
     /// Attributes a team-only replay touch marker to a concrete player.
     ///
     /// Prefers whichever of the recent candidate cache or the current frame's
@@ -664,7 +706,16 @@ impl TouchStateCalculator {
             if !confirmed_players.insert(dodge_refresh.player.clone()) {
                 continue;
             }
-            let Some(candidate) = self.candidate_for_player(&dodge_refresh.player) else {
+            let Some(candidate) = self
+                .candidate_for_player(&dodge_refresh.player)
+                .or_else(|| {
+                    self.current_frame_touch_candidate_for_dodge_refresh(
+                        dodge_refresh,
+                        ball,
+                        players,
+                    )
+                })
+            else {
                 continue;
             };
             touch_events.push(Self::touch_event_from_dodge_refresh(

--- a/src/stats/calculators/touch_state_tests.rs
+++ b/src/stats/calculators/touch_state_tests.rs
@@ -273,6 +273,101 @@ fn team_only_explicit_touch_events_without_physics_candidate_are_ignored() {
 }
 
 #[test]
+fn dodge_refresh_on_current_frame_contact_is_counted_as_touch() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let players = players(player_id.clone());
+    let mut calculator = TouchStateCalculator::new();
+    let live_play = LivePlayState {
+        gameplay_phase: GameplayPhase::ActivePlay,
+        is_live_play: true,
+    };
+    let events = FrameEventsState {
+        dodge_refreshed_events: vec![DodgeRefreshedEvent {
+            time: frame(1).time,
+            frame: 1,
+            player: player_id.clone(),
+            player_position: None,
+            is_team_0: true,
+            counter_value: 1,
+        }],
+        ..FrameEventsState::default()
+    };
+
+    calculator.update(
+        &frame(0),
+        &ball(glam::Vec3::ZERO),
+        &players,
+        &FrameEventsState::default(),
+        &live_play,
+    );
+    let touch_state = calculator.update(
+        &frame(1),
+        &ball(glam::Vec3::ZERO),
+        &players,
+        &events,
+        &live_play,
+    );
+
+    assert_eq!(touch_state.touch_events.len(), 1);
+    let touch = &touch_state.touch_events[0];
+    assert_eq!(touch.player, Some(player_id.clone()));
+    assert_eq!(touch.frame, 1);
+    assert!(touch.team_is_team_0);
+    assert_eq!(touch_state.last_touch_player, Some(player_id));
+    assert!(
+        touch.closest_approach_distance.unwrap() <= MARKER_CONTACT_ATTRIBUTION_MAX_GAP,
+        "expected dodge-refresh touch to be backed by current-frame contact"
+    );
+}
+
+#[test]
+fn dodge_refresh_away_from_ball_is_not_counted_as_touch() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let players = PlayerFrameState {
+        players: vec![player_sample(
+            player_id.clone(),
+            true,
+            glam::Vec3::new(2000.0, 0.0, BALL_RADIUS_Z),
+            glam::Vec3::ZERO,
+        )],
+    };
+    let mut calculator = TouchStateCalculator::new();
+    let live_play = LivePlayState {
+        gameplay_phase: GameplayPhase::ActivePlay,
+        is_live_play: true,
+    };
+    let events = FrameEventsState {
+        dodge_refreshed_events: vec![DodgeRefreshedEvent {
+            time: frame(1).time,
+            frame: 1,
+            player: player_id,
+            player_position: None,
+            is_team_0: true,
+            counter_value: 1,
+        }],
+        ..FrameEventsState::default()
+    };
+
+    calculator.update(
+        &frame(0),
+        &ball(glam::Vec3::ZERO),
+        &players,
+        &FrameEventsState::default(),
+        &live_play,
+    );
+    let touch_state = calculator.update(
+        &frame(1),
+        &ball(glam::Vec3::ZERO),
+        &players,
+        &events,
+        &live_play,
+    );
+
+    assert!(touch_state.touch_events.is_empty());
+    assert_eq!(touch_state.last_touch_player, None);
+}
+
+#[test]
 fn team_only_explicit_touch_events_keep_event_time_when_enriched_from_recent_cache() {
     let player_id = boxcars::RemoteId::Steam(1);
     let players = players(player_id.clone());

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -28,7 +28,7 @@
 //!   [`DodgeResetCalculator`], [`WallAerialCalculator`],
 //!   [`WallAerialShotCalculator`], [`CeilingShotCalculator`],
 //!   [`DoubleTapCalculator`], [`HalfVolleyCalculator`], [`OneTimerCalculator`],
-//!   [`BallCarryCalculator`] (carries / air dribbles).
+//!   [`BallCarryCalculator`], [`AirDribbleCalculator`].
 //! - **Play & contests** — [`TouchCalculator`], [`PassCalculator`],
 //!   [`CenterCalculator`], [`KickoffCalculator`], [`BumpCalculator`],
 //!   [`DemoCalculator`], [`RushCalculator`], [`ControlledPlayCalculator`],

--- a/src/util/geometry.rs
+++ b/src/util/geometry.rs
@@ -213,7 +213,7 @@ impl TouchCandidateScoring {
         relaxed_contact_gap_threshold: 25.0,
         strict_contact_min_position_deviation: 25.0,
         relaxed_contact_min_position_deviation: 500.0,
-        strict_contact_min_velocity_deviation: 50.0,
+        strict_contact_min_velocity_deviation: 15.0,
         relaxed_contact_min_velocity_deviation: 1000.0,
         relaxed_contact_score_penalty: 100.0,
         dodge_contact_score_bonus: 1.0,

--- a/src/util/geometry_tests.rs
+++ b/src/util/geometry_tests.rs
@@ -323,7 +323,8 @@ fn touch_candidate_scoring_requires_ball_deviation_for_contact_gaps() {
     let scoring = TouchCandidateScoring::DEFAULT;
 
     assert!(!scoring.accepts_contact_gap(0.0, 0.0, 0.0));
-    assert!(scoring.accepts_contact_gap(0.0, 0.0, 50.0));
+    assert!(scoring.accepts_contact_gap(0.0, 0.0, 15.0));
+    assert!(!scoring.accepts_contact_gap(0.0, 0.0, 14.9));
     assert!(scoring.accepts_contact_gap(0.0, 25.0, 0.0));
     assert!(!scoring.accepts_contact_gap(10.0, 499.0, 999.0));
     assert!(scoring.accepts_contact_gap(10.0, 0.0, 1000.0));

--- a/tests/clip_air_dribble_test.rs
+++ b/tests/clip_air_dribble_test.rs
@@ -14,8 +14,8 @@ use subtr_actor::{
 
 const AIR_DRIBBLE_GOAL_MOUTH_REPLAY: &str = "assets/air-dribble-goal-mouth-2026-05-24.replay";
 
-const AIR_DRIBBLE_START_TIME: f32 = 56.37;
-const AIR_DRIBBLE_END_TIME: f32 = 59.11;
+const AIR_DRIBBLE_START_TIME: f32 = 57.10;
+const AIR_DRIBBLE_END_TIME: f32 = 59.02;
 
 #[test]
 fn clip_detects_air_dribble_goal_and_rejects_unrelated_half_volley_tag() {


### PR DESCRIPTION
## Summary
- recover low-impulse flip reset touches by lowering the strict contact velocity threshold and using current-frame dodge-refresh contact evidence
- add a standalone air-dribble calculator based on continuous same-player non-ground touches
- wire air-dribble events through stats projection, timeline events, goal tags, and collector exports separately from ball carry
- expand the flip reset goal audit output with air-dribble and touch diagnostics

## Validation
- just check
- replay audit confirmed 3 wall aerials and AirDribbleGoal on all 3 goals in 019f1ca7

## Notes
- left unrelated untracked files alone: Paragon.msi, missedhalfflip.json
