### PR TITLE
Fill 'derive stats snapshots' load phase incrementally

### DIFF
--- a/js/stat-evaluation-player/src/replayLoader.ts
+++ b/js/stat-evaluation-player/src/replayLoader.ts
@@ -199,7 +199,10 @@ export async function loadReplayBundleInWorker(
           message.statsTimelineParts,
           options.onProgress,
         );
-        const statsFrameLookup = createStatsFrameLookup(statsTimeline);
+        const statsFrameLookup = createStatsFrameLookup(statsTimeline, options.onProgress);
+        while (statsFrameLookup.materializeNextChunk()) {
+          await waitForNextPaint();
+        }
         resolve({
           replay,
           raw,

--- a/js/stat-evaluation-player/src/statsTimeline.test.ts
+++ b/js/stat-evaluation-player/src/statsTimeline.test.ts
@@ -122,6 +122,42 @@ test("stats frame lookup materializes compact scaffold frames from events", () =
   assert.equal(frameOne?.players[1]?.demo.demos_taken, 1);
 });
 
+test("non-compact stats frame lookup reports immediate deriving-stats completion", () => {
+  const player = { Steam: "player-a" };
+  const statsTimeline: StatsTimeline = createStatsTimeline({
+    frames: [
+      {
+        frame_number: 0,
+        time: 0,
+        dt: 0,
+        players: [{ player_id: player, name: "A", is_team_0: true }],
+      },
+      {
+        frame_number: 1,
+        time: 1,
+        dt: 1,
+        players: [{ player_id: player, name: "A", is_team_0: true }],
+      },
+    ],
+  });
+
+  assert.equal(isCompactStatsTimeline(statsTimeline), false);
+  const progress: import("./replayLoadProgress.ts").ReplayLoadProgress[] = [];
+  const lookup = createStatsFrameLookup(statsTimeline, (entry) => {
+    progress.push(entry);
+  });
+
+  assert.equal(lookup.materializeNextChunk(), false);
+  assert.deepEqual(progress, [
+    { stage: "deriving-stats", processedFrames: 2, totalFrames: 2, progress: 1 },
+  ]);
+  // Idempotent: a second drive step does not emit again.
+  assert.equal(lookup.materializeNextChunk(), false);
+  assert.equal(progress.length, 1);
+  // Lazy get() still works after driving.
+  assert.equal(getStatsFrameForReplayFrame(lookup, 1)?.frame_number, 1);
+});
+
 test("stats frame lookup rejects mixed compact and materialized frame payloads", () => {
   const player = { Steam: "player-a" };
   const statsTimeline: StatsTimeline = createStatsTimeline({

--- a/js/stat-evaluation-player/src/statsTimeline.ts
+++ b/js/stat-evaluation-player/src/statsTimeline.ts
@@ -87,6 +87,16 @@ export type ShadowDefenseEvent = PlayerStateSpan<ShadowDefenseState>;
 export type RotationRoleEvent = PlayerStateSpan<RoleState>;
 export interface StatsFrameLookup {
   get(frameNumber: number): StatsFrame | undefined;
+  /**
+   * Eagerly materialize the next chunk of stats frames, reusing the same
+   * chunking/accumulator state as lazy {@link StatsFrameLookup.get} access.
+   * Returns `true` while more frames remain to be materialized and `false`
+   * once every frame has been materialized. Callers can drive this in a loop
+   * (yielding to the event loop between chunks) to fill a progress bar with
+   * real incremental progress during load without deferring the work to
+   * playback.
+   */
+  materializeNextChunk(): boolean;
 }
 export type {
   CeilingShotEvent,
@@ -230,7 +240,31 @@ export function createStatsFrameLookup(
       "stats timeline frames must be either all compact scaffolds or all materialized snapshots",
     );
   }
-  return createMaterializedStatsFrameLookup(statsTimeline as MaterializedStatsTimeline);
+  const materializedFrames = createMaterializedStatsFrameLookup(
+    statsTimeline as MaterializedStatsTimeline,
+  );
+  // Non-compact timelines are already fully materialized, so there is no
+  // incremental work to drive. Report immediate completion so the eager-drive
+  // loop in the loader finishes in a single step.
+  let reportedComplete = false;
+  return {
+    get(frameNumber: number) {
+      return materializedFrames.get(frameNumber);
+    },
+    materializeNextChunk() {
+      if (reportedComplete) {
+        return false;
+      }
+      reportedComplete = true;
+      onProgress?.({
+        stage: "deriving-stats",
+        processedFrames: statsTimeline.frames.length,
+        totalFrames: statsTimeline.frames.length,
+        progress: 1,
+      });
+      return false;
+    },
+  };
 }
 
 export function getStatsFrameForReplayFrame(

--- a/js/stat-evaluation-player/src/statsTimelineDerivation.test.ts
+++ b/js/stat-evaluation-player/src/statsTimelineDerivation.test.ts
@@ -60,6 +60,60 @@ test("event-derived stats frame lookup does not clone scaffold payloads before f
   assert.doesNotThrow(() => createEventDerivedStatsFrameLookup(timeline));
 });
 
+test("event-derived stats frame lookup drives materialization to completion via materializeNextChunk", () => {
+  const timeline = createStatsTimeline({
+    frames: Array.from({ length: 10 }, (_, index) => ({
+      frame_number: index * 10,
+      time: index,
+      dt: 0.1,
+      players: [],
+    })),
+  });
+  const progress: ReplayLoadProgress[] = [];
+
+  const lookup = createEventDerivedStatsFrameLookup(
+    timeline,
+    (entry) => {
+      progress.push(entry);
+    },
+    { materializationChunkSize: 3 },
+  );
+
+  let chunkCount = 0;
+  while (lookup.materializeNextChunk()) {
+    chunkCount += 1;
+    assert.ok(chunkCount < 100, "materializeNextChunk should terminate");
+  }
+
+  const derivingProgress = progress.filter((entry) => entry.stage === "deriving-stats");
+  assert.ok(derivingProgress.length > 1, "should emit incremental deriving-stats progress");
+  const finalProgress = derivingProgress[derivingProgress.length - 1]!;
+  assert.equal(finalProgress.progress, 1);
+  assert.equal(finalProgress.processedFrames, 10);
+  assert.equal(finalProgress.totalFrames, 10);
+
+  // Every frame is now a cache hit and get() does not emit further progress.
+  const progressCount = progress.length;
+  for (let index = 0; index < 10; index += 1) {
+    assert.equal(lookup.get(index * 10)?.frame_number, index * 10);
+  }
+  assert.equal(progress.length, progressCount);
+});
+
+test("event-derived stats frame lookup completes immediately at progress 1 for zero frames", () => {
+  const timeline = createStatsTimeline({ frames: [] });
+  const progress: ReplayLoadProgress[] = [];
+
+  const lookup = createEventDerivedStatsFrameLookup(timeline, (entry) => {
+    progress.push(entry);
+  });
+
+  assert.equal(lookup.materializeNextChunk(), false);
+  assert.deepEqual(progress, [
+    { stage: "deriving-stats", processedFrames: 0, totalFrames: 0, progress: 1 },
+  ]);
+});
+
 test("event-derived stats frame lookup expands later materialization chunks", () => {
   const timeline = createStatsTimeline({
     frames: Array.from({ length: 20 }, (_, index) => ({

--- a/js/stat-evaluation-player/src/statsTimelineDerivation.ts
+++ b/js/stat-evaluation-player/src/statsTimelineDerivation.ts
@@ -462,6 +462,21 @@ export function createEventDerivedStatsFrameLookup(
       materializeUntilIndex(frameIndex);
       return materializedFrames.get(frameNumber);
     },
+    materializeNextChunk() {
+      if (materializedUntilIndex >= scaffoldFrames.length - 1) {
+        if (scaffoldFrames.length === 0) {
+          onProgress?.({
+            stage: "deriving-stats",
+            processedFrames: 0,
+            totalFrames: 0,
+            progress: 1,
+          });
+        }
+        return false;
+      }
+      materializeUntilIndex(materializedUntilIndex + 1);
+      return materializedUntilIndex < scaffoldFrames.length - 1;
+    },
   };
 }
 


### PR DESCRIPTION
## Problem

The final replay-load phase — **"Derive stats snapshots"** (`deriving-stats` stage, progress range 0.96–1.0) — jumped straight from 96% to 100% instead of filling in.

The cause wasn't a measurement limitation; the *work* was deferred. The loader built the lazy `StatsFrameLookup` **without** an `onProgress` callback and never drove it, so stats-frame materialization was postponed to playback and the only `deriving-stats` progress events fired later, on demand, inside `get()`. Nothing was being computed during the load screen, so there was nothing to report on.

## Fix

Drive the materialization during load, in chunks, yielding to the event loop between them so every progress tick corresponds to real frames hydrated.

- `StatsFrameLookup` gains **`materializeNextChunk(): boolean`** — advances the existing chunked/growing materialization by one chunk, reusing the same accumulator state and the same progress emission as lazy `get()`; returns `false` once all frames are materialized.
- `loadReplayBundleInWorker` now passes `options.onProgress` into `createStatsFrameLookup` and drives it to completion:
  ```ts
  const statsFrameLookup = createStatsFrameLookup(statsTimeline, options.onProgress);
  while (statsFrameLookup.materializeNextChunk()) {
    await waitForNextPaint();
  }
  ```
  The bar now fills off real work, and the later lazy `get()` during playback is a pure cache hit.
- Non-compact (already-materialized) timelines report immediate completion; an empty timeline completes at `progress: 1` in a single step. `report.ts`'s lazy usage is unchanged.

## Tradeoff

This moves frame materialization into the load phase, so time-to-first-frame increases somewhat — that's the cost of the bar reflecting real progress. The zero-load-cost alternative (moving materialization into the worker thread) is a larger refactor left for later.

## Tests

- `statsTimelineDerivation.test.ts` / `statsTimeline.test.ts` — drive `materializeNextChunk` to completion, assert incremental `deriving-stats` progress reaches 1, `get()` afterward is a cache hit emitting no further progress, plus 0-frame and non-compact-branch coverage. 11/11 pass.
- `replayLoader.test.ts` — 10/10 pass.
- `tsc --noEmit` / `just check-style` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)