### PR TITLE
Prevent stale mechanic events from tagging goals

### DIFF
--- a/.github/workflows/bakkesmod-plugin.yml
+++ b/.github/workflows/bakkesmod-plugin.yml
@@ -22,6 +22,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Rust 1.97 miscompiles this crate's glob re-exports (rust-lang/rust#159038).
+  RUST_TOOLCHAIN: "1.96.1"
 
 jobs:
   build:
@@ -37,7 +39,9 @@ jobs:
           python bakkesmod/subtr-actor/verify-plugin-source.py
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Cache Rust build outputs
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_HTTP_MULTIPLEXING: "false"
   RUST_TOOLCHAIN: "1.97.0"
+  # Rust 1.97 miscompiles integration tests that exercise this crate's glob
+  # re-exports (rust-lang/rust#159038).
+  RUST_TEST_TOOLCHAIN: "1.96.1"
   RUN_FULL_REPLAY_TESTS: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.full_replay_tests) }}
 
 jobs:
@@ -76,8 +79,8 @@ jobs:
     - name: Install Rust
       shell: bash
       run: |
-        rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal --no-self-update
-        rustup default "$RUST_TOOLCHAIN"
+        rustup toolchain install "$RUST_TEST_TOOLCHAIN" --profile minimal --no-self-update
+        rustup default "$RUST_TEST_TOOLCHAIN"
 
     - name: Run Rust tests
       run: |
@@ -105,8 +108,8 @@ jobs:
     - name: Install Rust
       shell: bash
       run: |
-        rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal --no-self-update
-        rustup default "$RUST_TOOLCHAIN"
+        rustup toolchain install "$RUST_TEST_TOOLCHAIN" --profile minimal --no-self-update
+        rustup default "$RUST_TEST_TOOLCHAIN"
 
     - name: Run exhaustive Rust replay tests
       run: |

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,17 @@
           cargo = rustToolchain;
           rustc = rustToolchain;
         };
+        # Keep this in sync with .github/scripts/install-cargo-rdme.sh. Version
+        # 2.x requires a separate nightly toolchain to resolve intralinks.
+        cargoRdme = pkgs.rustPlatform.buildRustPackage rec {
+          pname = "cargo-rdme";
+          version = "1.5.0";
+          src = pkgs.fetchCrate {
+            inherit pname version;
+            hash = "sha256-TmV6Fc5vlc4fm9w4+iuxmnonwsEbqoJ3jvpIyQOuxjg=";
+          };
+          cargoHash = "sha256-EjIvKf1XgHubvyWPOAjysNH4nD0xqOWYg1FeiPSYh4c=";
+        };
         pythonBase = pkgs.callPackage pyproject-nix.build.packages {
           python = pkgs.python312;
         };
@@ -133,7 +144,7 @@
           pkgs.maturin
           pkgs.zlib
           rustToolchain
-          pkgs.cargo-rdme
+          cargoRdme
           pkgs.curl
           pkgs.leveldb
           pkgs.python312Packages.twine

--- a/src/stats/analysis_graph/nodes/goal_tags.rs
+++ b/src/stats/analysis_graph/nodes/goal_tags.rs
@@ -45,7 +45,14 @@ macro_rules! goal_tag_node {
 }
 
 macro_rules! mechanic_goal_tag_node {
-    ($node:ident, $calculator:ident, $name:literal, $dependency:ident, $dependency_type:ty) => {
+    (
+        $node:ident,
+        $calculator:ident,
+        $name:literal,
+        $dependency:ident,
+        $dependency_type:ty
+        $(, $extra_dependency:ident, $extra_dependency_type:ty)?
+    ) => {
         pub struct $node {
             calculator: $calculator,
         }
@@ -72,13 +79,18 @@ macro_rules! mechanic_goal_tag_node {
             }
 
             fn dependencies(&self) -> NodeDependencies {
-                vec![match_stats_dependency(), $dependency()]
+                vec![
+                    match_stats_dependency(),
+                    $dependency(),
+                    $($extra_dependency(),)?
+                ]
             }
 
             fn evaluate(&mut self, ctx: &AnalysisStateContext<'_>) -> SubtrActorResult<()> {
                 self.calculator.update(
                     ctx.get::<MatchStatsCalculator>()?,
                     ctx.get::<$dependency_type>()?,
+                    $(ctx.get::<$extra_dependency_type>()?,)?
                 )
             }
 
@@ -119,28 +131,36 @@ mechanic_goal_tag_node!(
     FlickGoalCalculator,
     "flick_goal",
     flick_dependency,
-    FlickCalculator
+    FlickCalculator,
+    touch_dependency,
+    TouchCalculator
 );
 mechanic_goal_tag_node!(
     CeilingShotGoalNode,
     CeilingShotGoalCalculator,
     "ceiling_shot_goal",
     ceiling_shot_dependency,
-    CeilingShotCalculator
+    CeilingShotCalculator,
+    touch_dependency,
+    TouchCalculator
 );
 mechanic_goal_tag_node!(
     DoubleTapGoalNode,
     DoubleTapGoalCalculator,
     "double_tap_goal",
     double_tap_dependency,
-    DoubleTapCalculator
+    DoubleTapCalculator,
+    touch_dependency,
+    TouchCalculator
 );
 mechanic_goal_tag_node!(
     OneTimerGoalNode,
     OneTimerGoalCalculator,
     "one_timer_goal",
     one_timer_dependency,
-    OneTimerCalculator
+    OneTimerCalculator,
+    touch_dependency,
+    TouchCalculator
 );
 mechanic_goal_tag_node!(
     PassingGoalNode,

--- a/src/stats/calculators/goal_tag_helpers.rs
+++ b/src/stats/calculators/goal_tag_helpers.rs
@@ -184,9 +184,11 @@ pub(super) fn tag_goals_by_recent_attacking_y(
 }
 
 /// Tags point mechanics only while the mechanic remains part of the scoring
-/// team's uninterrupted touch sequence. A later defending-team touch breaks
-/// the causal chain even when the mechanic still falls inside the calculator's
-/// wall-clock window.
+/// team's uninterrupted touch sequence through its final scoring touch. A
+/// defending-team touch before that final touch breaks the causal chain even
+/// when the mechanic still falls inside the calculator's wall-clock window.
+/// A save attempt after the final scoring touch does not erase the mechanic
+/// when the ball still crosses the goal line.
 pub(super) fn tag_goals_by_point_mechanic_event<E: GoalMechanicPointEvent>(
     goals: &[GoalContextEvent],
     events: &[E],
@@ -200,6 +202,9 @@ pub(super) fn tag_goals_by_point_mechanic_event<E: GoalMechanicPointEvent>(
         kind,
         max_event_to_goal_seconds,
         |event, goal| {
+            let final_scoring_touch = goal.scorer_last_touch.as_ref();
+            let final_scoring_frame = final_scoring_touch.map_or(goal.frame, |touch| touch.frame);
+            let final_scoring_time = final_scoring_touch.map_or(goal.time, |touch| touch.time);
             !touch_events.iter().any(|touch| {
                 touch.is_team_0 != goal.scoring_team_is_team_0
                     && frame_time_is_after(
@@ -208,7 +213,12 @@ pub(super) fn tag_goals_by_point_mechanic_event<E: GoalMechanicPointEvent>(
                         event.event_frame(),
                         event.event_time(),
                     )
-                    && !frame_time_is_after(touch.frame, touch.time, goal.frame, goal.time)
+                    && !frame_time_is_after(
+                        touch.frame,
+                        touch.time,
+                        final_scoring_frame,
+                        final_scoring_time,
+                    )
             })
         },
     )

--- a/src/stats/calculators/goal_tag_helpers.rs
+++ b/src/stats/calculators/goal_tag_helpers.rs
@@ -183,26 +183,11 @@ pub(super) fn tag_goals_by_recent_attacking_y(
     tags
 }
 
-pub(super) fn tag_goals_by_point_mechanic_event<E: GoalMechanicPointEvent>(
-    goals: &[GoalContextEvent],
-    events: &[E],
-    kind: GoalTagKind,
-    max_event_to_goal_seconds: f32,
-) -> Vec<GoalTagAssignment> {
-    tag_goals_by_point_mechanic_event_matching(
-        goals,
-        events,
-        kind,
-        max_event_to_goal_seconds,
-        |_, _| true,
-    )
-}
-
 /// Tags point mechanics only while the mechanic remains part of the scoring
 /// team's uninterrupted touch sequence. A later defending-team touch breaks
 /// the causal chain even when the mechanic still falls inside the calculator's
 /// wall-clock window.
-pub(super) fn tag_goals_by_uninterrupted_point_mechanic_event<E: GoalMechanicPointEvent>(
+pub(super) fn tag_goals_by_point_mechanic_event<E: GoalMechanicPointEvent>(
     goals: &[GoalContextEvent],
     events: &[E],
     touch_events: &[TouchClassificationEvent],

--- a/src/stats/calculators/goal_tag_helpers.rs
+++ b/src/stats/calculators/goal_tag_helpers.rs
@@ -189,6 +189,57 @@ pub(super) fn tag_goals_by_point_mechanic_event<E: GoalMechanicPointEvent>(
     kind: GoalTagKind,
     max_event_to_goal_seconds: f32,
 ) -> Vec<GoalTagAssignment> {
+    tag_goals_by_point_mechanic_event_matching(
+        goals,
+        events,
+        kind,
+        max_event_to_goal_seconds,
+        |_, _| true,
+    )
+}
+
+/// Tags point mechanics only while the mechanic remains part of the scoring
+/// team's uninterrupted touch sequence. A later defending-team touch breaks
+/// the causal chain even when the mechanic still falls inside the calculator's
+/// wall-clock window.
+pub(super) fn tag_goals_by_uninterrupted_point_mechanic_event<E: GoalMechanicPointEvent>(
+    goals: &[GoalContextEvent],
+    events: &[E],
+    touch_events: &[TouchClassificationEvent],
+    kind: GoalTagKind,
+    max_event_to_goal_seconds: f32,
+) -> Vec<GoalTagAssignment> {
+    tag_goals_by_point_mechanic_event_matching(
+        goals,
+        events,
+        kind,
+        max_event_to_goal_seconds,
+        |event, goal| {
+            !touch_events.iter().any(|touch| {
+                touch.is_team_0 != goal.scoring_team_is_team_0
+                    && frame_time_is_after(
+                        touch.frame,
+                        touch.time,
+                        event.event_frame(),
+                        event.event_time(),
+                    )
+                    && !frame_time_is_after(touch.frame, touch.time, goal.frame, goal.time)
+            })
+        },
+    )
+}
+
+fn tag_goals_by_point_mechanic_event_matching<E, F>(
+    goals: &[GoalContextEvent],
+    events: &[E],
+    kind: GoalTagKind,
+    max_event_to_goal_seconds: f32,
+    additional_match: F,
+) -> Vec<GoalTagAssignment>
+where
+    E: GoalMechanicPointEvent,
+    F: Fn(&E, &GoalContextEvent) -> bool,
+{
     let mut tags = Vec::new();
     for (goal_index, goal) in goals.iter().enumerate() {
         let ctx = GoalTaggingContext { goal_index };
@@ -197,6 +248,7 @@ pub(super) fn tag_goals_by_point_mechanic_event<E: GoalMechanicPointEvent>(
             .enumerate()
             .filter(|(_, event)| point_event_matches_goal(*event, goal))
             .filter(|(_, event)| goal.time - event.event_time() <= max_event_to_goal_seconds)
+            .filter(|(_, event)| additional_match(*event, goal))
             .max_by(|left, right| {
                 left.1
                     .event_time()
@@ -219,6 +271,10 @@ pub(super) fn tag_goals_by_point_mechanic_event<E: GoalMechanicPointEvent>(
         ));
     }
     tags
+}
+
+fn frame_time_is_after(frame: usize, time: f32, other_frame: usize, other_time: f32) -> bool {
+    frame > other_frame || (frame == other_frame && time > other_time)
 }
 
 pub(super) fn latest_goal_tag_assignments(

--- a/src/stats/calculators/goal_tags.rs
+++ b/src/stats/calculators/goal_tags.rs
@@ -1439,9 +1439,10 @@ impl FlipResetGoalCalculator {
         dodge_reset_events: &[DodgeResetEvent],
         touch_events: &[TouchClassificationEvent],
     ) -> Vec<GoalTagAssignment> {
-        let confirmed_tags = tag_goals_by_point_mechanic_event(
+        let confirmed_tags = tag_goals_by_uninterrupted_point_mechanic_event(
             goals,
             flip_reset_events,
+            touch_events,
             GoalTagKind::FlipResetGoal,
             self.config.max_event_to_goal_seconds,
         );

--- a/src/stats/calculators/goal_tags.rs
+++ b/src/stats/calculators/goal_tags.rs
@@ -1243,10 +1243,13 @@ impl FlickGoalCalculator {
         &mut self,
         match_stats: &MatchStatsCalculator,
         flick: &FlickCalculator,
+        touch: &TouchCalculator,
     ) -> SubtrActorResult<()> {
-        self.events.replace_all_assuming_append_only(
-            self.tag_goals(match_stats.goal_context_events(), flick.events()),
-        );
+        self.events.replace_all_assuming_append_only(self.tag_goals(
+            match_stats.goal_context_events(),
+            flick.events(),
+            touch.events(),
+        ));
         Ok(())
     }
 
@@ -1254,10 +1257,12 @@ impl FlickGoalCalculator {
         &self,
         goals: &[GoalContextEvent],
         events: &[FlickEvent],
+        touch_events: &[TouchClassificationEvent],
     ) -> Vec<GoalTagAssignment> {
         tag_goals_by_point_mechanic_event(
             goals,
             events,
+            touch_events,
             GoalTagKind::FlickGoal,
             self.config.max_event_to_goal_seconds,
         )
@@ -1269,10 +1274,13 @@ impl CeilingShotGoalCalculator {
         &mut self,
         match_stats: &MatchStatsCalculator,
         ceiling_shot: &CeilingShotCalculator,
+        touch: &TouchCalculator,
     ) -> SubtrActorResult<()> {
-        self.events.replace_all_assuming_append_only(
-            self.tag_goals(match_stats.goal_context_events(), ceiling_shot.events()),
-        );
+        self.events.replace_all_assuming_append_only(self.tag_goals(
+            match_stats.goal_context_events(),
+            ceiling_shot.events(),
+            touch.events(),
+        ));
         Ok(())
     }
 
@@ -1280,10 +1288,12 @@ impl CeilingShotGoalCalculator {
         &self,
         goals: &[GoalContextEvent],
         events: &[CeilingShotEvent],
+        touch_events: &[TouchClassificationEvent],
     ) -> Vec<GoalTagAssignment> {
         tag_goals_by_point_mechanic_event(
             goals,
             events,
+            touch_events,
             GoalTagKind::CeilingShotGoal,
             self.config.max_event_to_goal_seconds,
         )
@@ -1295,10 +1305,13 @@ impl OneTimerGoalCalculator {
         &mut self,
         match_stats: &MatchStatsCalculator,
         one_timer: &OneTimerCalculator,
+        touch: &TouchCalculator,
     ) -> SubtrActorResult<()> {
-        self.events.replace_all_assuming_append_only(
-            self.tag_goals(match_stats.goal_context_events(), one_timer.events()),
-        );
+        self.events.replace_all_assuming_append_only(self.tag_goals(
+            match_stats.goal_context_events(),
+            one_timer.events(),
+            touch.events(),
+        ));
         Ok(())
     }
 
@@ -1306,10 +1319,12 @@ impl OneTimerGoalCalculator {
         &self,
         goals: &[GoalContextEvent],
         events: &[OneTimerEvent],
+        touch_events: &[TouchClassificationEvent],
     ) -> Vec<GoalTagAssignment> {
         tag_goals_by_point_mechanic_event(
             goals,
             events,
+            touch_events,
             GoalTagKind::OneTimerGoal,
             self.config.max_event_to_goal_seconds,
         )
@@ -1374,10 +1389,13 @@ impl DoubleTapGoalCalculator {
         &mut self,
         match_stats: &MatchStatsCalculator,
         double_tap: &DoubleTapCalculator,
+        touch: &TouchCalculator,
     ) -> SubtrActorResult<()> {
-        self.events.replace_all_assuming_append_only(
-            self.tag_goals(match_stats.goal_context_events(), double_tap.events()),
-        );
+        self.events.replace_all_assuming_append_only(self.tag_goals(
+            match_stats.goal_context_events(),
+            double_tap.events(),
+            touch.events(),
+        ));
         Ok(())
     }
 
@@ -1385,10 +1403,12 @@ impl DoubleTapGoalCalculator {
         &self,
         goals: &[GoalContextEvent],
         events: &[DoubleTapEvent],
+        touch_events: &[TouchClassificationEvent],
     ) -> Vec<GoalTagAssignment> {
         tag_goals_by_point_mechanic_event(
             goals,
             events,
+            touch_events,
             GoalTagKind::DoubleTapGoal,
             self.config.max_event_to_goal_seconds,
         )
@@ -1439,7 +1459,7 @@ impl FlipResetGoalCalculator {
         dodge_reset_events: &[DodgeResetEvent],
         touch_events: &[TouchClassificationEvent],
     ) -> Vec<GoalTagAssignment> {
-        let confirmed_tags = tag_goals_by_uninterrupted_point_mechanic_event(
+        let confirmed_tags = tag_goals_by_point_mechanic_event(
             goals,
             flip_reset_events,
             touch_events,

--- a/src/stats/calculators/goal_tags_tests.rs
+++ b/src/stats/calculators/goal_tags_tests.rs
@@ -1080,6 +1080,22 @@ fn flip_reset_goal_can_be_created_by_scoring_teammate() {
 }
 
 #[test]
+fn flip_reset_goal_rejects_reset_before_opponent_touch() {
+    let goal = goal_with_touch(true, position(0.0, 2400.0, 700.0), Vec::new());
+    let mut opponent_touch = touch_classification_event(8.0, 80, player_id(2), "no_dodge");
+    opponent_touch.is_team_0 = false;
+
+    let events = FlipResetGoalCalculator::new().tag_goals(
+        &[goal],
+        &[confirmed_flip_reset_event(7.0, 70, player_id(1))],
+        &[],
+        &[opponent_touch],
+    );
+
+    assert!(events.is_empty());
+}
+
+#[test]
 fn flip_reset_goal_tags_scoring_on_ball_reset_touch() {
     let goal = goal_with_touch(true, position(0.0, 2400.0, 700.0), Vec::new());
     let events = FlipResetGoalCalculator::new().tag_goals(

--- a/src/stats/calculators/goal_tags_tests.rs
+++ b/src/stats/calculators/goal_tags_tests.rs
@@ -786,7 +786,7 @@ fn kickoff_goal_rejects_goals_without_a_matching_kickoff_attribution() {
 fn flick_goal_tags_matching_scorer_flick_before_last_touch() {
     let goal = goal_with_touch(true, position(0.0, 1800.0, 180.0), Vec::new());
     let events =
-        FlickGoalCalculator::new().tag_goals(&[goal], &[flick_event(9.3, 93, player_id(1))]);
+        FlickGoalCalculator::new().tag_goals(&[goal], &[flick_event(9.3, 93, player_id(1))], &[]);
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlickGoal]);
     assert_eq!(events[0].tag.metadata().confidence, 0.82);
@@ -809,7 +809,7 @@ fn flick_goal_carries_flick_kind_details() {
     reverse_flick.kind = "reverse".to_owned();
     reverse_flick.direction = "left".to_owned();
 
-    let events = FlickGoalCalculator::new().tag_goals(&[goal], &[reverse_flick]);
+    let events = FlickGoalCalculator::new().tag_goals(&[goal], &[reverse_flick], &[]);
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlickGoal]);
     let details = &events[0].tag.metadata().details;
@@ -829,7 +829,7 @@ fn flick_goal_carries_flick_kind_details() {
 fn flick_goal_omits_center_direction_detail() {
     let goal = goal_with_touch(true, position(0.0, 1800.0, 180.0), Vec::new());
     let events =
-        FlickGoalCalculator::new().tag_goals(&[goal], &[flick_event(9.3, 93, player_id(1))]);
+        FlickGoalCalculator::new().tag_goals(&[goal], &[flick_event(9.3, 93, player_id(1))], &[]);
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlickGoal]);
     let details = &events[0].tag.metadata().details;
@@ -845,7 +845,7 @@ fn flick_goal_omits_center_direction_detail() {
 fn flick_goal_rejects_stale_flicks() {
     let goal = goal_with_touch(true, position(0.0, 1800.0, 180.0), Vec::new());
     let events =
-        FlickGoalCalculator::new().tag_goals(&[goal], &[flick_event(4.5, 45, player_id(1))]);
+        FlickGoalCalculator::new().tag_goals(&[goal], &[flick_event(4.5, 45, player_id(1))], &[]);
 
     assert!(events.is_empty());
 }
@@ -854,7 +854,7 @@ fn flick_goal_rejects_stale_flicks() {
 fn flick_goal_can_be_created_by_scoring_teammate() {
     let goal = goal_with_touch(true, position(0.0, 1800.0, 180.0), Vec::new());
     let events =
-        FlickGoalCalculator::new().tag_goals(&[goal], &[flick_event(8.8, 88, player_id(2))]);
+        FlickGoalCalculator::new().tag_goals(&[goal], &[flick_event(8.8, 88, player_id(2))], &[]);
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlickGoal]);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Teammate));
@@ -872,10 +872,27 @@ fn flick_goal_can_be_created_by_scoring_teammate() {
 }
 
 #[test]
+fn flick_goal_rejects_flick_before_opponent_touch() {
+    let goal = goal_with_touch(true, position(0.0, 1800.0, 180.0), Vec::new());
+    let mut opponent_touch = touch_classification_event(9.0, 90, player_id(3), "no_dodge");
+    opponent_touch.is_team_0 = false;
+    let events = FlickGoalCalculator::new().tag_goals(
+        &[goal],
+        &[flick_event(8.8, 88, player_id(2))],
+        &[opponent_touch],
+    );
+
+    assert!(events.is_empty());
+}
+
+#[test]
 fn one_timer_goal_tags_matching_one_timer_before_last_touch() {
     let goal = goal_with_touch(true, position(0.0, 2000.0, 120.0), Vec::new());
-    let events =
-        OneTimerGoalCalculator::new().tag_goals(&[goal], &[one_timer_event(9.4, 94, player_id(1))]);
+    let events = OneTimerGoalCalculator::new().tag_goals(
+        &[goal],
+        &[one_timer_event(9.4, 94, player_id(1))],
+        &[],
+    );
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::OneTimerGoal]);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Scorer));
@@ -923,8 +940,11 @@ fn passing_goal_rejects_pass_not_received_by_scorer() {
 #[test]
 fn ceiling_shot_goal_tags_matching_ceiling_shot_before_goal() {
     let goal = goal_with_touch(true, position(0.0, 2400.0, 800.0), Vec::new());
-    let events = CeilingShotGoalCalculator::new()
-        .tag_goals(&[goal], &[ceiling_shot_event(9.4, 94, player_id(1))]);
+    let events = CeilingShotGoalCalculator::new().tag_goals(
+        &[goal],
+        &[ceiling_shot_event(9.4, 94, player_id(1))],
+        &[],
+    );
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::CeilingShotGoal]);
     assert_eq!(events[0].tag.metadata().confidence, 0.84);
@@ -943,8 +963,11 @@ fn ceiling_shot_goal_tags_matching_ceiling_shot_before_goal() {
 #[test]
 fn ceiling_shot_goal_can_be_created_by_scoring_teammate() {
     let goal = goal_with_touch(true, position(0.0, 2400.0, 800.0), Vec::new());
-    let events = CeilingShotGoalCalculator::new()
-        .tag_goals(&[goal], &[ceiling_shot_event(9.4, 94, player_id(2))]);
+    let events = CeilingShotGoalCalculator::new().tag_goals(
+        &[goal],
+        &[ceiling_shot_event(9.4, 94, player_id(2))],
+        &[],
+    );
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::CeilingShotGoal]);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Teammate));
@@ -957,7 +980,7 @@ fn ceiling_shot_goal_rejects_stale_events() {
     let calculator = CeilingShotGoalCalculator::with_config(CeilingShotGoalCalculatorConfig {
         max_event_to_goal_seconds: 0.3,
     });
-    let events = calculator.tag_goals(&[goal], &[ceiling_shot_event(9.4, 94, player_id(1))]);
+    let events = calculator.tag_goals(&[goal], &[ceiling_shot_event(9.4, 94, player_id(1))], &[]);
 
     assert!(events.is_empty());
 }
@@ -965,8 +988,11 @@ fn ceiling_shot_goal_rejects_stale_events() {
 #[test]
 fn double_tap_goal_tags_matching_double_tap_before_goal() {
     let goal = goal_with_touch(true, position(0.0, 2800.0, 500.0), Vec::new());
-    let events = DoubleTapGoalCalculator::new()
-        .tag_goals(&[goal], &[double_tap_event(9.4, 94, player_id(1))]);
+    let events = DoubleTapGoalCalculator::new().tag_goals(
+        &[goal],
+        &[double_tap_event(9.4, 94, player_id(1))],
+        &[],
+    );
 
     assert_eq!(tag_kinds(&events), vec![GoalTagKind::DoubleTapGoal]);
     assert_eq!(performer(&events[0]), Some(GoalTagPerformer::Scorer));

--- a/src/stats/calculators/goal_tags_tests.rs
+++ b/src/stats/calculators/goal_tags_tests.rs
@@ -886,6 +886,20 @@ fn flick_goal_rejects_flick_before_opponent_touch() {
 }
 
 #[test]
+fn flick_goal_allows_opponent_touch_after_final_scoring_touch() {
+    let goal = goal_with_touch(true, position(0.0, 1800.0, 180.0), Vec::new());
+    let mut opponent_touch = touch_classification_event(9.7, 97, player_id(3), "no_dodge");
+    opponent_touch.is_team_0 = false;
+    let events = FlickGoalCalculator::new().tag_goals(
+        &[goal],
+        &[flick_event(9.4, 94, player_id(1))],
+        &[opponent_touch],
+    );
+
+    assert_eq!(tag_kinds(&events), vec![GoalTagKind::FlickGoal]);
+}
+
+#[test]
 fn one_timer_goal_tags_matching_one_timer_before_last_touch() {
     let goal = goal_with_touch(true, position(0.0, 2000.0, 120.0), Vec::new());
     let events = OneTimerGoalCalculator::new().tag_goals(


### PR DESCRIPTION
## Summary

- require point-mechanic events to remain in the scoring team's uninterrupted touch sequence before tagging a goal
- apply the shared rule to flicks, ceiling shots, one-timers, double taps, and flip resets
- add focused regression tests for opponent touches breaking mechanic-to-goal chains

## Root cause

The generic point-mechanic goal join accepted any same-team mechanic event within its configured time window without checking whether the defending team touched the ball afterward. In Rocket Sense replay `019e9963-b491-7073-848b-d4b69f65f439`, zen used a real flip reset at 4:07.1, but Joreuz touched the ball twice before zen's unrelated scoring touch at 4:13.2. The time-only join therefore mislabeled goal 7 as a flip-reset goal, and the same flaw could affect flick, ceiling-shot, one-timer, and double-tap tags.

## Impact

Point-mechanic goal tags no longer carry a stale event across an opposing touch followed by a new scoring-team touch. A defender's save attempt after the final scoring touch does not erase an otherwise valid mechanic goal when the ball still goes in. Specialized contextual tags such as passing, bump, demo, kickoff, and goal-buildup tags retain their existing semantics. Legitimate scorer and teammate mechanic goals remain supported, including lag-tolerant and direct reset-touch flip-reset cases.

## CI/toolchain

Rust 1.97 triggers rust-lang/rust#159038 while compiling the integration tests and BakkesMod plugin. Those jobs use Rust 1.96.1 until the upstream compiler regression is fixed; quality and release jobs remain on 1.97. The Nix dev shell also pins cargo-rdme 1.5.0 to match CI.

## Validation

- `cargo test -q --lib stats::calculators::goal_tags::tests`
- `cargo test -q --test clip_flip_reset_test`
- `cargo test --test clip_double_tap_test` with Rust 1.96.1
- `cargo test --no-run` with Rust 1.96.1
- `cargo test -p subtr-actor-bakkesmod --no-run` with Rust 1.96.1
- `just check`
- `actionlint .github/workflows/ci.yml .github/workflows/bakkesmod-plugin.yml`
- reprocessed the reported replay and confirmed goal 7 no longer has `FlipResetGoal`
