### PR TITLE
Let dodge touches bypass the passive-contact touch rate limit

### DIFF
--- a/src/stats/calculators/flick.rs
+++ b/src/stats/calculators/flick.rs
@@ -346,7 +346,13 @@ struct PendingFlick {
     real_dodge_start: Option<RecentDodgeStart>,
     /// Whether the touch was classified as a dodge contact downstream.
     classified_dodge: bool,
-    /// Ball velocity in the frame just before the touch.
+    /// Start of the impulse measurement: the time of the first touch in this
+    /// contact episode. Equal to the touch time unless this pending superseded
+    /// an earlier same-episode touch, in which case it inherits that touch's
+    /// anchor so the measured impulse spans the whole episode (a dodge drags
+    /// the ball across several frames; see [`FLICK_IMPULSE_WINDOW_SECONDS`]).
+    measure_start_time: f32,
+    /// Ball velocity in the frame just before the touch at `measure_start_time`.
     pre_velocity: glam::Vec3,
     peak_impulse: glam::Vec3,
     peak_magnitude: f32,
@@ -1020,17 +1026,47 @@ impl FlickCalculator {
         // One flick per dodge: a newer touch by the same player supersedes its
         // earlier window so a single dribble cannot emit multiple flicks when
         // its control touches fall within one impulse window of each other.
+        // A still-live pending being superseded is the same contact episode —
+        // it can only exist within the short retention window, and the touch
+        // rate limit only lets a same-player pair through that fast when a
+        // dodge-powered launch follows a passive contact. The new pending
+        // inherits the earlier measurement anchor instead of resetting it, so
+        // the launch impulse already delivered before this touch stays in the
+        // measured peak.
+        let inherited_measurement = self
+            .pending_flicks
+            .iter()
+            .find(|pending| {
+                pending.player.player_id == player.player_id
+                    && touch_event.time >= pending.touch_event.time
+            })
+            .map(|pending| {
+                (
+                    pending.measure_start_time,
+                    pending.pre_velocity,
+                    pending.peak_impulse,
+                    pending.peak_magnitude,
+                )
+            });
         self.pending_flicks
             .retain(|pending| pending.player.player_id != player.player_id);
+        let (measure_start_time, pre_velocity, peak_impulse, peak_magnitude) =
+            inherited_measurement.unwrap_or((
+                touch_event.time,
+                pre_velocity,
+                glam::Vec3::ZERO,
+                0.0,
+            ));
         self.pending_flicks.push(PendingFlick {
             touch_event: touch_event.clone(),
             ball: ball.clone(),
             player: player.clone(),
             real_dodge_start: self.dodge_start_for_touch(player),
             classified_dodge: false,
+            measure_start_time,
             pre_velocity,
-            peak_impulse: glam::Vec3::ZERO,
-            peak_magnitude: 0.0,
+            peak_impulse,
+            peak_magnitude,
         });
     }
 
@@ -1052,13 +1088,20 @@ impl FlickCalculator {
                 return false;
             }
 
-            // Measure the impulse only over the (shorter) impulse window; the
-            // entry is kept alive past it purely so a late-replicating dodge byte
-            // can still confirm the launch touch.
+            // Measure the impulse only over the (shorter) impulse window,
+            // anchored on the latest touch; the entry is kept alive past it
+            // purely so a late-replicating dodge byte can still confirm the
+            // launch touch. Gravity compensation spans from the episode's
+            // measurement anchor, which precedes the touch when this pending
+            // inherited an earlier same-episode window.
             if elapsed <= FLICK_IMPULSE_WINDOW_SECONDS {
                 if let Some(velocity) = current_velocity {
-                    let impulse =
-                        Self::gravity_compensated_impulse(velocity, flick.pre_velocity, elapsed);
+                    let measure_elapsed = (frame.time - flick.measure_start_time).max(0.0);
+                    let impulse = Self::gravity_compensated_impulse(
+                        velocity,
+                        flick.pre_velocity,
+                        measure_elapsed,
+                    );
                     let magnitude = impulse.length();
                     if magnitude > flick.peak_magnitude {
                         flick.peak_magnitude = magnitude;

--- a/src/stats/calculators/touch_state.rs
+++ b/src/stats/calculators/touch_state.rs
@@ -21,6 +21,15 @@ enum TouchCooldownKey {
     Team(bool),
 }
 
+/// Last rate-limit-accepted touch for a cooldown key: its time plus whether it
+/// carried dodge evidence, so a dodge-powered touch can bypass the rate limit
+/// imposed by an earlier passive contact.
+#[derive(Debug, Clone, Copy)]
+struct LastCooldownTouch {
+    time: f32,
+    dodge_contact: bool,
+}
+
 const TOUCH_SCORING: TouchCandidateScoring = TouchCandidateScoring::DEFAULT;
 const TOUCH_CANDIDATE_WINDOW_FRAMES: usize = 4;
 const CONTESTED_TOUCH_WINDOW_FRAMES: usize = 1;
@@ -158,7 +167,7 @@ pub struct TouchStateCalculator {
     previous_ball_rigid_body: Option<(boxcars::RigidBody, f32)>,
     current_last_touch: Option<TouchEvent>,
     recent_touch_candidates: HashMap<PlayerId, TouchEvent>,
-    last_touch_times: HashMap<TouchCooldownKey, f32>,
+    last_touch_times: HashMap<TouchCooldownKey, LastCooldownTouch>,
     recent_team_touches: Vec<RecentTeamTouch>,
     next_touch_id: u64,
 }
@@ -761,11 +770,24 @@ impl TouchStateCalculator {
         const FLOAT_EPSILON: f32 = 0.0001;
 
         let key = Self::touch_cooldown_key(event);
-        let allowed = self.last_touch_times.get(&key).is_none_or(|last_time| {
-            event.time - last_time + FLOAT_EPSILON >= TOUCH_RATE_LIMIT_SECONDS
+        let allowed = self.last_touch_times.get(&key).is_none_or(|last| {
+            // The rate limit dedupes repeat samples of one continuous contact
+            // (a carry or dribble). A dodge-powered touch arriving on the heels
+            // of a passive contact is a distinct mechanic (flip-reset
+            // conversion, flick), not another sample of the same contact, so it
+            // bypasses the limit. Repeated dodge touches still rate-limit
+            // against each other.
+            (event.dodge_contact && !last.dodge_contact)
+                || event.time - last.time + FLOAT_EPSILON >= TOUCH_RATE_LIMIT_SECONDS
         });
         if allowed {
-            self.last_touch_times.insert(key, event.time);
+            self.last_touch_times.insert(
+                key,
+                LastCooldownTouch {
+                    time: event.time,
+                    dodge_contact: event.dodge_contact,
+                },
+            );
         }
         allowed
     }

--- a/src/stats/calculators/touch_state_tests.rs
+++ b/src/stats/calculators/touch_state_tests.rs
@@ -204,6 +204,65 @@ fn suppresses_same_player_touch_candidates_inside_cooldown() {
 }
 
 #[test]
+fn dodge_touch_bypasses_passive_contact_cooldown() {
+    let player_id = boxcars::RemoteId::Steam(1);
+    let passive_players = players(player_id.clone());
+    let mut dodging_sample = passive_players.players[0].clone();
+    dodging_sample.dodge_active = true;
+    let dodging_players = PlayerFrameState {
+        players: vec![dodging_sample],
+    };
+    let mut calculator = TouchStateCalculator::new();
+    let live_play = LivePlayState {
+        gameplay_phase: GameplayPhase::ActivePlay,
+        is_live_play: true,
+    };
+
+    calculator.update(
+        &frame(0),
+        &ball(glam::Vec3::ZERO),
+        &passive_players,
+        &FrameEventsState::default(),
+        &live_play,
+    );
+    // A passive contact touch starts the per-player cooldown window.
+    let passive_touch = calculator.update(
+        &frame(1),
+        &ball(glam::Vec3::new(300.0, 0.0, 0.0)),
+        &passive_players,
+        &FrameEventsState::default(),
+        &live_play,
+    );
+    // A dodge-powered touch inside the window is a distinct mechanic (flick,
+    // flip-reset conversion) and must not be swallowed by the passive contact.
+    let dodge_touch = calculator.update(
+        &frame(2),
+        &ball(glam::Vec3::new(650.0, 0.0, 0.0)),
+        &dodging_players,
+        &FrameEventsState::default(),
+        &live_play,
+    );
+    // Repeated dodge-contact samples still rate-limit against each other.
+    let repeat_dodge_touch = calculator.update(
+        &frame(3),
+        &ball(glam::Vec3::new(1000.0, 0.0, 0.0)),
+        &dodging_players,
+        &FrameEventsState::default(),
+        &live_play,
+    );
+
+    assert_eq!(passive_touch.touch_events.len(), 1);
+    assert!(!passive_touch.touch_events[0].dodge_contact);
+
+    assert_eq!(dodge_touch.touch_events.len(), 1);
+    assert!(dodge_touch.touch_events[0].dodge_contact);
+    assert_eq!(dodge_touch.touch_events[0].frame, 2);
+
+    assert!(repeat_dodge_touch.touch_events.is_empty());
+    assert_eq!(repeat_dodge_touch.last_touch_player, Some(player_id));
+}
+
+#[test]
 fn detects_touch_while_kickoff_waits_for_first_touch() {
     let player_id = boxcars::RemoteId::Steam(1);
     let players = players(player_id.clone());


### PR DESCRIPTION
## Problem

Since low-impulse contacts became detectable (7ebc203f), the soft first contact of a carry/flip-reset episode registers as a touch and starts the per-player touch rate limit (0.25s). The dodge-powered launch touch ~0.1–0.23s later was then silently swallowed, which regressed several consumers that key on that touch:

- **Flip reset confirmation**: with no touch at/after the reset, the reset resolved `used=false` and `FlipResetGoal` was lost (re-breaking 565c6cc0/fad2f654). Reproduced on rocket-sense replay `019f21df-eaf9-73e2-84b3-37a8d1cfa6d8` goal 2: reset at 112.656 with a 0.046s conversion showed `outcome=GoalScored, used=false` on master.
- **Air dribble runs**: the missing dodge touch dropped the run below the ≥3-touch gate, losing `AirDribbleGoal` on the same goal.
- **Flick anchoring**: see second commit.

## Fix

A touch carrying dodge evidence bypasses the rate limit when the previous accepted touch was passive. The rate limiter's job is deduping repeat samples of one continuous contact; a dodge is a discrete input and a distinct mechanic. Repeated dodge touches still rate-limit against each other.

With both touches present, a dodge touch superseding a still-live pending flick reset the impulse measurement window and measured only the launch tail, flattening the launch geometry (calemacar middle flick misclassified side→reverse). A superseding same-episode pending now inherits the measurement anchor (pre-touch ball velocity + accumulated peak), with gravity compensation spanning from that anchor.

## Verification

- `cargo test --lib --tests`: 944 passed, 0 failed (includes clip_flip_reset, clip_flick, reverse_flick, clip_air_dribble, clip_speed_flip ground-truth suites).
- New unit test `dodge_touch_bypasses_passive_contact_cooldown`.
- `flip_reset_goal_audit` on the reporting replay: goal 2 regains `FlipResetGoal` + `AirDribbleGoal`; reset shows `used=true, time_to_use=0.046` matching pre-regression behavior; all other goals/resets unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)