### PR TITLE
Classify wall-aerial walls from position, not car orientation

### DIFF
--- a/src/stats/calculators/wall_aerial.rs
+++ b/src/stats/calculators/wall_aerial.rs
@@ -15,10 +15,13 @@ pub(crate) const WALL_AERIAL_MIN_TOUCH_BALL_Z: f32 = 400.0;
 const WALL_AERIAL_REFERENCE_BALL_SPEED_CHANGE: f32 = 80.0;
 pub(crate) const WALL_AERIAL_HIGH_CONFIDENCE: f32 = 0.78;
 
-/// Minimum horizontal magnitude of the car's up (roof) vector before we trust
-/// it as a wall surface normal. Below this the car is roughly upright (on the
-/// floor or tumbling in the air) and we fall back to field position.
-const WALL_AERIAL_MIN_WALL_NORMAL_HORIZONTAL: f32 = 0.5;
+/// Field coordinates where the rounded corner arcs begin: the flat walls
+/// (side `|x| = 4096`, end `|y| = 5120`) curve into a quarter circle of radius
+/// 1152 beyond these. Subtracting them from an on-wall position (clamping the
+/// residual at zero) leaves the outward wall normal: axis-aligned on a flat
+/// wall, radial on a corner arc.
+const WALL_CORNER_ARC_START_ABS_X: f32 = 4096.0 - 1152.0;
+const WALL_CORNER_ARC_START_ABS_Y: f32 = 5120.0 - 1152.0;
 /// Ratio of the smaller to the larger attack-relative axis above which a wall
 /// takeoff is treated as a (diagonal) corner. `tan(22.5°)` splits each quadrant
 /// into three equal 45° sectors across the eight [`WallAerialWall`] directions.
@@ -82,36 +85,18 @@ pub(crate) fn wall_aerial_wall_for_position(position: glam::Vec3) -> Option<Wall
     None
 }
 
-/// The car's up (roof) vector, i.e. the surface normal of whatever it is resting
-/// on. On a wall this points away from the wall toward the field interior.
-pub(crate) fn player_up_vector(player: &PlayerSample) -> Option<glam::Vec3> {
-    let rigid_body = player.rigid_body.as_ref()?;
-    Some(quat_to_glam(&rigid_body.rotation) * glam::Vec3::Z)
-}
-
-/// Classify which wall (relative to the player's attack direction) a takeoff
-/// came from. Prefers the car's surface normal (its roof points away from the
-/// wall it is driving on), falling back to field position when orientation is
-/// unavailable or too upright to read a wall from.
+/// Classify which wall (relative to the player's attack direction) an on-wall
+/// position is on. The residual of each axis beyond the corner-arc start is the
+/// outward wall normal — zero along an axis whose flat wall is out of reach, and
+/// the radial direction of the arc in a corner — so field position alone
+/// determines the wall, independent of car orientation.
 pub(crate) fn wall_aerial_wall_classification(
     is_team_0: bool,
     position: glam::Vec3,
-    up: Option<glam::Vec3>,
 ) -> WallAerialWall {
-    if let Some(up) = up {
-        let horizontal = glam::vec2(up.x, up.y);
-        if horizontal.length() >= WALL_AERIAL_MIN_WALL_NORMAL_HORIZONTAL {
-            // The wall lies opposite the roof direction.
-            return wall_aerial_wall_from_axes(is_team_0, -horizontal.x, -horizontal.y);
-        }
-    }
-    // Fallback: scale each axis by its wall reach so the comparison reflects how
-    // close the car is to the side wall vs. the end wall.
-    wall_aerial_wall_from_axes(
-        is_team_0,
-        position.x / SIDE_WALL_CONTACT_ABS_X,
-        position.y / BACK_WALL_CONTACT_ABS_Y,
-    )
+    let x = position.x.signum() * (position.x.abs() - WALL_CORNER_ARC_START_ABS_X).max(0.0);
+    let y = position.y.signum() * (position.y.abs() - WALL_CORNER_ARC_START_ABS_Y).max(0.0);
+    wall_aerial_wall_from_axes(is_team_0, x, y)
 }
 
 /// Map a horizontal direction toward the wall (any positive scale) into an
@@ -268,7 +253,7 @@ impl WallAerialCalculator {
     /// A wall aerial is "ride the wall, leave it, hit the ball in the air." We
     /// detect the first two phases here, keyed purely on the player being on the
     /// wall surface (`wall_aerial_wall_for_position`) — no ball control required.
-    /// The attack-relative wall label is read from the car's roof vector at the
+    /// The attack-relative wall label is read from the field position at the
     /// last on-wall frame (`wall_aerial_wall_classification`).
     fn update_wall_contacts_and_takeoffs(&mut self, frame: &FrameInfo, players: &PlayerFrameState) {
         for player in &players.players {
@@ -278,11 +263,7 @@ impl WallAerialCalculator {
 
             // On the wall: start or extend the contact span, and defer takeoff.
             if let Some(surface) = wall_aerial_wall_for_position(position) {
-                let wall_direction = wall_aerial_wall_classification(
-                    player.is_team_0,
-                    position,
-                    player_up_vector(player),
-                );
+                let wall_direction = wall_aerial_wall_classification(player.is_team_0, position);
                 match self.wall_contacts.get_mut(&player.player_id) {
                     Some(span) if span.surface == surface => {
                         span.last_time = frame.time;

--- a/src/stats/calculators/wall_aerial_shot.rs
+++ b/src/stats/calculators/wall_aerial_shot.rs
@@ -1,6 +1,6 @@
 use super::wall_aerial::{
-    WALL_AERIAL_MIN_TOUCH_BALL_Z, WALL_AERIAL_MIN_TOUCH_PLAYER_Z, player_up_vector,
-    wall_aerial_normalize_score, wall_aerial_wall_classification, wall_aerial_wall_for_position,
+    WALL_AERIAL_MIN_TOUCH_BALL_Z, WALL_AERIAL_MIN_TOUCH_PLAYER_Z, wall_aerial_normalize_score,
+    wall_aerial_wall_classification, wall_aerial_wall_for_position,
 };
 use super::*;
 
@@ -88,11 +88,7 @@ impl WallAerialShotCalculator {
             }
 
             if wall_aerial_wall_for_position(position).is_some() {
-                let wall_direction = wall_aerial_wall_classification(
-                    player.is_team_0,
-                    position,
-                    player_up_vector(player),
-                );
+                let wall_direction = wall_aerial_wall_classification(player.is_team_0, position);
                 self.recent_wall_contacts.insert(
                     player.player_id.clone(),
                     RecentWallContact {

--- a/src/stats/calculators/wall_aerial_tests.rs
+++ b/src/stats/calculators/wall_aerial_tests.rs
@@ -658,92 +658,75 @@ fn rejects_aerial_that_starts_near_wall_but_never_on_it() {
     assert!(calculator.events().is_empty());
 }
 
-// The car's up (roof) vector points away from the wall it is driving on, so the
-// wall lies along `-up`. These exercise the orientation-based classifier
-// directly (position is only consulted in the fallback path).
-const ON_WALL_POSITION: glam::Vec3 = glam::Vec3::new(0.0, 0.0, 600.0);
+// Which wall a position is on follows from the position alone: the residual of
+// each axis beyond the corner-arc start is the outward wall normal.
 
 #[test]
-fn classifies_side_walls_relative_to_attack_direction_from_orientation() {
-    // Team 0 attacks toward +y, so +x is their right.
-    let up_on_plus_x_wall = glam::Vec3::new(-1.0, 0.0, 0.05);
-    let up_on_minus_x_wall = glam::Vec3::new(1.0, 0.0, 0.05);
+fn classifies_side_walls_relative_to_attack_direction() {
+    let plus_x_wall = glam::Vec3::new(4096.0, 0.0, 600.0);
+    let minus_x_wall = glam::Vec3::new(-4096.0, 0.0, 600.0);
+    // Team 0 attacks toward +y, so the +x wall is their right.
     assert_eq!(
-        wall_aerial_wall_classification(true, ON_WALL_POSITION, Some(up_on_plus_x_wall)),
+        wall_aerial_wall_classification(true, plus_x_wall),
         WallAerialWall::Right,
     );
     assert_eq!(
-        wall_aerial_wall_classification(true, ON_WALL_POSITION, Some(up_on_minus_x_wall)),
+        wall_aerial_wall_classification(true, minus_x_wall),
         WallAerialWall::Left,
     );
     // Team 1 attacks toward -y, so the same +x wall is on their left.
     assert_eq!(
-        wall_aerial_wall_classification(false, ON_WALL_POSITION, Some(up_on_plus_x_wall)),
+        wall_aerial_wall_classification(false, plus_x_wall),
         WallAerialWall::Left,
     );
 }
 
 #[test]
-fn classifies_end_walls_as_front_or_back_from_orientation() {
-    // On the +y wall the roof points toward -y; for team 0 that is the
-    // opponent's (front) end. The opposite wall is their own (back) end.
+fn classifies_end_walls_as_front_or_back() {
+    let plus_y_wall = glam::Vec3::new(1500.0, 5120.0, 600.0);
+    let minus_y_wall = glam::Vec3::new(1500.0, -5120.0, 600.0);
+    // For team 0 the +y end wall is the opponent's (front) end.
     assert_eq!(
-        wall_aerial_wall_classification(
-            true,
-            ON_WALL_POSITION,
-            Some(glam::Vec3::new(0.0, -1.0, 0.05)),
-        ),
+        wall_aerial_wall_classification(true, plus_y_wall),
         WallAerialWall::Front,
     );
     assert_eq!(
-        wall_aerial_wall_classification(
-            true,
-            ON_WALL_POSITION,
-            Some(glam::Vec3::new(0.0, 1.0, 0.05)),
-        ),
+        wall_aerial_wall_classification(true, minus_y_wall),
         WallAerialWall::Back,
     );
     // Team 1's attack direction is flipped, so the same walls swap roles.
     assert_eq!(
-        wall_aerial_wall_classification(
-            false,
-            ON_WALL_POSITION,
-            Some(glam::Vec3::new(0.0, -1.0, 0.05)),
-        ),
+        wall_aerial_wall_classification(false, plus_y_wall),
         WallAerialWall::Back,
     );
 }
 
 #[test]
-fn classifies_diagonal_takeoffs_as_corners() {
-    // Roof pointing diagonally inward means the car is on a rounded corner.
-    let up_off_plus_x_plus_y_corner = glam::Vec3::new(-0.7, -0.7, 0.1);
+fn classifies_corner_arc_positions_as_corners() {
+    // The midpoint of the +x/+y corner arc: the radial (outward-normal)
+    // direction is a 45° diagonal.
+    let mid_corner = glam::Vec3::new(3758.6, 4782.6, 600.0);
     assert_eq!(
-        wall_aerial_wall_classification(true, ON_WALL_POSITION, Some(up_off_plus_x_plus_y_corner)),
+        wall_aerial_wall_classification(true, mid_corner),
         WallAerialWall::FrontRight,
     );
     assert_eq!(
-        wall_aerial_wall_classification(false, ON_WALL_POSITION, Some(up_off_plus_x_plus_y_corner)),
+        wall_aerial_wall_classification(false, mid_corner),
         WallAerialWall::BackLeft,
     );
 }
 
 #[test]
-fn falls_back_to_position_when_orientation_is_upright() {
-    // A purely vertical roof carries no wall information, so we classify from the
-    // field position instead (here a near-corner location).
-    let upright = glam::Vec3::new(0.0, 0.0, 1.0);
+fn side_wall_positions_near_a_corner_stay_side_walls() {
+    // Deep along the flat side wall, short of the corner-arc start: still side.
     assert_eq!(
-        wall_aerial_wall_classification(
-            true,
-            glam::Vec3::new(3700.0, 5100.0, 600.0),
-            Some(upright),
-        ),
-        WallAerialWall::FrontRight,
+        wall_aerial_wall_classification(true, glam::Vec3::new(4096.0, 3800.0, 600.0)),
+        WallAerialWall::Right,
     );
-    // Missing orientation entirely uses the same fallback.
+    // Just onto the corner arc near its side-wall end: the outward normal still
+    // points mostly sideways.
     assert_eq!(
-        wall_aerial_wall_classification(true, glam::Vec3::new(3700.0, 0.0, 600.0), None),
+        wall_aerial_wall_classification(true, glam::Vec3::new(4050.0, 4300.0, 600.0)),
         WallAerialWall::Right,
     );
 }


### PR DESCRIPTION
## Summary
- Wall-aerial wall classification previously read the car's roof (up) vector as a wall normal. Since the takeoff flip happens inside the same on-wall box used to detect wall contact, and the span's wall label is overwritten every on-wall frame (last-one-wins), the flip itself could relabel a clean side-wall aerial as a corner.
- The position-based fallback path was also broken independently: it scaled x by 3600 and y by 5000 before running the corner-sector test, distorting the angle enough that more than half the side wall (from |y| ≈ 2360) classified as a corner instead of a flat wall.
- Replaced both paths with a single position-only classifier that derives the outward wall normal from the field's actual corner-arc geometry (rounded corners start at |x| = 2944 / |y| = 3968, radius 1152), then feeds that into the existing 22.5° sector split.
- Removed `player_up_vector` and the orientation-horizontal gate, now unused.

## Test plan
- [x] `cargo test --lib calculators::wall_aerial` — 20 tests pass, including new position-based classification tests (flat walls, corner-arc midpoint, near-corner side-wall positions)
- [x] `cargo test --test wall_aerial_fixture_test -- --ignored` — whole-replay fixture still finds the same 6 reviewed wall aerials
- [x] `just check-rust` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)