### PR TITLE
Make team control cover summed player possession

### DIFF
--- a/js/stat-evaluation-player/src/generated/PlayerPossessionEvent.ts
+++ b/js/stat-evaluation-player/src/generated/PlayerPossessionEvent.ts
@@ -10,7 +10,10 @@ import type { RemoteIdTs } from "./RemoteIdTs.ts";
 export type PlayerPossessionEvent = { player_id: RemoteIdTs, is_team_0: boolean, start_frame: number, end_frame: number, start_time: number, end_time: number,
 /**
  * Seconds the player actually held possession. Excludes contested gap
- * time inside a merged span, so it can be less than `end_time - start_time`.
+ * time inside a merged span and the loose tail after the player's final
+ * touch (once the ball is hit away, the remaining flight time is nobody's
+ * possession — mirroring how team possession backdates a loss to the last
+ * touch), so it can be less than `end_time - start_time`.
  */
 duration: number, touch_count: number, aerial_touch_count: number, wall_touch_count: number,
 /**

--- a/src/stats/analysis_graph/mod.rs
+++ b/src/stats/analysis_graph/mod.rs
@@ -270,3 +270,7 @@ pub fn graph_with_all_analysis_nodes() -> AnalysisGraph {
 #[cfg(test)]
 #[path = "module_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "possession_invariant_tests.rs"]
+mod possession_invariant_tests;

--- a/src/stats/analysis_graph/possession_invariant_tests.rs
+++ b/src/stats/analysis_graph/possession_invariant_tests.rs
@@ -1,0 +1,73 @@
+use super::*;
+use crate::{PlayerPossessionCalculator, PossessionCalculator};
+use std::path::Path;
+
+fn parse_replay(path: &str) -> boxcars::Replay {
+    let replay_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
+    let data = std::fs::read(&replay_path)
+        .unwrap_or_else(|_| panic!("Failed to read replay file: {}", replay_path.display()));
+    boxcars::ParserBuilder::new(&data[..])
+        .always_check_crc()
+        .must_parse_network_data()
+        .parse()
+        .unwrap_or_else(|_| panic!("Failed to parse replay: {}", replay_path.display()))
+}
+
+/// Team control (the strict `possession` stream) must cover at least the summed
+/// per-player possession of its players: a player can only possess the ball
+/// while their team controls it. This broke when the strict resolver's window
+/// was tighter than the eager tracker's loose-ball timeout (holds with touches
+/// 1.5–3s apart earned zero team credit) and when player spans credited loose
+/// tails after the final touch that the resolver sent to neutral.
+#[test]
+#[ignore = "real-replay sweep is slow; run explicitly when changing possession resolution"]
+fn team_control_covers_summed_player_possession_on_real_replays() {
+    let fixtures = [
+        "assets/post-eac-ranked-duel-2026-04-28-a.replay",
+        "assets/post-eac-ranked-duel-2026-04-28-b.replay",
+        "assets/post-eac-ranked-doubles-2026-04-28.replay",
+        "assets/post-eac-ranked-standard-2026-04-28.replay",
+        "assets/recent-ranked-doubles-2026-03-10.replay",
+        "assets/recent-ranked-standard-2026-03-10-a.replay",
+        "assets/recent-ranked-standard-2026-03-10-b.replay",
+        "assets/rlcs-2025-worlds-grand-final-flcn-nrg-g5.replay",
+    ];
+    for fixture in fixtures {
+        let replay = parse_replay(fixture);
+        let graph = collect_analysis_graph_for_replay(&replay, graph_with_all_analysis_nodes())
+            .expect("graph should evaluate");
+        let possession = graph
+            .state::<PossessionCalculator>()
+            .expect("possession state");
+        let player_possession = graph
+            .state::<PlayerPossessionCalculator>()
+            .expect("player possession state");
+
+        let mut team = [0.0f64; 2];
+        for event in possession.events() {
+            match (event.active, event.possession_state.as_str()) {
+                (true, "team_zero") => team[0] += event.duration as f64,
+                (true, "team_one") => team[1] += event.duration as f64,
+                _ => {}
+            }
+        }
+        let mut players = [0.0f64; 2];
+        for event in player_possession.events() {
+            players[if event.is_team_0 { 0 } else { 1 }] += event.duration as f64;
+        }
+        println!(
+            "{fixture}: control team0={:.1}s team1={:.1}s, player sums team0={:.1}s team1={:.1}s",
+            team[0], team[1], players[0], players[1]
+        );
+        for side in 0..2 {
+            // Small tolerance: player spans open one frame before their first
+            // touch (crediting that frame's dt), which the resolver does not.
+            assert!(
+                players[side] <= team[side] + 1.0,
+                "{fixture}: team{side} control {:.1}s < summed player possession {:.1}s",
+                team[side],
+                players[side],
+            );
+        }
+    }
+}

--- a/src/stats/calculators/loose_possession.rs
+++ b/src/stats/calculators/loose_possession.rs
@@ -2,9 +2,11 @@ use super::possession::{OpenPossession, PossessionLabel, ResolvedPossession};
 use super::*;
 
 /// How long the loose resolver waits for a follow-up touch before deciding a
-/// contested ball's fate. Mirrors the strict resolver's window, but the loose
-/// resolver keeps crediting the last team to touch through loose balls instead
-/// of letting them lapse to neutral.
+/// contested ball's fate. Unlike the strict resolver's window (which also
+/// bounds touch spacing within a hold, so it matches the loose-ball timeout),
+/// this only governs how long an opponent's unconfirmed challenge touch stays
+/// pending: the loose resolver keeps crediting the last team to touch through
+/// loose balls instead of letting them lapse to neutral.
 const LOOSE_RESOLUTION_WINDOW_SECONDS: f32 = 1.5;
 
 /// A team-possession span under the *loose* definition: the team that last

--- a/src/stats/calculators/player_possession.rs
+++ b/src/stats/calculators/player_possession.rs
@@ -37,7 +37,10 @@ pub struct PlayerPossessionEvent {
     pub start_time: f32,
     pub end_time: f32,
     /// Seconds the player actually held possession. Excludes contested gap
-    /// time inside a merged span, so it can be less than `end_time - start_time`.
+    /// time inside a merged span and the loose tail after the player's final
+    /// touch (once the ball is hit away, the remaining flight time is nobody's
+    /// possession — mirroring how team possession backdates a loss to the last
+    /// touch), so it can be less than `end_time - start_time`.
     pub duration: f32,
     pub touch_count: u32,
     pub aerial_touch_count: u32,
@@ -64,6 +67,20 @@ pub struct PlayerPossessionEvent {
     pub end_field_third: Option<String>,
 }
 
+/// The per-frame accumulators that only count while the ball is possessed.
+/// The running copy accrues every active frame; a snapshot is taken at each
+/// ball contact, and the snapshot is what the emitted event reports, so the
+/// provisional loose tail after the final touch is never credited.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+struct PossessedTotals {
+    duration: f32,
+    close_time: f32,
+    advance_distance: f32,
+    retreat_distance: f32,
+    carry_time: f32,
+    air_dribble_time: f32,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 struct ActivePlayerPossession {
     player_id: PlayerId,
@@ -72,17 +89,14 @@ struct ActivePlayerPossession {
     end_frame: usize,
     start_time: f32,
     end_time: f32,
-    duration: f32,
+    running: PossessedTotals,
+    /// [`Self::running`] as of the player's most recent ball contact.
+    at_last_touch: PossessedTotals,
     touch_count: u32,
     aerial_touch_count: u32,
     wall_touch_count: u32,
     first_touch_time: Option<f32>,
     last_touch_time: Option<f32>,
-    close_time: f32,
-    advance_distance: f32,
-    retreat_distance: f32,
-    carry_time: f32,
-    air_dribble_time: f32,
     carry_count: u32,
     air_dribble_count: u32,
     last_carry_kind: Option<BallCarryKind>,
@@ -107,17 +121,13 @@ impl ActivePlayerPossession {
             end_frame: frame.frame_number,
             start_time: (frame.time - frame.dt).max(0.0),
             end_time: frame.time,
-            duration: 0.0,
+            running: PossessedTotals::default(),
+            at_last_touch: PossessedTotals::default(),
             touch_count: 0,
             aerial_touch_count: 0,
             wall_touch_count: 0,
             first_touch_time: None,
             last_touch_time: None,
-            close_time: 0.0,
-            advance_distance: 0.0,
-            retreat_distance: 0.0,
-            carry_time: 0.0,
-            air_dribble_time: 0.0,
             carry_count: 0,
             air_dribble_count: 0,
             last_carry_kind: None,
@@ -127,7 +137,7 @@ impl ActivePlayerPossession {
     }
 
     fn record_frame(&mut self, frame: &FrameInfo, field_third: Option<String>) {
-        self.duration += frame.dt.max(0.0);
+        self.running.duration += frame.dt.max(0.0);
         self.end_frame = frame.frame_number;
         self.end_time = frame.time;
         if field_third.is_some() {
@@ -136,6 +146,9 @@ impl ActivePlayerPossession {
     }
 
     fn record_touch(&mut self, touch: &TouchEvent) {
+        // Any contact — even one too close to the previous touch to count as
+        // distinct — extends the possessed totals to this frame.
+        self.at_last_touch = self.running;
         if self
             .last_touch_time
             .is_some_and(|last| touch.time - last < DISTINCT_TOUCH_GAP_SECONDS)
@@ -161,9 +174,9 @@ impl ActivePlayerPossession {
         let team_forward_sign = if self.is_team_0 { 1.0 } else { -1.0 };
         let advance = (ball_y - previous_ball_y) * team_forward_sign;
         if advance >= 0.0 {
-            self.advance_distance += advance;
+            self.running.advance_distance += advance;
         } else {
-            self.retreat_distance -= advance;
+            self.running.retreat_distance -= advance;
         }
     }
 
@@ -183,7 +196,7 @@ impl ActivePlayerPossession {
                 player_position.distance(ball_position) <= controlled_play::CLOSE_DISTANCE_3D
             });
         if close {
-            self.close_time += frame.dt.max(0.0);
+            self.running.close_time += frame.dt.max(0.0);
         }
     }
 
@@ -195,12 +208,13 @@ impl ActivePlayerPossession {
     }
 
     /// Controlled play's qualifying criteria, applied to this span. Kept in
-    /// lockstep via the shared constants in `controlled_play`.
+    /// lockstep via the shared constants in `controlled_play`, and judged on
+    /// the same possessed totals the emitted event reports.
     fn is_sustained_control(&self) -> bool {
         self.touch_count >= controlled_play::MIN_TOUCHES
-            && self.duration >= controlled_play::MIN_EPISODE_DURATION_SECONDS
+            && self.at_last_touch.duration >= controlled_play::MIN_EPISODE_DURATION_SECONDS
             && self.touch_span() >= controlled_play::MIN_FIRST_TO_LAST_TOUCH_DURATION_SECONDS
-            && self.close_time >= controlled_play::MIN_CLOSE_DURATION_SECONDS
+            && self.at_last_touch.close_time >= controlled_play::MIN_CLOSE_DURATION_SECONDS
     }
 
     fn record_carry_sample(&mut self, frame: &FrameInfo, kind: Option<BallCarryKind>) {
@@ -212,8 +226,8 @@ impl ActivePlayerPossession {
                 }
             }
             match kind {
-                BallCarryKind::Carry => self.carry_time += frame.dt.max(0.0),
-                BallCarryKind::AirDribble => self.air_dribble_time += frame.dt.max(0.0),
+                BallCarryKind::Carry => self.running.carry_time += frame.dt.max(0.0),
+                BallCarryKind::AirDribble => self.running.air_dribble_time += frame.dt.max(0.0),
             }
         }
         self.last_carry_kind = kind;
@@ -228,17 +242,17 @@ impl ActivePlayerPossession {
             end_frame: self.end_frame,
             start_time: self.start_time,
             end_time: self.end_time,
-            duration: self.duration,
+            duration: self.at_last_touch.duration,
             touch_count: self.touch_count,
             aerial_touch_count: self.aerial_touch_count,
             wall_touch_count: self.wall_touch_count,
-            advance_distance: self.advance_distance,
-            retreat_distance: self.retreat_distance,
-            carry_time: self.carry_time,
-            air_dribble_time: self.air_dribble_time,
+            advance_distance: self.at_last_touch.advance_distance,
+            retreat_distance: self.at_last_touch.retreat_distance,
+            carry_time: self.at_last_touch.carry_time,
+            air_dribble_time: self.at_last_touch.air_dribble_time,
             carry_count: self.carry_count,
             air_dribble_count: self.air_dribble_count,
-            close_time: self.close_time,
+            close_time: self.at_last_touch.close_time,
             sustained_control,
             start_field_third: self.start_field_third,
             end_field_third: self.end_field_third,
@@ -381,6 +395,10 @@ impl PlayerPossessionCalculator {
                     self.finalize(active);
                 } else {
                     active.last_carry_kind = None;
+                    // The loose tail since the last touch was provisional; the
+                    // hold lapsed, so it is not possession even if the same
+                    // player re-establishes control and the span resumes.
+                    active.running = active.at_last_touch;
                     self.suspended = Some((active, frame.time));
                 }
             }
@@ -422,13 +440,15 @@ impl PlayerPossessionCalculator {
         if let (Some(previous_ball_y), Some(ball_y)) = (self.previous_ball_y, ball_y) {
             active.record_ball_movement(previous_ball_y, ball_y);
         }
+        let carry_kind = Self::carry_sample_kind(&active.player_id, ball, players);
+        active.record_carry_sample(frame, carry_kind);
+        // Touches last: a touch snapshots the running possessed totals, which
+        // must already include this frame's samples.
         for touch in touch_state.touch_events.iter() {
             if touch.player.as_ref() == Some(&active.player_id) {
                 active.record_touch(touch);
             }
         }
-        let carry_kind = Self::carry_sample_kind(&active.player_id, ball, players);
-        active.record_carry_sample(frame, carry_kind);
         self.previous_ball_y = ball_y;
 
         Ok(())

--- a/src/stats/calculators/player_possession_tests.rs
+++ b/src/stats/calculators/player_possession_tests.rs
@@ -168,9 +168,12 @@ fn emits_single_enriched_span_for_continuous_possession() {
     assert_eq!(event.touch_count, 2);
     assert_eq!(event.aerial_touch_count, 0);
     assert_eq!(event.wall_touch_count, 0);
-    assert!((event.duration - 8.0 * DT).abs() < 1e-4);
-    // 7 inter-frame deltas of 100 uu each land inside the span.
-    assert!((event.advance_distance - 700.0).abs() < 1.0);
+    // Possessed duration is credited only up to the final touch (step 4);
+    // the touchless tail through step 7 is not possession.
+    assert!((event.duration - 5.0 * DT).abs() < 1e-4);
+    // 4 inter-frame deltas of 100 uu each land before the final touch; the
+    // drift after it is not credited.
+    assert!((event.advance_distance - 400.0).abs() < 1.0);
     assert_eq!(event.retreat_distance, 0.0);
     assert_eq!(event.carry_time, 0.0);
 }
@@ -244,8 +247,12 @@ fn merges_spans_across_a_short_neutral_gap() {
     let events = calculator.events();
     assert_eq!(events.len(), 1);
     let event = &events[0];
-    // The contested gap is excluded from possessed duration.
-    assert!((event.duration - 8.0 * DT).abs() < 1e-4);
+    // Possessed duration credits touch-to-touch time only: the provisional
+    // tail of the first stretch (after its lone touch at step 0) is rolled
+    // back when the span suspends, the contested gap is excluded, and the
+    // touchless tail after the final touch at step 8 is never credited. That
+    // leaves just the two touch frames.
+    assert!((event.duration - 2.0 * DT).abs() < 1e-4);
     assert_eq!(event.start_frame, 0);
     assert_eq!(event.end_frame, 11);
 }
@@ -419,7 +426,8 @@ fn accumulates_carry_time_when_ball_rides_the_player() {
     let events = calculator.events();
     assert_eq!(events.len(), 1);
     let event = &events[0];
-    assert!((event.carry_time - 8.0 * DT).abs() < 1e-4);
+    // Carry time is credited up to the final touch (step 4), like duration.
+    assert!((event.carry_time - 5.0 * DT).abs() < 1e-4);
     assert_eq!(event.carry_count, 1);
     assert_eq!(event.air_dribble_time, 0.0);
 }
@@ -540,9 +548,10 @@ fn ball_drifting_far_ends_the_span_without_crediting_the_drift() {
     assert_eq!(events.len(), 1);
     let event = &events[0];
     assert_eq!(event.touch_count, 2);
-    // Only the near frames (0..=3) are credited; the drift is excluded.
+    // The span's window ends where the drift starts, and possessed duration
+    // ends at the final touch (step 2).
     assert_eq!(event.end_frame, 3);
-    assert!((event.duration - 4.0 * DT).abs() < 1e-4);
+    assert!((event.duration - 3.0 * DT).abs() < 1e-4);
 }
 
 #[test]

--- a/src/stats/calculators/possession.rs
+++ b/src/stats/calculators/possession.rs
@@ -8,11 +8,16 @@ const LOOSE_BALL_TIMEOUT_SECONDS: f32 = 3.0;
 /// last touch; the loose time after that touch stays provisional until either
 /// the same owner re-touches (kept), the opponent confirms a turnover (the gap
 /// goes neutral and the opponent is credited from their first touch), or this
-/// window elapses with no follow-up (the gap goes neutral). It unifies the old
-/// pending-turnover (1.25s) and loose-ball (3.0s) windows: with loss backdated
-/// to the last touch, the distinction no longer changes anyone's credited time,
-/// so a single resolution deadline suffices.
-const POSSESSION_RESOLUTION_WINDOW_SECONDS: f32 = 1.5;
+/// window elapses with no follow-up (the gap goes neutral).
+///
+/// This must match the per-player loose-ball timeout
+/// ([`LOOSE_BALL_TIMEOUT_SECONDS`], which drives the eager tracker behind
+/// per-player possession spans): both answer "how far apart may touches be
+/// before the hold is broken?". When this window was shorter (1.5s), a hold
+/// whose touches came 1.5–3s apart stayed continuous for the player stream but
+/// oscillated Acquiring→Neutral here — earning zero team-control credit — so
+/// summed player possession routinely exceeded team control.
+const POSSESSION_RESOLUTION_WINDOW_SECONDS: f32 = LOOSE_BALL_TIMEOUT_SECONDS;
 
 /// A team-or-neutral label for a resolved possession segment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/stats/calculators/possession_tests.rs
+++ b/src/stats/calculators/possession_tests.rs
@@ -90,10 +90,25 @@ fn brief_control_with_no_follow_up_is_backdated_to_last_touch() {
     let mut sim = ResolverSim::new();
     sim.step(10, 1.0, &[touch(10, 1.0, p(1), true)]);
     sim.step(13, 1.3, &[touch(13, 1.3, p(1), true)]); // confirm
-    sim.step(90, 3.0, &[]); // 1.7s with no touch → loss, backdated to 1.3
-    sim.finish(120, 4.0);
+    sim.step(140, 4.7, &[]); // 3.4s with no touch → loss, backdated to 1.3
+    sim.finish(180, 6.0);
 
     assert_eq!(sim.team_segments(), vec![(true, 1.0, 1.3)]);
+}
+
+#[test]
+fn sparse_dribble_touches_within_loose_timeout_stay_one_continuous_hold() {
+    // Touches 2.5s apart — farther than the old 1.5s window but within the
+    // loose-ball timeout — must confirm and sustain a single hold, matching
+    // the eager tracker that drives per-player possession. Otherwise summed
+    // player possession exceeds team control.
+    let mut sim = ResolverSim::new();
+    sim.step(30, 1.0, &[touch(30, 1.0, p(1), true)]);
+    sim.step(105, 3.5, &[touch(105, 3.5, p(1), true)]); // confirm at 2.5s spacing
+    sim.step(180, 6.0, &[touch(180, 6.0, p(1), true)]); // extend at 2.5s spacing
+    sim.finish(300, 10.0);
+
+    assert_eq!(sim.team_segments(), vec![(true, 1.0, 6.0)]);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

The strict team-possession stream ("Team control" in the rocket-sense UI) routinely summed to **less** than the individual player-possession stat — in one real duel fixture a team was credited 2.3s of control for a full game while its lone player showed 22.1s of individual possession, with ~90% of live time landing in neutral.

## Causes

1. **Resolver window (1.5s) was tighter than the eager tracker's loose-ball timeout (3.0s).** Both answer "how far apart may touches be before the hold breaks?", but they disagreed: a hold whose touches came 1.5–3s apart stayed continuous for the per-player stream while the strict resolver oscillated `Acquiring → Neutral` and credited the team nothing. `POSSESSION_RESOLUTION_WINDOW_SECONDS` now equals `LOOSE_BALL_TIMEOUT_SECONDS`.

2. **Player spans credited the provisional loose tail after the final touch** (up to the 3s timeout), and even retro-credited it across suspend/resume merges — while the resolver backdates a loss to the last touch. Possessed totals (duration, close/carry/air-dribble time, advance/retreat distance) are now snapshotted at each ball contact (`PossessedTotals` running/at-last-touch), the snapshot is what the emitted event reports, and the running copy rolls back when a hold lapses into suspension. `sustained_control` is judged on the same reported totals.

## Result

Establishes the invariant **individual possession ⊆ team control (strict) ⊆ team possession (loose)**. A new ignored regression test (`team_control_covers_summed_player_possession_on_real_replays`) verifies per-team coverage on eight real replay fixtures; before the fix team control credited 10–50% of summed player possession, after it covers 100%+ in every mode (2v2/3v3 exceed player sums, as passing chains count for the team but no single player).

Note for consumers: individual possession durations drop noticeably (~40–60% on the fixtures) since loose tails no longer count — downstream materialized stats need reprocessing after a bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)